### PR TITLE
fix(game-server): P0 2건 — I-14 DB 영속저장 (UUID 정규화) + I-15 GAME_OVER winnerId

### DIFF
--- a/src/frontend/e2e/auth.json
+++ b/src/frontend/e2e/auth.json
@@ -2,7 +2,7 @@
   "cookies": [
     {
       "name": "next-auth.csrf-token",
-      "value": "67d8e2cd57c8ec9da22cb3787858e220b8d6285a3e726edad02a7ecc908991b2%7C525076b00a8b7945ddaf2b745739a2fc463184d4172e6a04705d59b811caba0d",
+      "value": "6914c3ca7c0a1431a0472042066143621e8dcc27c95024156ee380e25fde93e2%7Cde3a84a315bba78b7a1b1020560774a6d72a9bb9953825b3b023db9469b3df24",
       "domain": "localhost",
       "path": "/",
       "expires": -1,
@@ -22,10 +22,10 @@
     },
     {
       "name": "next-auth.session-token",
-      "value": "eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2R0NNIn0.._QqMGPqu5qHgmuv5.TG8hpGKQeCeX-14h7MN0f_JC_e06Zf6jUtZ4OSY2-vvKpDwH5OaS1jb2-fO-uSyykpUb4NqnYkI2b1vQBbsZdFGta8EEwpvrnaTXbEYX3WRS9mCmAe45oHeT7lisJ7jOaecegAgZq24lvGubd5nnXoy0Ua3TJK-LDZ2Xh6E4tGr5_Jvc9Nzz09iLjs13roesUDPecY-CvKD-KTqO5j1OdtYWl3U59FsPJYYm_wC8wGlX8IkGKHfr6m2oHYGyWlNcg6m5wN27HRdRBJeRzMO97btNo5XILr_Ps3_YX6Mmd9aM9zgz9OvVinOShTcASNaL8y9UJpzCQDQlQr2Lqno5lI07Oiro-1vuMqERWBwaypMEzvnHu5d4iccCsF8vkZi_monVBQNQ92IbO2IDJGLdtSuI75KHkdrWNNOl1BOR1uT759n3Kkg6j8Wm15uUEjehBRoT-pmJYA-BNDb3EB_l2uOajum15gLm_HPP6-AgUgcWlHsncFvjNalDF7FTEPVzvbo4b3QRwL6frwS3r3ZQ-nOzcm-IpEGv2yOaMyBI5GLWN2huhY1yfxd_r3wvpSPVDJTVB5iUFnuE5A6RmH1xqalULCY.-a1KqDUUyLt_Wy1ULie7JA",
+      "value": "eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2R0NNIn0..QcQSFA8-jFN63cG-.zrCoMOZz6yqQEC8PkCtb4oEOPWyGPuMOM6hWGRond7fstJdcJHNZrI2tehBNqL8UehkYi0r37fqRD0Fe1RMNeIeePTSC5dtwbY8WRp0LCWId03glXuifKpxfxSXFkTt9dkX8TI1XQeU0P7tJvopVhpGS5VH_HJRMBUl7RRL9lzaimH0JCoaiNf14KSDtLJwzIHAeyzdZts5Ur4lSt5mn89D4qcP1J1rtJJdb21CbFkSj5vHgQ7RUOuG_c6UAdIQLqpD31tius_4zx67RMwR2ZXG5rhQC8KJj1LDxLBt2cz-qk1tCLmYFCFh5rScdg-geh6bgPrG4S4bbfWjw4vbzOCmOX3pMUDWCmYmm9c2DIiLEqrgkdL2HHcZbAWrNuEb336rli3j5qdejNzq2q8lpZ2q0S099IqKy8GkFbGnFjMo9a5uoi-29jS0x-XbK8bzqqcWwTpwDBogeOR7PIGtQ0rq5hrJVrOwXZFZYlA_AG8cX0zIHfeZyyirWdWtBqiOyTXxTovb67DRzxJ7tTXvVaqfqFLyQdp469ZdO_h_qTRK_GdV1ndoKo8RZ_F1lhIn47BY0-Um-oRKNCVgCE1hdoK3j20g.kI028h9ojeWVlKPeABOC2Q",
       "domain": "localhost",
       "path": "/",
-      "expires": 1776850898.583777,
+      "expires": 1776926683.466669,
       "httpOnly": true,
       "secure": false,
       "sameSite": "Lax"
@@ -37,7 +37,7 @@
       "localStorage": [
         {
           "name": "nextauth.message",
-          "value": "{\"event\":\"session\",\"data\":{\"trigger\":\"getSession\"},\"timestamp\":1776764498}"
+          "value": "{\"event\":\"session\",\"data\":{\"trigger\":\"getSession\"},\"timestamp\":1776840283}"
         }
       ]
     }

--- a/src/frontend/e2e/rearrangement.spec.ts
+++ b/src/frontend/e2e/rearrangement.spec.ts
@@ -175,12 +175,14 @@ test.describe("TC-RR: 재배치 합병 (§6.2 유형 2)", () => {
   });
 
   // ==================================================================
-  // Case 2: Negative Path — 최초 등록 전 합병 거부
+  // Case 2: I-2 핫픽스 이후 기대치 — hasInitialMeld=false 에서도 호환 시 append 허용
   // ==================================================================
 
-  test("TC-RR-02: 최초 등록 전 합병 시도는 머지되지 않고 그룹이 분리됨", async ({
+  test("TC-RR-02: 최초 등록 전이라도 호환 타일(Y9a→[R9 B9 K9])은 append 허용됨 (I-2 핫픽스 이후 기대치)", async ({
     page,
   }) => {
+    // I-2 핫픽스(commit eef2bbc): hasInitialMeld 와 무관하게 호환성 통과 시 append 허용.
+    // 구 동작(차단)을 검증하던 기대치를 새 동작(허용)으로 갱신.
     await createRoomAndStart(page, {
       playerCount: 2,
       aiCount: 1,
@@ -188,7 +190,7 @@ test.describe("TC-RR: 재배치 합병 (§6.2 유형 2)", () => {
     });
     await waitForGameReady(page);
 
-    // hasInitialMeld=false → handleDragEnd line 517 분기 차단
+    // hasInitialMeld=false — I-2 이후에는 호환 시 append 가드가 제거됨
     await setupMergeScenario(page, { hasInitialMeld: false });
 
     // 사전 조건: 보드에 1개 그룹(3타일)
@@ -207,20 +209,24 @@ test.describe("TC-RR: 재배치 합병 (§6.2 유형 2)", () => {
 
     await dndDrag(page, y9, r9);
 
-    // 기대: 머지가 일어나지 않으므로
-    //   - 서버 그룹 [R9 B9 K9]는 여전히 3타일로 유지 (또는 board fallthrough로
-    //     Y9a가 별도 pending 그룹이 됐을 수 있음)
-    //   - 4타일 합병 그룹은 존재하지 않아야 함
+    // 기대(I-2 핫픽스 이후):
+    //   - Y9a는 숫자 9로 [R9 B9 K9]와 호환 → append 성공 → 4타일 pending 그룹 생성
+    //   - 3타일 그룹은 더 이상 존재하지 않아야 함
     await expect(
       page.locator('span[aria-label="4개 타일"]')
-    ).toHaveCount(0, { timeout: 2000 });
+    ).toHaveCount(1, { timeout: 5000 });
 
-    // 서버 그룹은 그대로 3타일 유지
-    // (참고: §6.1 즉시 조치 1 완료 후 등록 전에는 드롭 자체가 비활성화될 수도 있다.
-    //  현재는 handleDragEnd의 가드만으로 합병이 차단되는 동작을 검증한다.)
+    // 머지된 그룹은 "미확정" 마커가 붙음
     await expect(
-      page.locator('span[aria-label="3개 타일"]')
-    ).toHaveCount(1, { timeout: 2000 });
+      page.locator("text=미확정").first()
+    ).toBeVisible({ timeout: 3000 });
+
+    // 랙에서 Y9a 소거 확인 (pendingMyTiles 로 이동)
+    await expect(
+      page.locator(
+        'section[aria-label="내 타일 랙"] [aria-label="Y9a 타일 (드래그 가능)"]'
+      )
+    ).toHaveCount(0, { timeout: 3000 });
   });
 });
 

--- a/src/game-server/cmd/server/main.go
+++ b/src/game-server/cmd/server/main.go
@@ -152,6 +152,13 @@ func buildRouter(
 		rankingHandler = handler.NewRankingHandler(eloRepo, logger)
 		wsHandler.WithEloRepo(eloRepo)
 
+		// I-14: 게임 영속저장 레포지터리 주입 (games / game_players / game_events)
+		pgGameRepo := repository.NewPostgresGameRepo(db)
+		pgGamePlayerRepo := repository.NewPostgresGamePlayerRepo(db)
+		pgGameEventRepo := repository.NewPostgresGameEventRepo(db)
+		wsHandler.WithPersistenceRepos(pgGameRepo, pgGamePlayerRepo, pgGameEventRepo)
+		logger.Info("game persistence repos injected")
+
 		userRepo := repository.NewPostgresUserRepo(db)
 		authHandler.WithUserRepo(userRepo)
 
@@ -162,6 +169,7 @@ func buildRouter(
 		logger.Warn("postgres unavailable — practice API disabled")
 		logger.Warn("postgres unavailable — ranking API disabled")
 		logger.Warn("postgres unavailable — admin API disabled")
+		logger.Warn("postgres unavailable — game persistence disabled")
 	}
 
 	// Redis가 가용하면 ELO Sorted Set 업데이트 활성화

--- a/src/game-server/internal/handler/ws_handler.go
+++ b/src/game-server/internal/handler/ws_handler.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
@@ -1710,6 +1711,17 @@ func tileScoreFromCode(code string) int {
 	return num
 }
 
+// isValidUUID s가 RFC 4122 UUID 형식인지 확인한다.
+// game_players.user_id / game_events.player_id 처럼 UUID 타입 컬럼에 삽입하기 전에
+// 게스트 ID("qa-테스터-xxx" 등 자유 문자열) 를 걸러내기 위해 사용한다.
+func isValidUUID(s string) bool {
+	if s == "" {
+		return false
+	}
+	_, err := uuid.Parse(s)
+	return err == nil
+}
+
 // updateElo 게임 종료 후 ELO 레이팅을 업데이트한다.
 // eloRepo가 nil이거나 PRACTICE 모드이면 건너뛴다.
 // 순위는 남은 타일 수 기준으로 결정한다 (0장=1위, 이후 타일 적은 순).
@@ -1963,9 +1975,11 @@ func (h *WSHandler) persistGameResult(state *model.GameStateRedis, endType strin
 	if h.pgGamePlayerRepo != nil {
 		for _, p := range state.Players {
 			finalTiles := len(p.Rack)
-			isWinner := p.UserID == winnerID
+			isWinner := p.UserID == winnerID && winnerID != ""
+			// Bug 1 fix: game_players.user_id is UUID type — only set when p.UserID is a valid UUID.
+			// 게스트 ID ("qa-테스터-xxx" 등 자유 문자열)는 NULL로 저장한다 (컬럼이 NULLABLE).
 			var userIDPtr *string
-			if p.UserID != "" {
+			if isValidUUID(p.UserID) {
 				uid := p.UserID
 				userIDPtr = &uid
 			}
@@ -1993,10 +2007,16 @@ func (h *WSHandler) persistGameResult(state *model.GameStateRedis, endType strin
 
 	// 3. game_events 테이블 — GAME_END 이벤트 1건 삽입
 	if h.pgGameEventRepo != nil {
-		actorID := winnerID
 		actorSeat := 0
 		if winnerSeat >= 0 {
 			actorSeat = winnerSeat
+		}
+		// Bug 2 fix: game_events.player_id is UUID NOT NULL.
+		// winnerID가 빈 문자열이거나 UUID 형식이 아닌 경우(forfeit/stalemate 무승부 또는 게스트)
+		// uuid.Nil("00000000-0000-0000-0000-000000000000") 을 시스템 센티넬로 사용한다.
+		actorID := winnerID
+		if !isValidUUID(actorID) {
+			actorID = uuid.Nil.String()
 		}
 		payload := fmt.Sprintf(`{"endType":"%s","turnCount":%d}`, endType, state.TurnCount)
 		ev := &model.GameEvent{

--- a/src/game-server/internal/handler/ws_handler.go
+++ b/src/game-server/internal/handler/ws_handler.go
@@ -87,6 +87,10 @@ type WSHandler struct {
 	aiClient      client.AIClientInterface // nil이면 AI 기능 비활성화
 	eloRepo       repository.EloRepository // nil이면 ELO 업데이트 건너뜀
 	redisClient   *redis.Client            // nil이면 Redis Sorted Set 업데이트 건너뜀
+	// I-14: 게임 영속저장 — nil이면 DB 쓰기 건너뜀 (postgres 미연결 시)
+	pgGameRepo       repository.GameRepository       // games + rooms 테이블
+	pgGamePlayerRepo repository.GamePlayerRepository // game_players 테이블
+	pgGameEventRepo  repository.GameEventRepository  // game_events 테이블
 	jwtSecret     string
 	logger        *zap.Logger
 	timers        map[string]*turnTimer  // key: gameID
@@ -135,6 +139,18 @@ func (h *WSHandler) WithEloRepo(eloRepo repository.EloRepository) {
 // nil이면 Redis Sorted Set 업데이트가 비활성화된다.
 func (h *WSHandler) WithRedisClient(rc *redis.Client) {
 	h.redisClient = rc
+}
+
+// WithPersistenceRepos I-14: 게임 영속저장용 PostgreSQL 레포지터리를 주입한다.
+// nil이면 DB 쓰기를 건너뛰고 경고만 기록한다 (postgres 미연결 허용).
+func (h *WSHandler) WithPersistenceRepos(
+	gameRepo repository.GameRepository,
+	playerRepo repository.GamePlayerRepository,
+	eventRepo repository.GameEventRepository,
+) {
+	h.pgGameRepo = gameRepo
+	h.pgGamePlayerRepo = playerRepo
+	h.pgGameEventRepo = eventRepo
 }
 
 // HandleWS GET /ws?roomId={roomId}
@@ -841,6 +857,9 @@ func (h *WSHandler) broadcastGameOver(conn *Connection, state *model.GameStateRe
 			Results:    results,
 		},
 	})
+
+	// I-14: 게임 결과 DB 영속화 (비동기)
+	go h.persistGameResult(state, endType)
 
 	// ELO 업데이트 (비동기)
 	go h.updateElo(state)
@@ -1599,6 +1618,9 @@ func (h *WSHandler) broadcastGameOverFromState(roomID string, state *model.GameS
 		},
 	})
 
+	// I-14: 게임 결과 DB 영속화 (비동기)
+	go h.persistGameResult(state, endType)
+
 	// ELO 업데이트 (비동기)
 	go h.updateElo(state)
 
@@ -1800,6 +1822,127 @@ func (h *WSHandler) updateEloRedis(ctx context.Context, ch engine.EloChange) {
 		zap.String("userID", ch.UserID),
 		zap.String("newTier", ch.NewTier),
 		zap.Int("newRating", ch.NewRating),
+	)
+}
+
+// persistGameResult I-14: 게임 종료 시 games / game_players / game_events 테이블에 영속화한다.
+// pgGameRepo / pgGamePlayerRepo / pgGameEventRepo 중 하나라도 nil이면 해당 테이블은 건너뛴다.
+// 비동기 goroutine에서 호출된다 — 에러는 경고 로그로 처리하고 WS 흐름을 차단하지 않는다.
+func (h *WSHandler) persistGameResult(state *model.GameStateRedis, endType string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if h.pgGameRepo == nil && h.pgGamePlayerRepo == nil && h.pgGameEventRepo == nil {
+		return // postgres 미연결 — 조용히 건너뜀
+	}
+
+	// 승자 결정
+	winnerID := ""
+	winnerSeat := -1
+	for _, p := range state.Players {
+		if len(p.Rack) == 0 {
+			winnerID = p.UserID
+			winnerSeat = p.SeatOrder
+			break
+		}
+	}
+	// stalemate 시 ErrorCode="STALEMATE"를 기반으로 endType을 재지정한다
+	if state.IsStalemate {
+		endType = "STALEMATE"
+	}
+
+	// 1. games 테이블 삽입
+	if h.pgGameRepo != nil {
+		now := time.Now().UTC()
+		var wIDPtr *string
+		if winnerID != "" {
+			wIDPtr = &winnerID
+		}
+		var wSeatPtr *int
+		if winnerSeat >= 0 {
+			wSeatPtr = &winnerSeat
+		}
+		game := &model.Game{
+			ID:          state.GameID,
+			Status:      model.GameStatusFinished,
+			PlayerCount: len(state.Players),
+			WinnerID:    wIDPtr,
+			WinnerSeat:  wSeatPtr,
+			TurnCount:   state.TurnCount,
+			Settings:    "{}",
+			StartedAt:   nil, // 시작 시각 미기록 (향후 개선)
+			EndedAt:     &now,
+		}
+		if err := h.pgGameRepo.CreateGame(ctx, game); err != nil {
+			h.logger.Warn("ws: persistGameResult: create game failed",
+				zap.String("gameID", state.GameID),
+				zap.Error(err),
+			)
+			// games INSERT 실패해도 game_players / game_events 는 계속 시도
+		}
+	}
+
+	// 2. game_players 테이블 삽입
+	if h.pgGamePlayerRepo != nil {
+		for _, p := range state.Players {
+			finalTiles := len(p.Rack)
+			isWinner := p.UserID == winnerID
+			var userIDPtr *string
+			if p.UserID != "" {
+				uid := p.UserID
+				userIDPtr = &uid
+			}
+			gp := &model.GamePlayer{
+				GameID:       state.GameID,
+				UserID:       userIDPtr,
+				PlayerType:   model.PlayerType(p.PlayerType),
+				AIModel:      p.AIModel,
+				AIPersona:    p.AIPersona,
+				AIDifficulty: p.AIDifficulty,
+				SeatOrder:    p.SeatOrder,
+				InitialTiles: 14,
+				FinalTiles:   &finalTiles,
+				IsWinner:     isWinner,
+			}
+			if err := h.pgGamePlayerRepo.CreateGamePlayer(ctx, gp); err != nil {
+				h.logger.Warn("ws: persistGameResult: create game_player failed",
+					zap.String("gameID", state.GameID),
+					zap.Int("seat", p.SeatOrder),
+					zap.Error(err),
+				)
+			}
+		}
+	}
+
+	// 3. game_events 테이블 — GAME_END 이벤트 1건 삽입
+	if h.pgGameEventRepo != nil {
+		actorID := winnerID
+		actorSeat := 0
+		if winnerSeat >= 0 {
+			actorSeat = winnerSeat
+		}
+		payload := fmt.Sprintf(`{"endType":"%s","turnCount":%d}`, endType, state.TurnCount)
+		ev := &model.GameEvent{
+			GameID:     state.GameID,
+			PlayerID:   actorID,
+			TurnNumber: state.TurnCount,
+			Seat:       actorSeat,
+			EventType:  model.EventTypeGameEnd,
+			Payload:    payload,
+		}
+		if err := h.pgGameEventRepo.CreateGameEvent(ctx, ev); err != nil {
+			h.logger.Warn("ws: persistGameResult: create game_event failed",
+				zap.String("gameID", state.GameID),
+				zap.Error(err),
+			)
+		}
+	}
+
+	h.logger.Info("ws: game persisted",
+		zap.String("gameID", state.GameID),
+		zap.String("endType", endType),
+		zap.Int("turnCount", state.TurnCount),
+		zap.String("winnerID", winnerID),
 	)
 }
 
@@ -2026,6 +2169,9 @@ func (h *WSHandler) forfeitAndBroadcast(roomID, gameID string, seat int, userID,
 				Results:    results,
 			},
 		})
+
+		// I-14: 게임 결과 DB 영속화 (비동기)
+		go h.persistGameResult(state, endType)
 
 		go h.updateElo(state)
 

--- a/src/game-server/internal/handler/ws_handler.go
+++ b/src/game-server/internal/handler/ws_handler.go
@@ -823,29 +823,22 @@ func (h *WSHandler) broadcastGameOver(conn *Connection, state *model.GameStateRe
 	h.cancelTurnTimer(conn.gameID)
 	h.cleanupGame(conn.gameID)
 
+	endType := "NORMAL"
+	if state.IsStalemate {
+		endType = "STALEMATE"
+	}
+
+	// I-15: resolveWinnerFromState로 stalemate 시에도 올바른 승자 판정
+	winnerID, winnerSeat := resolveWinnerFromState(state)
+
 	results := make([]WSPlayerResult, len(state.Players))
 	for i, p := range state.Players {
 		results[i] = WSPlayerResult{
 			Seat:           p.SeatOrder,
 			PlayerType:     p.PlayerType,
 			RemainingTiles: p.Rack,
-			IsWinner:       len(p.Rack) == 0,
+			IsWinner:       p.UserID == winnerID && winnerID != "",
 		}
-	}
-
-	winnerSeat := -1
-	winnerID := ""
-	for _, p := range state.Players {
-		if len(p.Rack) == 0 {
-			winnerSeat = p.SeatOrder
-			winnerID = p.UserID
-			break
-		}
-	}
-
-	endType := "NORMAL"
-	if state.IsStalemate {
-		endType = "STALEMATE"
 	}
 
 	h.hub.BroadcastToRoom(conn.roomID, &WSMessage{
@@ -857,6 +850,14 @@ func (h *WSHandler) broadcastGameOver(conn *Connection, state *model.GameStateRe
 			Results:    results,
 		},
 	})
+
+	h.logger.Info("ws: GAME_OVER broadcast",
+		zap.String("gameID", conn.gameID),
+		zap.String("roomID", conn.roomID),
+		zap.String("endType", endType),
+		zap.String("winnerID", winnerID),
+		zap.Int("winnerSeat", winnerSeat),
+	)
 
 	// I-14: 게임 결과 DB 영속화 (비동기)
 	go h.persistGameResult(state, endType)
@@ -1578,10 +1579,19 @@ func (h *WSHandler) broadcastTurnEndFromState(roomID string, seat int, state *mo
 
 // broadcastGameOverFromState Connection 없이 roomID 기반으로 GAME_OVER를 브로드캐스트한다.
 // AI 턴에서 게임이 종료될 때 사용한다.
+// I-15: stalemate/forfeit 종료 시 winner 판정이 len(Rack)==0 이외의 경우에도 올바르게 동작하도록
+//       resolveWinnerFromState 헬퍼를 사용하여 교착 종료 시 최소 타일 보유자를 승자로 반환한다.
 func (h *WSHandler) broadcastGameOverFromState(roomID string, state *model.GameStateRedis) {
 	// 게임 종료 시 진행 중인 타이머 취소 + AI goroutine 취소 + Redis 정리
 	h.cancelTurnTimer(state.GameID)
 	h.cleanupGame(state.GameID)
+
+	endType := "NORMAL"
+	if state.IsStalemate {
+		endType = "STALEMATE"
+	}
+
+	winnerID, winnerSeat := resolveWinnerFromState(state)
 
 	results := make([]WSPlayerResult, len(state.Players))
 	for i, p := range state.Players {
@@ -1589,23 +1599,8 @@ func (h *WSHandler) broadcastGameOverFromState(roomID string, state *model.GameS
 			Seat:           p.SeatOrder,
 			PlayerType:     p.PlayerType,
 			RemainingTiles: p.Rack,
-			IsWinner:       len(p.Rack) == 0,
+			IsWinner:       p.UserID == winnerID && winnerID != "",
 		}
-	}
-
-	winnerSeat := -1
-	winnerID := ""
-	for _, p := range state.Players {
-		if len(p.Rack) == 0 {
-			winnerSeat = p.SeatOrder
-			winnerID = p.UserID
-			break
-		}
-	}
-
-	endType := "NORMAL"
-	if state.IsStalemate {
-		endType = "STALEMATE"
 	}
 
 	h.hub.BroadcastToRoom(roomID, &WSMessage{
@@ -1617,6 +1612,14 @@ func (h *WSHandler) broadcastGameOverFromState(roomID string, state *model.GameS
 			Results:    results,
 		},
 	})
+
+	h.logger.Info("ws: GAME_OVER broadcast",
+		zap.String("gameID", state.GameID),
+		zap.String("roomID", roomID),
+		zap.String("endType", endType),
+		zap.String("winnerID", winnerID),
+		zap.Int("winnerSeat", winnerSeat),
+	)
 
 	// I-14: 게임 결과 DB 영속화 (비동기)
 	go h.persistGameResult(state, endType)
@@ -1631,6 +1634,80 @@ func (h *WSHandler) broadcastGameOverFromState(roomID string, state *model.GameS
 			zap.Error(err),
 		)
 	}
+}
+
+// resolveWinnerFromState 게임 상태에서 승자 userID와 seat을 결정한다.
+// 1) 타일 0장인 플레이어 → 정상 승리
+// 2) Stalemate → 최소 점수(낮은 쪽) 플레이어 (service.finishGameStalemate 와 동일 로직)
+// 3) 무승부 / FORFEITED만 남은 경우 → winnerID=""
+func resolveWinnerFromState(state *model.GameStateRedis) (winnerID string, winnerSeat int) {
+	// 1. 정상 승리: rack 0장
+	for _, p := range state.Players {
+		if len(p.Rack) == 0 {
+			return p.UserID, p.SeatOrder
+		}
+	}
+
+	// 2. stalemate: 최소 점수 플레이어
+	if state.IsStalemate {
+		type scored struct {
+			userID string
+			seat   int
+			score  int
+			count  int
+		}
+		scores := make([]scored, 0, len(state.Players))
+		for _, p := range state.Players {
+			if p.Status == model.PlayerStatusForfeited {
+				continue
+			}
+			total := 0
+			for _, code := range p.Rack {
+				total += tileScoreFromCode(code)
+			}
+			scores = append(scores, scored{userID: p.UserID, seat: p.SeatOrder, score: total, count: len(p.Rack)})
+		}
+		if len(scores) == 0 {
+			return "", -1
+		}
+		best := scores[0]
+		for _, sc := range scores[1:] {
+			if sc.score < best.score || (sc.score == best.score && sc.count < best.count) {
+				best = sc
+			}
+		}
+		// 동점 확인
+		for _, sc := range scores {
+			if sc.userID != best.userID && sc.score == best.score && sc.count == best.count {
+				return "", -1 // 무승부
+			}
+		}
+		return best.userID, best.seat
+	}
+
+	return "", -1
+}
+
+// tileScoreFromCode 타일 코드에서 점수를 계산한다 (handler 내부 사용).
+// service.tileScore와 동일 로직이지만 handler 패키지가 service에 의존하지 않도록 복사한다.
+func tileScoreFromCode(code string) int {
+	if len(code) >= 2 && code[:2] == "JK" {
+		return 30 // 조커: engine.JokerScore와 동일
+	}
+	if len(code) < 2 {
+		return 0
+	}
+	// 숫자 부분 파싱: R7a → "7", B13b → "13"
+	num := 0
+	for i := 1; i < len(code); i++ {
+		c := code[i]
+		if c >= '0' && c <= '9' {
+			num = num*10 + int(c-'0')
+		} else {
+			break
+		}
+	}
+	return num
 }
 
 // updateElo 게임 종료 후 ELO 레이팅을 업데이트한다.

--- a/src/game-server/internal/handler/ws_persist_test.go
+++ b/src/game-server/internal/handler/ws_persist_test.go
@@ -19,6 +19,14 @@ import (
 // I-14: persistGameResult 단위 테스트
 // ============================================================
 
+// 테스트용 UUID 상수 (RFC 4122 형식)
+const (
+	testWinnerUUID = "11111111-1111-1111-1111-111111111111"
+	testLoserUUID  = "22222222-2222-2222-2222-222222222222"
+	// 시스템 센티넬: forfeit/stalemate 무승부 시 game_events.player_id에 사용
+	nilUUID = "00000000-0000-0000-0000-000000000000"
+)
+
 // --- mock GameRepository ---
 
 type mockGameRepo struct {
@@ -105,6 +113,8 @@ func newPersistTestHandler() (*WSHandler, *mockGameRepo, *mockGamePlayerRepo, *m
 	return h, pgGame, pgPlayer, pgEvent
 }
 
+// makeFinishedState UUID 기반 플레이어로 정상 종료 상태를 생성한다.
+// winnerUserID는 RFC 4122 UUID 형식이어야 game_players.user_id 가 올바르게 저장된다.
 func makeFinishedState(gameID, winnerUserID string, winnerSeat int) *model.GameStateRedis {
 	loserSeat := 1
 	if winnerSeat == 1 {
@@ -120,7 +130,7 @@ func makeFinishedState(gameID, winnerUserID string, winnerSeat int) *model.GameS
 		},
 		{
 			SeatOrder:   loserSeat,
-			UserID:      "loser-id",
+			UserID:      testLoserUUID,
 			DisplayName: "Player B",
 			PlayerType:  "HUMAN",
 			Rack:        []string{"R1a", "B2b", "Y3a"},
@@ -135,18 +145,18 @@ func makeFinishedState(gameID, winnerUserID string, winnerSeat int) *model.GameS
 	}
 }
 
-// TestPersistGameResult_NormalWin 정상 승리 시 games/game_players/game_events 모두 삽입
+// TestPersistGameResult_NormalWin UUID 승자로 정상 승리 시 games/game_players/game_events 모두 삽입
 func TestPersistGameResult_NormalWin(t *testing.T) {
 	h, pgGame, pgPlayer, pgEvent := newPersistTestHandler()
 
-	state := makeFinishedState("game-001", "winner-user", 0)
+	state := makeFinishedState("game-001", testWinnerUUID, 0)
 	h.persistGameResult(state, "NORMAL")
 
 	require.Len(t, pgGame.games, 1, "games 테이블 1건 삽입")
 	assert.Equal(t, "game-001", pgGame.games[0].ID)
 	assert.Equal(t, model.GameStatusFinished, pgGame.games[0].Status)
 	require.NotNil(t, pgGame.games[0].WinnerID)
-	assert.Equal(t, "winner-user", *pgGame.games[0].WinnerID)
+	assert.Equal(t, testWinnerUUID, *pgGame.games[0].WinnerID)
 	assert.NotNil(t, pgGame.games[0].EndedAt)
 
 	require.Len(t, pgPlayer.players, 2, "game_players 2건 삽입")
@@ -154,8 +164,8 @@ func TestPersistGameResult_NormalWin(t *testing.T) {
 	for _, gp := range pgPlayer.players {
 		if gp.IsWinner {
 			winnerFound = true
-			require.NotNil(t, gp.UserID)
-			assert.Equal(t, "winner-user", *gp.UserID)
+			require.NotNil(t, gp.UserID, "UUID 승자는 user_id가 NOT NULL")
+			assert.Equal(t, testWinnerUUID, *gp.UserID)
 			finalTiles := 0
 			assert.Equal(t, &finalTiles, gp.FinalTiles)
 		}
@@ -166,6 +176,8 @@ func TestPersistGameResult_NormalWin(t *testing.T) {
 	assert.Equal(t, model.EventTypeGameEnd, pgEvent.events[0].EventType)
 	assert.Equal(t, "game-001", pgEvent.events[0].GameID)
 	assert.Contains(t, pgEvent.events[0].Payload, "NORMAL")
+	// UUID 승자이면 player_id가 해당 UUID여야 함
+	assert.Equal(t, testWinnerUUID, pgEvent.events[0].PlayerID)
 }
 
 // TestPersistGameResult_Stalemate 교착 종료 시 endType이 STALEMATE로 덮어씌워짐
@@ -189,19 +201,23 @@ func TestPersistGameResult_Stalemate(t *testing.T) {
 
 	require.Len(t, pgEvent.events, 1)
 	assert.Contains(t, pgEvent.events[0].Payload, "STALEMATE")
+	// Bug 2 fix 검증: winnerID 없어도 player_id가 uuid.Nil로 채워져 빈 문자열이 아님
+	assert.Equal(t, nilUUID, pgEvent.events[0].PlayerID, "stalemate 무승부 시 player_id는 uuid.Nil")
 }
 
 // TestPersistGameResult_Forfeit 기권 시 endType FORFEIT이 기록됨
 func TestPersistGameResult_Forfeit(t *testing.T) {
 	h, pgGame, _, pgEvent := newPersistTestHandler()
 
-	state := makeFinishedState("game-003", "winner-user", 0)
+	state := makeFinishedState("game-003", testWinnerUUID, 0)
 
 	h.persistGameResult(state, "FORFEIT")
 
 	require.Len(t, pgGame.games, 1)
 	require.Len(t, pgEvent.events, 1)
 	assert.Contains(t, pgEvent.events[0].Payload, "FORFEIT")
+	// FORFEIT 종료에도 UUID 승자가 있으면 player_id는 해당 UUID
+	assert.Equal(t, testWinnerUUID, pgEvent.events[0].PlayerID)
 }
 
 // TestPersistGameResult_NilRepos 레포지터리가 nil이면 패닉 없이 조용히 종료
@@ -213,7 +229,7 @@ func TestPersistGameResult_NilRepos(t *testing.T) {
 		pgGameEventRepo:  nil,
 	}
 
-	state := makeFinishedState("game-004", "winner-user", 0)
+	state := makeFinishedState("game-004", testWinnerUUID, 0)
 
 	assert.NotPanics(t, func() {
 		h.persistGameResult(state, "NORMAL")
@@ -257,7 +273,7 @@ func TestResolveWinnerFromState_Stalemate_MinScore(t *testing.T) {
 		IsStalemate: true,
 		Players: []model.PlayerState{
 			{SeatOrder: 0, UserID: "player-A", Rack: []string{"R10a", "B10b"}}, // score=20
-			{SeatOrder: 1, UserID: "player-B", Rack: []string{"R1a"}},           // score=1
+			{SeatOrder: 1, UserID: "player-B", Rack: []string{"R1a"}},          // score=1
 		},
 	}
 	wID, wSeat := resolveWinnerFromState(state)
@@ -324,7 +340,7 @@ func TestPersistGameResult_AsyncSafe(t *testing.T) {
 		gameID := fmt.Sprintf("game-%03d", i)
 		go func(gid string) {
 			defer wg.Done()
-			state := makeFinishedState(gid, "winner-user", 0)
+			state := makeFinishedState(gid, testWinnerUUID, 0)
 			h.persistGameResult(state, "NORMAL")
 		}(gameID)
 	}
@@ -342,4 +358,159 @@ func TestPersistGameResult_AsyncSafe(t *testing.T) {
 	pgEvent.mu.Lock()
 	assert.Len(t, pgEvent.events, 5, "게임당 GAME_END 1건")
 	pgEvent.mu.Unlock()
+}
+
+// ============================================================
+// I-14 UUID 정규화 버그 수정 회귀 테스트 (QA 실측 버그 2건)
+// ============================================================
+
+// TestPersistGameResult_GuestUserID_NullInDB
+// Bug 1: 게스트 user_id("qa-테스터-1776838709181" 등 자유 문자열)는
+// game_players.user_id(UUID 컬럼)에 NULL로 저장되어야 한다. (SQLSTATE 22P02 방지)
+func TestPersistGameResult_GuestUserID_NullInDB(t *testing.T) {
+	h, _, pgPlayer, pgEvent := newPersistTestHandler()
+
+	// 게스트 ID: 자유 문자열 (UUID 형식 아님)
+	guestID := "qa-테스터-1776838709181"
+	state := &model.GameStateRedis{
+		GameID:    "game-guest-001",
+		TurnCount: 10,
+		Players: []model.PlayerState{
+			{
+				SeatOrder:   0,
+				UserID:      guestID, // 비 UUID 게스트 ID — 승자
+				DisplayName: "QA Tester",
+				PlayerType:  "HUMAN",
+				Rack:        []string{}, // 승자: 타일 0장
+			},
+			{
+				SeatOrder:   1,
+				UserID:      "ai-bot-0001", // AI도 비 UUID 케이스
+				DisplayName: "AI Bot",
+				PlayerType:  "AI_OPENAI",
+				Rack:        []string{"R1a", "B2b"},
+			},
+		},
+		IsStalemate: false,
+	}
+
+	h.persistGameResult(state, "NORMAL")
+
+	require.Len(t, pgPlayer.players, 2, "game_players 2건 삽입")
+	for _, gp := range pgPlayer.players {
+		// 비 UUID ID는 user_id가 NULL이어야 한다 — SQLSTATE 22P02 방지
+		assert.Nil(t, gp.UserID, "비 UUID user_id는 game_players.user_id에 NULL로 저장")
+	}
+
+	require.Len(t, pgEvent.events, 1)
+	// Bug 2 검증: 게스트가 winner여도 player_id에 Nil UUID 사용 (게스트는 UUID 아님)
+	assert.Equal(t, nilUUID, pgEvent.events[0].PlayerID,
+		"비 UUID 게스트 winner → player_id = uuid.Nil")
+}
+
+// TestPersistGameResult_EmptyWinnerID_GameEventUsesNilUUID
+// Bug 2: forfeit 종료 시 모든 플레이어가 타일을 가지고 있어 winnerID=""이면
+// game_events.player_id(UUID NOT NULL)에 uuid.Nil을 사용해야 한다. (빈 문자열 UUID 변환 실패 방지)
+func TestPersistGameResult_EmptyWinnerID_GameEventUsesNilUUID(t *testing.T) {
+	h, _, _, pgEvent := newPersistTestHandler()
+
+	// 모든 플레이어 타일 남아있음 + stalemate 아님 → winnerID="" 결정됨
+	state := &model.GameStateRedis{
+		GameID:    "game-forfeit-001",
+		TurnCount: 5,
+		Players: []model.PlayerState{
+			{
+				SeatOrder:  0,
+				UserID:     testWinnerUUID,
+				PlayerType: "HUMAN",
+				Rack:       []string{"R1a"}, // 타일 남아있음
+			},
+			{
+				SeatOrder:  1,
+				UserID:     testLoserUUID,
+				PlayerType: "HUMAN",
+				Rack:       []string{"B2b"}, // 타일 남아있음
+				Status:     model.PlayerStatusForfeited,
+			},
+		},
+		IsStalemate: false,
+	}
+
+	h.persistGameResult(state, "FORFEIT")
+
+	require.Len(t, pgEvent.events, 1)
+	playerID := pgEvent.events[0].PlayerID
+	assert.NotEmpty(t, playerID, "player_id는 빈 문자열이 아니어야 함 (NOT NULL 컬럼)")
+	// 타일 0장 플레이어 없음 → winnerID="" → player_id = uuid.Nil
+	assert.Equal(t, nilUUID, playerID,
+		"승자 없는 FORFEIT 종료 시 player_id = uuid.Nil (00000000-...)")
+}
+
+// TestPersistGameResult_MixedPlayers_UUIDAndGuest
+// UUID 사용자(OAuth)와 게스트 ID가 혼재할 때 각각 올바르게 처리됨
+func TestPersistGameResult_MixedPlayers_UUIDAndGuest(t *testing.T) {
+	h, _, pgPlayer, pgEvent := newPersistTestHandler()
+
+	state := &model.GameStateRedis{
+		GameID:    "game-mixed-001",
+		TurnCount: 15,
+		Players: []model.PlayerState{
+			{
+				SeatOrder:   0,
+				UserID:      testWinnerUUID, // OAuth 로그인 사용자 — UUID
+				DisplayName: "OAuth User",
+				PlayerType:  "HUMAN",
+				Rack:        []string{}, // 승자
+			},
+			{
+				SeatOrder:   1,
+				UserID:      "guest-anonymous-9999", // 게스트 — 자유 문자열
+				DisplayName: "Guest",
+				PlayerType:  "HUMAN",
+				Rack:        []string{"R5a", "B6b"},
+			},
+		},
+		IsStalemate: false,
+	}
+
+	h.persistGameResult(state, "NORMAL")
+
+	require.Len(t, pgPlayer.players, 2)
+	for _, gp := range pgPlayer.players {
+		if gp.IsWinner {
+			// OAuth 사용자(UUID)는 user_id 보존
+			require.NotNil(t, gp.UserID, "OAuth UUID 승자는 user_id NOT NULL")
+			assert.Equal(t, testWinnerUUID, *gp.UserID)
+		} else {
+			// 게스트는 user_id = NULL
+			assert.Nil(t, gp.UserID, "게스트는 user_id = NULL")
+		}
+	}
+
+	// 승자가 UUID이므로 player_id도 UUID
+	require.Len(t, pgEvent.events, 1)
+	assert.Equal(t, testWinnerUUID, pgEvent.events[0].PlayerID)
+}
+
+// TestIsValidUUID isValidUUID 헬퍼 단위 테스트
+func TestIsValidUUID(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"11111111-1111-1111-1111-111111111111", true},
+		{"00000000-0000-0000-0000-000000000000", true},
+		{"550e8400-e29b-41d4-a716-446655440000", true},
+		{"", false},
+		{"winner-user", false},
+		{"qa-테스터-1776838709181", false},
+		{"guest-anonymous-9999", false},
+		{"not-a-uuid", false},
+		{"12345678-1234-1234-1234-12345678901", false}, // 짧음
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isValidUUID(tt.input))
+		})
+	}
 }

--- a/src/game-server/internal/handler/ws_persist_test.go
+++ b/src/game-server/internal/handler/ws_persist_test.go
@@ -1,0 +1,265 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/k82022603/RummiArena/game-server/internal/model"
+	"github.com/k82022603/RummiArena/game-server/internal/repository"
+	"github.com/k82022603/RummiArena/game-server/internal/service"
+)
+
+// ============================================================
+// I-14: persistGameResult 단위 테스트
+// ============================================================
+
+// --- mock GameRepository ---
+
+type mockGameRepo struct {
+	mu    sync.Mutex
+	games []*model.Game
+}
+
+func (m *mockGameRepo) CreateGame(_ context.Context, game *model.Game) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.games = append(m.games, game)
+	return nil
+}
+func (m *mockGameRepo) GetGame(_ context.Context, _ string) (*model.Game, error) { return nil, nil }
+func (m *mockGameRepo) UpdateGame(_ context.Context, _ *model.Game) error        { return nil }
+func (m *mockGameRepo) CreateRoom(_ context.Context, _ *model.Room) error        { return nil }
+func (m *mockGameRepo) GetRoom(_ context.Context, _ string) (*model.Room, error) { return nil, nil }
+func (m *mockGameRepo) UpdateRoom(_ context.Context, _ *model.Room) error        { return nil }
+func (m *mockGameRepo) ListRooms(_ context.Context) ([]*model.Room, error)       { return nil, nil }
+
+// --- mock GamePlayerRepository ---
+
+type mockGamePlayerRepo struct {
+	mu      sync.Mutex
+	players []*model.GamePlayer
+}
+
+func (m *mockGamePlayerRepo) CreateGamePlayer(_ context.Context, gp *model.GamePlayer) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.players = append(m.players, gp)
+	return nil
+}
+func (m *mockGamePlayerRepo) GetGamePlayers(_ context.Context, _ string) ([]*model.GamePlayer, error) {
+	return nil, nil
+}
+func (m *mockGamePlayerRepo) UpdateGamePlayer(_ context.Context, _ *model.GamePlayer) error {
+	return nil
+}
+
+// --- mock GameEventRepository ---
+
+type mockGameEventRepo struct {
+	mu     sync.Mutex
+	events []*model.GameEvent
+}
+
+func (m *mockGameEventRepo) CreateGameEvent(_ context.Context, ev *model.GameEvent) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, ev)
+	return nil
+}
+func (m *mockGameEventRepo) ListGameEvents(_ context.Context, _ string) ([]*model.GameEvent, error) {
+	return nil, nil
+}
+
+// --- 헬퍼 ---
+
+func newPersistTestHandler() (*WSHandler, *mockGameRepo, *mockGamePlayerRepo, *mockGameEventRepo) {
+	gameStateRepo := repository.NewMemoryGameStateRepo()
+	gameSvc := service.NewGameService(gameStateRepo)
+	turnSvc := service.NewTurnService(gameStateRepo, gameSvc)
+	roomRepo := repository.NewMemoryRoomRepo()
+	roomSvc := service.NewRoomService(roomRepo, repository.NewMemoryGameStateRepoAdapter())
+
+	pgGame := &mockGameRepo{}
+	pgPlayer := &mockGamePlayerRepo{}
+	pgEvent := &mockGameEventRepo{}
+
+	h := &WSHandler{
+		hub:              NewHub(zap.NewNop()),
+		roomSvc:          roomSvc,
+		gameSvc:          gameSvc,
+		turnSvc:          turnSvc,
+		logger:           zap.NewNop(),
+		timers:           make(map[string]*turnTimer),
+		graceTimers:      make(map[string]*graceTimer),
+		aiTurnCancels:    make(map[string]context.CancelFunc),
+		pgGameRepo:       pgGame,
+		pgGamePlayerRepo: pgPlayer,
+		pgGameEventRepo:  pgEvent,
+	}
+	return h, pgGame, pgPlayer, pgEvent
+}
+
+func makeFinishedState(gameID, winnerUserID string, winnerSeat int) *model.GameStateRedis {
+	loserSeat := 1
+	if winnerSeat == 1 {
+		loserSeat = 0
+	}
+	players := []model.PlayerState{
+		{
+			SeatOrder:   winnerSeat,
+			UserID:      winnerUserID,
+			DisplayName: "Player A",
+			PlayerType:  "HUMAN",
+			Rack:        []string{}, // 승자: 타일 0장
+		},
+		{
+			SeatOrder:   loserSeat,
+			UserID:      "loser-id",
+			DisplayName: "Player B",
+			PlayerType:  "HUMAN",
+			Rack:        []string{"R1a", "B2b", "Y3a"},
+		},
+	}
+	return &model.GameStateRedis{
+		GameID:      gameID,
+		Status:      model.GameStatusFinished,
+		TurnCount:   20,
+		Players:     players,
+		IsStalemate: false,
+	}
+}
+
+// TestPersistGameResult_NormalWin 정상 승리 시 games/game_players/game_events 모두 삽입
+func TestPersistGameResult_NormalWin(t *testing.T) {
+	h, pgGame, pgPlayer, pgEvent := newPersistTestHandler()
+
+	state := makeFinishedState("game-001", "winner-user", 0)
+	h.persistGameResult(state, "NORMAL")
+
+	require.Len(t, pgGame.games, 1, "games 테이블 1건 삽입")
+	assert.Equal(t, "game-001", pgGame.games[0].ID)
+	assert.Equal(t, model.GameStatusFinished, pgGame.games[0].Status)
+	require.NotNil(t, pgGame.games[0].WinnerID)
+	assert.Equal(t, "winner-user", *pgGame.games[0].WinnerID)
+	assert.NotNil(t, pgGame.games[0].EndedAt)
+
+	require.Len(t, pgPlayer.players, 2, "game_players 2건 삽입")
+	winnerFound := false
+	for _, gp := range pgPlayer.players {
+		if gp.IsWinner {
+			winnerFound = true
+			require.NotNil(t, gp.UserID)
+			assert.Equal(t, "winner-user", *gp.UserID)
+			finalTiles := 0
+			assert.Equal(t, &finalTiles, gp.FinalTiles)
+		}
+	}
+	assert.True(t, winnerFound, "승자 game_player 레코드 존재")
+
+	require.Len(t, pgEvent.events, 1, "game_events 1건 삽입 (GAME_END)")
+	assert.Equal(t, model.EventTypeGameEnd, pgEvent.events[0].EventType)
+	assert.Equal(t, "game-001", pgEvent.events[0].GameID)
+	assert.Contains(t, pgEvent.events[0].Payload, "NORMAL")
+}
+
+// TestPersistGameResult_Stalemate 교착 종료 시 endType이 STALEMATE로 덮어씌워짐
+func TestPersistGameResult_Stalemate(t *testing.T) {
+	h, pgGame, pgPlayer, pgEvent := newPersistTestHandler()
+
+	state := makeFinishedState("game-002", "", 0)
+	state.IsStalemate = true
+	// 교착 시 랙이 비지 않음
+	for i := range state.Players {
+		state.Players[i].Rack = []string{"R1a"}
+	}
+
+	// endType 인자가 "NORMAL"이어도 IsStalemate=true면 STALEMATE로 덮임
+	h.persistGameResult(state, "NORMAL")
+
+	require.Len(t, pgGame.games, 1)
+	assert.Nil(t, pgGame.games[0].WinnerID, "교착 시 winner 없음 (타일 동점)")
+
+	require.Len(t, pgPlayer.players, 2)
+
+	require.Len(t, pgEvent.events, 1)
+	assert.Contains(t, pgEvent.events[0].Payload, "STALEMATE")
+}
+
+// TestPersistGameResult_Forfeit 기권 시 endType FORFEIT이 기록됨
+func TestPersistGameResult_Forfeit(t *testing.T) {
+	h, pgGame, _, pgEvent := newPersistTestHandler()
+
+	state := makeFinishedState("game-003", "winner-user", 0)
+
+	h.persistGameResult(state, "FORFEIT")
+
+	require.Len(t, pgGame.games, 1)
+	require.Len(t, pgEvent.events, 1)
+	assert.Contains(t, pgEvent.events[0].Payload, "FORFEIT")
+}
+
+// TestPersistGameResult_NilRepos 레포지터리가 nil이면 패닉 없이 조용히 종료
+func TestPersistGameResult_NilRepos(t *testing.T) {
+	h := &WSHandler{
+		logger:           zap.NewNop(),
+		pgGameRepo:       nil,
+		pgGamePlayerRepo: nil,
+		pgGameEventRepo:  nil,
+	}
+
+	state := makeFinishedState("game-004", "winner-user", 0)
+
+	assert.NotPanics(t, func() {
+		h.persistGameResult(state, "NORMAL")
+	})
+}
+
+// TestWithPersistenceRepos WithPersistenceRepos setter가 필드에 올바르게 주입하는지 확인
+func TestWithPersistenceRepos(t *testing.T) {
+	h := &WSHandler{logger: zap.NewNop()}
+	pgGame := &mockGameRepo{}
+	pgPlayer := &mockGamePlayerRepo{}
+	pgEvent := &mockGameEventRepo{}
+
+	h.WithPersistenceRepos(pgGame, pgPlayer, pgEvent)
+
+	assert.Equal(t, pgGame, h.pgGameRepo)
+	assert.Equal(t, pgPlayer, h.pgGamePlayerRepo)
+	assert.Equal(t, pgEvent, h.pgGameEventRepo)
+}
+
+// TestPersistGameResult_AsyncSafe persistGameResult를 고루틴으로 동시 호출해도 race 없음
+func TestPersistGameResult_AsyncSafe(t *testing.T) {
+	h, pgGame, pgPlayer, pgEvent := newPersistTestHandler()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		gameID := fmt.Sprintf("game-%03d", i)
+		go func(gid string) {
+			defer wg.Done()
+			state := makeFinishedState(gid, "winner-user", 0)
+			h.persistGameResult(state, "NORMAL")
+		}(gameID)
+	}
+	wg.Wait()
+
+	// 5판: games=5, game_players=10, game_events=5
+	pgGame.mu.Lock()
+	assert.Len(t, pgGame.games, 5, "5개 게임 records")
+	pgGame.mu.Unlock()
+
+	pgPlayer.mu.Lock()
+	assert.Len(t, pgPlayer.players, 10, "각 게임당 2명")
+	pgPlayer.mu.Unlock()
+
+	pgEvent.mu.Lock()
+	assert.Len(t, pgEvent.events, 5, "게임당 GAME_END 1건")
+	pgEvent.mu.Unlock()
+}

--- a/src/game-server/internal/handler/ws_persist_test.go
+++ b/src/game-server/internal/handler/ws_persist_test.go
@@ -234,6 +234,86 @@ func TestWithPersistenceRepos(t *testing.T) {
 	assert.Equal(t, pgEvent, h.pgGameEventRepo)
 }
 
+// ============================================================
+// I-15: resolveWinnerFromState 단위 테스트
+// ============================================================
+
+// TestResolveWinnerFromState_NormalWin 타일 0장 플레이어 → 정상 승리
+func TestResolveWinnerFromState_NormalWin(t *testing.T) {
+	state := &model.GameStateRedis{
+		Players: []model.PlayerState{
+			{SeatOrder: 0, UserID: "loser", Rack: []string{"R1a", "B2b"}},
+			{SeatOrder: 1, UserID: "winner", Rack: []string{}},
+		},
+	}
+	wID, wSeat := resolveWinnerFromState(state)
+	assert.Equal(t, "winner", wID)
+	assert.Equal(t, 1, wSeat)
+}
+
+// TestResolveWinnerFromState_Stalemate_MinScore 교착 종료: 점수 낮은 쪽 승리
+func TestResolveWinnerFromState_Stalemate_MinScore(t *testing.T) {
+	state := &model.GameStateRedis{
+		IsStalemate: true,
+		Players: []model.PlayerState{
+			{SeatOrder: 0, UserID: "player-A", Rack: []string{"R10a", "B10b"}}, // score=20
+			{SeatOrder: 1, UserID: "player-B", Rack: []string{"R1a"}},           // score=1
+		},
+	}
+	wID, wSeat := resolveWinnerFromState(state)
+	assert.Equal(t, "player-B", wID)
+	assert.Equal(t, 1, wSeat)
+}
+
+// TestResolveWinnerFromState_Stalemate_Tie 교착 종료: 동점 → 무승부
+func TestResolveWinnerFromState_Stalemate_Tie(t *testing.T) {
+	state := &model.GameStateRedis{
+		IsStalemate: true,
+		Players: []model.PlayerState{
+			{SeatOrder: 0, UserID: "player-A", Rack: []string{"R5a"}}, // score=5
+			{SeatOrder: 1, UserID: "player-B", Rack: []string{"B5b"}}, // score=5
+		},
+	}
+	wID, wSeat := resolveWinnerFromState(state)
+	assert.Equal(t, "", wID, "동점이면 무승부 (winnerId 빈 문자열)")
+	assert.Equal(t, -1, wSeat)
+}
+
+// TestResolveWinnerFromState_NoWinner 승자 없음 (모든 랙 비지 않고 stalemate 아님)
+func TestResolveWinnerFromState_NoWinner(t *testing.T) {
+	state := &model.GameStateRedis{
+		IsStalemate: false,
+		Players: []model.PlayerState{
+			{SeatOrder: 0, UserID: "player-A", Rack: []string{"R1a"}},
+			{SeatOrder: 1, UserID: "player-B", Rack: []string{"B2a"}},
+		},
+	}
+	wID, wSeat := resolveWinnerFromState(state)
+	assert.Equal(t, "", wID)
+	assert.Equal(t, -1, wSeat)
+}
+
+// TestTileScoreFromCode 타일 코드 점수 계산 검증
+func TestTileScoreFromCode(t *testing.T) {
+	tests := []struct {
+		code     string
+		expected int
+	}{
+		{"JK1", 30},
+		{"JK2", 30},
+		{"R7a", 7},
+		{"B13b", 13},
+		{"Y1a", 1},
+		{"K9b", 9},
+		{"", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.code, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tileScoreFromCode(tt.code))
+		})
+	}
+}
+
 // TestPersistGameResult_AsyncSafe persistGameResult를 고루틴으로 동시 호출해도 race 없음
 func TestPersistGameResult_AsyncSafe(t *testing.T) {
 	h, pgGame, pgPlayer, pgEvent := newPersistTestHandler()

--- a/src/game-server/internal/repository/postgres_repo.go
+++ b/src/game-server/internal/repository/postgres_repo.go
@@ -171,3 +171,34 @@ func (r *postgresGamePlayerRepo) UpdateGamePlayer(ctx context.Context, gp *model
 	}
 	return nil
 }
+
+// GameEventRepository defines persistent game-event operations backed by PostgreSQL.
+type GameEventRepository interface {
+	CreateGameEvent(ctx context.Context, ev *model.GameEvent) error
+	ListGameEvents(ctx context.Context, gameID string) ([]*model.GameEvent, error)
+}
+
+// postgresGameEventRepo implements GameEventRepository.
+type postgresGameEventRepo struct {
+	db *gorm.DB
+}
+
+// NewPostgresGameEventRepo creates a PostgreSQL-backed GameEventRepository.
+func NewPostgresGameEventRepo(db *gorm.DB) GameEventRepository {
+	return &postgresGameEventRepo{db: db}
+}
+
+func (r *postgresGameEventRepo) CreateGameEvent(ctx context.Context, ev *model.GameEvent) error {
+	if err := r.db.WithContext(ctx).Create(ev).Error; err != nil {
+		return fmt.Errorf("postgres_repo: create game_event: %w", err)
+	}
+	return nil
+}
+
+func (r *postgresGameEventRepo) ListGameEvents(ctx context.Context, gameID string) ([]*model.GameEvent, error) {
+	var events []*model.GameEvent
+	if err := r.db.WithContext(ctx).Where("game_id = ?", gameID).Order("created_at ASC").Find(&events).Error; err != nil {
+		return nil, fmt.Errorf("postgres_repo: list game_events for game %q: %w", gameID, err)
+	}
+	return events, nil
+}


### PR DESCRIPTION
## Summary
2026-04-22 실측에서 확인된 **백엔드 P0 2건** 핫픽스. 1주일간 `game_events count=0` 이었던 미스터리 해결 포함.

- **I-14 DB 영속저장 0건** — `WSHandler` 에 `Game/GamePlayer/GameEvent` 3 repo 주입 + `persistGameResult` 헬퍼로 3개 종료 분기(win/stalemate/forfeit)에서 DB insert. 기존에는 `eloRepo` 만 주입되어 ELO 만 기록됐던 설계 누락을 해소.
- **I-14 2차: UUID 정규화 (QA 실측 버그 2건)** — `game_players.user_id` 게스트 자유 문자열 UUID 파싱 실패 + `game_events.player_id` 빈 문자열 UUID 실패. `isValidUUID` 헬퍼 + `uuid.Nil` 센티넬로 애플리케이션 레이어에서 정규화 (DB 스키마 변경 없음).
- **I-15 GAME_OVER winnerId 판정** — stalemate/forfeit 종료 시 `len(Rack)==0` 만 체크해서 winner 가 빈 문자열로 브로드캐스트되던 문제. `resolveWinnerFromState` 헬퍼로 정확한 판정.

## Test plan
- [x] Go 525/525 PASS (`go test ./... -count=1`, 7 packages)
- [x] 신규 단위 테스트 21건: I-14 persistence 17건 + UUID 정규화 4건
- [x] `go vet ./...` clean
- [x] 로컬 K8s 실측 AI vs AI 1판 완료 후 DB 증분 확인:
  - games: 58 → 60 (+2)
  - game_players: 58 → 62 (+4, HUMAN+AI 양측 저장 확인)
  - game_events: **0 → 2** (+2, GAME_END event 기록) ← 1주일 미스터리 해결
- [x] 롤백 가능: `kubectl rollout undo deployment/game-server -n rummikub`

## Sprint 7 Week 1 이관 TODO
- **PK 충돌 방어** — `games` INSERT 에 `ON CONFLICT DO NOTHING` 추가 필요
- **~~StartGame 시 rooms/games INSERT 누락~~** — **I-17 / ADR D-03 로 재분류 (Option B 채택, 2026-04-22)**
  - 현상: MVP 모드로 `MemoryRoomRepo` 만 DI. `PostgresRoomRepo` 구현은 존재하나 미사용
  - 결정 완료: [Issue #43 (I-17)](https://github.com/k82022603/RummiArena/issues/43) / ADR D-03 (`work_logs/decisions/2026-04-22-rooms-postgres-phase1.md`, [PR #40 merged](https://github.com/k82022603/RummiArena/pull/40))
  - 구현: [PR #42 진행 중](https://github.com/k82022603/RummiArena/pull/42) — feat/rooms-postgres-phase1-impl
- **`game.RoomCode` 빈 문자열** — NOT NULL 위반 가능성, 마이그레이션 또는 기본값 처리 (I-17 구현 시 함께 해소)

관련 커밋: ff9854d, c4b566a, 247c7c8

🤖 Generated with [Claude Code](https://claude.com/claude-code)