### PR TITLE
feat(game-server): D-03 rooms PostgreSQL Phase 1 Dual-Write 구현

### DIFF
--- a/scripts/smoke-rooms-phase1.py
+++ b/scripts/smoke-rooms-phase1.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+smoke-rooms-phase1.py — PR #42 Phase 1 Dual-Write 최소 smoke 테스트
+- UUID 형식 userId로 dev-login → 방 생성 → 게임 시작 → WS 자동 드로우로 진행
+- rooms 테이블 dual-write 트리거 검증
+- Ollama (AI_LLAMA) 사용, 비용 $0
+"""
+import asyncio
+import json
+import time
+import uuid
+import sys
+import requests
+import websockets
+
+BASE_URL = "http://localhost:30080"
+WS_URL   = "ws://localhost:30080/ws"
+MAX_TURNS = 30          # smoke: 30턴으로 제한 (충분한 시간 내 완료)
+WS_TIMEOUT = 90         # 90초 타임아웃 (Ollama가 느릴 수 있으므로)
+
+def dev_login_uuid(user_id: str, display_name: str) -> str:
+    resp = requests.post(
+        f"{BASE_URL}/api/auth/dev-login",
+        json={"userId": user_id, "displayName": display_name},
+        timeout=10
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    token = data.get("token") or data.get("data", {}).get("token", "")
+    return token
+
+def create_room(token: str, room_name: str) -> str:
+    headers = {"Authorization": f"Bearer {token}"}
+    body = {
+        "name": room_name,
+        "playerCount": 2,
+        "turnTimeoutSec": 120,
+        "displayName": "Smoke-Host",
+        "aiPlayers": [{
+            "type": "AI_LLAMA",
+            "persona": "calculator",
+            "difficulty": "beginner",
+            "psychologyLevel": 0,
+        }]
+    }
+    resp = requests.post(f"{BASE_URL}/api/rooms", json=body, headers=headers, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    room_id = data.get("id") or data.get("roomId") or data.get("data", {}).get("id", "")
+    return str(room_id)
+
+def start_game(token: str, room_id: str):
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = requests.post(f"{BASE_URL}/api/rooms/{room_id}/start", headers=headers, timeout=10)
+    resp.raise_for_status()
+
+async def run_ws_autodraw(token: str, room_id: str) -> dict:
+    """자동 드로우로 최대 MAX_TURNS 진행"""
+    ws_uri = f"{WS_URL}?roomId={room_id}"
+    stats = {"turns": 0, "result": "TIMEOUT", "game_over": False}
+
+    try:
+        async with websockets.connect(ws_uri, open_timeout=15, close_timeout=10) as ws:
+            # AUTH — envelope format: {type, payload: {token}}
+            auth_msg = {"type": "AUTH", "payload": {"token": token}, "seq": 0}
+            await ws.send(json.dumps(auth_msg))
+
+            start_t = time.time()
+            my_seat = None
+            turn_count = 0
+
+            while time.time() - start_t < WS_TIMEOUT:
+                try:
+                    raw = await asyncio.wait_for(ws.recv(), timeout=30)
+                except asyncio.TimeoutError:
+                    print("  WS recv timeout — assuming game ended or stalled")
+                    break
+
+                msg = json.loads(raw)
+                mtype = msg.get("type", "")
+
+                if mtype == "AUTH_OK":
+                    my_seat = msg.get("seat", 0)
+                    print(f"  AUTH_OK seat={my_seat}")
+
+                elif mtype == "GAME_STATE":
+                    # Initial game state — check if it's our turn (seat 0 goes first usually)
+                    gs = msg.get("payload", msg.get("gameState", msg))
+                    current = gs.get("currentSeat", gs.get("currentPlayer", -1))
+                    if current == my_seat and turn_count == 0:
+                        turn_count += 1
+                        stats["turns"] = turn_count
+                        draw_msg = {"type": "DRAW_TILE", "payload": {}, "seq": turn_count}
+                        await ws.send(json.dumps(draw_msg))
+                        print(f"  T{turn_count:02d} seat={my_seat}: DRAW_TILE (from GAME_STATE)")
+
+                elif mtype == "TURN_START":
+                    payload = msg.get("payload", {})
+                    current = payload.get("seat", -1)
+                    turn_count += 1
+                    stats["turns"] = turn_count
+
+                    if turn_count > MAX_TURNS:
+                        print(f"  Reached MAX_TURNS={MAX_TURNS}, stopping")
+                        break
+
+                    if current == my_seat:
+                        # 항상 DRAW_TILE (auto-draw 전략)
+                        draw_msg = {"type": "DRAW_TILE", "payload": {}, "seq": turn_count}
+                        await ws.send(json.dumps(draw_msg))
+                        print(f"  T{turn_count:02d} seat={my_seat}: DRAW_TILE")
+                    else:
+                        print(f"  T{turn_count:02d} AI thinking...")
+
+                elif mtype == "GAME_OVER":
+                    stats["result"] = "GAME_OVER"
+                    stats["game_over"] = True
+                    print(f"  GAME_OVER received: {json.dumps(msg)[:200]}")
+                    break
+
+                elif mtype == "ERROR":
+                    print(f"  ERROR: {msg}")
+
+    except Exception as e:
+        print(f"  WS exception: {e}")
+        stats["result"] = f"ERROR: {e}"
+
+    return stats
+
+async def main():
+    host_uuid = str(uuid.uuid4())
+    print(f"\n{'='*60}")
+    print(f"  PR #42 Phase 1 Rooms Dual-Write Smoke Test")
+    print(f"  host_uuid={host_uuid}")
+    print(f"{'='*60}\n")
+
+    # 1) dev-login with UUID
+    print("[1] dev-login with UUID userId...")
+    token = dev_login_uuid(host_uuid, "SmokeHost-Phase1")
+    print(f"  token obtained: {token[:30]}...")
+
+    # 2) create room
+    room_name = f"smoke-phase1-{int(time.time())}"
+    print(f"[2] creating room '{room_name}'...")
+    room_id = create_room(token, room_name)
+    print(f"  room_id={room_id}")
+
+    if not room_id:
+        print("FATAL: room_id is empty")
+        sys.exit(1)
+
+    # 3) start game
+    print("[3] starting game...")
+    start_game(token, room_id)
+    print("  game started")
+
+    # 4) run WS auto-draw
+    print(f"[4] running WS auto-draw (max {MAX_TURNS} turns, timeout {WS_TIMEOUT}s)...")
+    t0 = time.time()
+    stats = await run_ws_autodraw(token, room_id)
+    elapsed = time.time() - t0
+    print(f"  result={stats['result']} turns={stats['turns']} elapsed={elapsed:.1f}s")
+
+    print(f"\n{'='*60}")
+    print(f"  room_id : {room_id}")
+    print(f"  host_id : {host_uuid}")
+    print(f"  result  : {stats['result']}")
+    print(f"  turns   : {stats['turns']}")
+    print(f"  elapsed : {elapsed:.1f}s")
+    print(f"{'='*60}")
+    print(f"\nROOM_ID={room_id}")  # for shell capture
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/verify-rooms-persistence.sh
+++ b/scripts/verify-rooms-persistence.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# verify-rooms-persistence.sh — D-03 Phase 1 Dual-Write 배포 후 실 K8s/PG 검증
+#
+# 목적: AI vs AI 1판 배치 실행 이후 rooms 테이블과 games 테이블 사이의
+# FK 관계가 정상 기록되었는지를 ADR §"검증 계획" 에 명시된 4가지 SQL 질의로 확인한다.
+#
+# 사용:
+#   scripts/verify-rooms-persistence.sh                  # 최근 방 자동 선택
+#   scripts/verify-rooms-persistence.sh --room-id <uuid> # 특정 방 검증
+#
+# 종료 코드:
+#   0 — 모든 assertion PASS
+#   1 — 하나 이상 FAIL
+#   2 — 환경 오류(kubectl, psql 접근 불가 등)
+#
+# 연관:
+#   - ADR: work_logs/decisions/2026-04-22-rooms-postgres-phase1.md §"Integration Test"
+#   - Go 통합 테스트: src/game-server/e2e/rooms_persistence_test.go
+#   - 단위 테스트: src/game-server/internal/service/room_service_test.go §D-03
+
+set -uo pipefail
+
+# ─── 색상 (터미널 TTY 일 때만) ────────────────────────────────────────
+if [ -t 1 ]; then
+  C_RED='\033[0;31m'
+  C_GREEN='\033[0;32m'
+  C_YELLOW='\033[0;33m'
+  C_BLUE='\033[0;34m'
+  C_RESET='\033[0m'
+else
+  C_RED='' C_GREEN='' C_YELLOW='' C_BLUE='' C_RESET=''
+fi
+
+# ─── 환경 변수 (기본값) ──────────────────────────────────────────────
+NS="${NS:-rummikub}"
+PG_DEPLOY="${PG_DEPLOY:-deploy/postgres}"
+PG_USER="${PG_USER:-rummikub}"
+PG_DB="${PG_DB:-rummikub}"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+# ─── 인자 파싱 ───────────────────────────────────────────────────────
+ROOM_ID=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --room-id)
+      ROOM_ID="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      sed -n '2,20p' "$0"
+      exit 0
+      ;;
+    *)
+      echo -e "${C_RED}unknown argument: $1${C_RESET}" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# ─── 헬퍼 함수 ───────────────────────────────────────────────────────
+
+# psql_q "<SQL>" — PostgreSQL 에서 단일 값 질의. 공백/개행 제거 후 출력.
+psql_q() {
+  local sql="$1"
+  kubectl exec -n "$NS" "$PG_DEPLOY" -- \
+    psql -U "$PG_USER" -d "$PG_DB" -t -A -c "$sql" 2>/dev/null
+}
+
+# assert_eq "name" "expected" "actual"
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo -e "  ${C_GREEN}PASS${C_RESET} — ${name} (=${actual})"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo -e "  ${C_RED}FAIL${C_RESET} — ${name} (expected=${expected}, actual=${actual})"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+# assert_ge "name" "minimum" "actual"
+assert_ge() {
+  local name="$1" minimum="$2" actual="$3"
+  if [ -z "$actual" ]; then
+    echo -e "  ${C_RED}FAIL${C_RESET} — ${name} (no value returned)"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    return
+  fi
+  if [ "$actual" -ge "$minimum" ] 2>/dev/null; then
+    echo -e "  ${C_GREEN}PASS${C_RESET} — ${name} (${actual} >= ${minimum})"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo -e "  ${C_RED}FAIL${C_RESET} — ${name} (${actual} < ${minimum})"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+# ─── 사전 점검 ───────────────────────────────────────────────────────
+echo -e "${C_BLUE}=== D-03 Phase 1 Dual-Write 배포 후 검증 ===${C_RESET}"
+echo "namespace=$NS deploy=$PG_DEPLOY user=$PG_USER db=$PG_DB"
+echo ""
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo -e "${C_RED}kubectl 이 PATH 에 없습니다.${C_RESET}" >&2
+  exit 2
+fi
+
+if ! kubectl -n "$NS" get "$PG_DEPLOY" >/dev/null 2>&1; then
+  echo -e "${C_RED}kubectl -n $NS get $PG_DEPLOY 실패 — 클러스터/namespace 확인 필요.${C_RESET}" >&2
+  exit 2
+fi
+
+# pg_isready
+if ! kubectl exec -n "$NS" "$PG_DEPLOY" -- pg_isready -U "$PG_USER" >/dev/null 2>&1; then
+  echo -e "${C_RED}pg_isready 실패 — PostgreSQL 접속 불가.${C_RESET}" >&2
+  exit 2
+fi
+
+# ─── Assertion 1: rooms 테이블 INSERT 발생 ───────────────────────────
+echo -e "${C_YELLOW}[1/5] rooms 테이블 INSERT 검증${C_RESET}"
+ROOMS_COUNT=$(psql_q "SELECT count(*) FROM rooms;")
+assert_ge "SELECT count(*) FROM rooms" 1 "$ROOMS_COUNT"
+
+# ─── Assertion 2: 대상 방 ID 자동 선택 (--room-id 미지정 시) ────────────
+if [ -z "$ROOM_ID" ]; then
+  ROOM_ID=$(psql_q "SELECT id FROM rooms ORDER BY updated_at DESC LIMIT 1;")
+  if [ -z "$ROOM_ID" ]; then
+    echo -e "  ${C_RED}FAIL${C_RESET} — 최근 방을 찾을 수 없음. rooms 테이블이 비어 있습니다."
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  else
+    echo -e "  ${C_BLUE}INFO${C_RESET} — 자동 선택 room_id=${ROOM_ID}"
+  fi
+fi
+
+# ─── Assertion 3: 해당 방 상태가 FINISHED (게임 종료 후 기준) ────────
+echo -e "${C_YELLOW}[2/5] rooms.status=FINISHED 검증${C_RESET}"
+if [ -n "$ROOM_ID" ]; then
+  STATUS=$(psql_q "SELECT status FROM rooms WHERE id = '${ROOM_ID}';")
+  assert_eq "SELECT status FROM rooms WHERE id=\$1" "FINISHED" "$STATUS"
+else
+  echo -e "  ${C_YELLOW}SKIP${C_RESET} — room_id 없음"
+fi
+
+# ─── Assertion 4: games.room_id NOT NULL (I-14 wire 이후) ─────────────
+echo -e "${C_YELLOW}[3/5] games.room_id NOT NULL 검증 (I-14 FK 정상화)${C_RESET}"
+NULL_GAMES=$(psql_q "SELECT count(*) FROM games WHERE room_id IS NULL;")
+TOTAL_GAMES=$(psql_q "SELECT count(*) FROM games;")
+echo "  games total=${TOTAL_GAMES}, games with room_id=NULL: ${NULL_GAMES}"
+# D-03 이후 새로 INSERT 된 게임은 모두 room_id 를 가져야 한다.
+# PR #38 이전 레거시 row 는 NULL 일 수 있으므로, 최근 10분 이내 INSERT 된 게임 기준 검사.
+RECENT_NULL_GAMES=$(psql_q "SELECT count(*) FROM games WHERE room_id IS NULL AND created_at > NOW() - INTERVAL '10 minutes';")
+assert_eq "SELECT count(*) FROM games WHERE room_id IS NULL AND recent" "0" "$RECENT_NULL_GAMES"
+
+# ─── Assertion 5: rooms-games JOIN (FK 유효성) ─────────────────────────
+echo -e "${C_YELLOW}[4/5] rooms-games JOIN (FK 유효성)${C_RESET}"
+JOIN_COUNT=$(psql_q "SELECT count(*) FROM rooms r JOIN games g ON g.room_id = r.id;")
+assert_ge "SELECT count(*) FROM rooms r JOIN games g ON g.room_id = r.id" 1 "$JOIN_COUNT"
+
+# ─── Assertion 6 (Bonus): stale 데이터 가드 ────────────────────────────
+echo -e "${C_YELLOW}[5/5] Bonus — stale 데이터 가드 (최근 10분 이내 방 >= 1)${C_RESET}"
+RECENT_ROOMS=$(psql_q "SELECT count(*) FROM rooms WHERE created_at > NOW() - INTERVAL '10 minutes';")
+assert_ge "SELECT count(*) FROM rooms WHERE created_at > NOW()-INTERVAL '10 minutes'" 1 "$RECENT_ROOMS"
+
+# ─── 결과 요약 ───────────────────────────────────────────────────────
+echo ""
+echo -e "${C_BLUE}========================================${C_RESET}"
+echo -e "  결과: ${C_GREEN}PASS=${PASS_COUNT}${C_RESET} / ${C_RED}FAIL=${FAIL_COUNT}${C_RESET}"
+echo -e "${C_BLUE}========================================${C_RESET}"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  echo ""
+  echo -e "${C_YELLOW}참고 — FAIL 시 점검 포인트:${C_RESET}"
+  echo "  1) main.go 에 pgGameRepo 주입되었는가? (로그: 'rooms dual-write enabled')"
+  echo "  2) 게임이 실제 종료되었는가? (AI vs AI 배치 완료 확인)"
+  echo "  3) 호스트가 UUID 형식인가? (게스트 non-UUID 는 DB 쓰기 스킵이 정상)"
+  echo "  4) persistGameResult 가 roomID 를 전달받는가? (I-14 wire 확인)"
+  echo "  5) rooms/games 테이블이 올바르게 AutoMigrate 되었는가?"
+  exit 1
+fi
+
+exit 0

--- a/src/game-server/cmd/server/main.go
+++ b/src/game-server/cmd/server/main.go
@@ -100,7 +100,13 @@ func buildRouter(
 	gameStateRepo repository.MemoryGameStateRepository,
 	roomRepo repository.MemoryRoomRepository,
 ) *gin.Engine {
-	roomSvc := service.NewRoomService(roomRepo, gameStateRepo)
+	// D-03: Dual-Write — DB 연결 존재 시 pgRoomRepo 주입, 없으면 nil (best-effort 비활성)
+	var pgRoomRepo repository.GameRepository
+	if db != nil {
+		pgRoomRepo = repository.NewPostgresGameRepo(db)
+		logger.Info("rooms dual-write enabled (D-03 Phase 1)")
+	}
+	roomSvc := service.NewRoomService(roomRepo, gameStateRepo, pgRoomRepo)
 	// SEC-RL-002: Redis가 가용하면 AI 게임 생성 쿨다운 활성화
 	if infra.IsRedisAvailable(redisClient) {
 		service.SetCooldownChecker(roomSvc, service.NewRedisCooldownChecker(redisClient))

--- a/src/game-server/e2e/README.md
+++ b/src/game-server/e2e/README.md
@@ -1,0 +1,101 @@
+# game-server E2E 테스트
+
+`src/game-server/e2e/` 는 `httptest.NewServer` + 인메모리 레포지터리로 외부 의존성 없이 돌아가는 통합 테스트 모음이다. PostgreSQL/Redis/AI adapter 를 실제 기동하지 않는다.
+
+## 구성 파일
+
+| 파일 | 범위 |
+|------|------|
+| `game_flow_test.go` | 공통 테스트 헬퍼(buildTestRouter, issueDevToken, doRequest, decodeJSON) + 전체 게임 흐름 시나리오 |
+| `room_lifecycle_test.go` | FinishRoom 멱등성/NOT_FOUND/ListRooms 필터 시나리오 |
+| `ws_multiplayer_test.go` | 2 Human 플레이어 WebSocket 게임 시나리오 |
+| `rooms_persistence_test.go` | **D-03 Phase 1 Dual-Write 통합 검증** (mock PostgreSQL 호출 이력 assertion) |
+
+## 실행
+
+```bash
+cd src/game-server
+go test ./e2e/... -count=1 -timeout 90s        # 전체
+go test ./e2e/... -run TestRoomsPersistence -v # Phase 1 Dual-Write 만
+```
+
+## D-03 rooms-persistence 검증 — 두 갈래
+
+D-03 Phase 1 Dual-Write 는 **Go 통합 테스트** (off-box) + **bash 검증 스크립트** (in-cluster) 두 갈래로 검증한다. 범위가 겹치지 않는다.
+
+### (1) Go 통합 테스트 — `rooms_persistence_test.go`
+
+- **대상**: `service.RoomService` → mock `repository.GameRepository` 경로를 HTTP 경계를 거쳐 검증
+- **전제**: DB/Redis/K8s 불필요, `go test` 만으로 실행
+- **시나리오 3건**:
+  1. `TestRoomsPersistence_FullFlow_HTTPBoundary` — Create → Join → Start → Finish 흐름에서 mock 호출 시퀀스가 [CreateRoom, UpdateRoom(WAITING), UpdateRoom(PLAYING), UpdateRoom(FINISHED)] 임을 확인
+  2. `TestRoomsPersistence_GuestHost_HTTPSkipsDB` — 비-UUID 호스트는 FK 방어로 mock 호출 0건
+  3. `TestRoomsPersistence_CreateRoomFailure_HTTPStillSucceeds` — mock 이 첫 CreateRoom 에서 error 반환해도 HTTP 201 + log.Printf 로 best-effort 실패 기록
+
+### (2) bash 검증 스크립트 — `scripts/verify-rooms-persistence.sh`
+
+실제 K8s 클러스터에 배포된 PostgreSQL 을 조회하여 ADR §"검증 계획" 의 SQL 4가지 + bonus stale 가드를 실행.
+
+#### 사전 조건
+1. `kubectl` 가 PATH 에 존재하고 대상 클러스터에 인증되어 있어야 한다
+2. `namespace=rummikub` 에 `deploy/postgres` 와 `deploy/game-server` 가 모두 Running
+3. game-server 이미지가 `feat/rooms-postgres-phase1-impl` 브랜치 기반 (main.go 에서 pgGameRepo 주입 + ws_handler persistGameResult 3-arg 마이그레이션 완료)
+4. AI vs AI 1판 배치가 이미 실행 완료된 상태 (rooms/games 에 최소 1건의 row 가 있어야 의미 있음)
+
+#### 실행
+```bash
+# 자동 선택 (최근 updated_at 기준 최근 방)
+./scripts/verify-rooms-persistence.sh
+
+# 특정 방 지정
+./scripts/verify-rooms-persistence.sh --room-id 12345678-1234-4123-8123-1234567890ab
+
+# 도움말
+./scripts/verify-rooms-persistence.sh --help
+```
+
+#### 기대 출력 (PASS 케이스)
+```
+=== D-03 Phase 1 Dual-Write 배포 후 검증 ===
+namespace=rummikub deploy=deploy/postgres user=rummikub db=rummikub
+
+[1/5] rooms 테이블 INSERT 검증
+  PASS — SELECT count(*) FROM rooms (1 >= 1)
+  INFO — 자동 선택 room_id=...
+
+[2/5] rooms.status=FINISHED 검증
+  PASS — SELECT status FROM rooms WHERE id=$1 (=FINISHED)
+
+[3/5] games.room_id NOT NULL 검증 (I-14 FK 정상화)
+  games total=N, games with room_id=NULL: M
+  PASS — SELECT count(*) FROM games WHERE room_id IS NULL AND recent (=0)
+
+[4/5] rooms-games JOIN (FK 유효성)
+  PASS — SELECT count(*) FROM rooms r JOIN games g ON g.room_id = r.id (1 >= 1)
+
+[5/5] Bonus — stale 데이터 가드 (최근 10분 이내 방 >= 1)
+  PASS — SELECT count(*) FROM rooms WHERE created_at > NOW()-INTERVAL '10 minutes' (1 >= 1)
+
+========================================
+  결과: PASS=5 / FAIL=0
+========================================
+```
+
+#### 종료 코드
+- `0` — 전체 PASS
+- `1` — assertion FAIL 1건 이상
+- `2` — 환경 오류(kubectl 없음, 클러스터 접근 불가, pg_isready 실패 등)
+
+#### FAIL 시 점검 포인트
+스크립트 자체가 종료 시 출력하지만 요약:
+1. main.go 에 pgGameRepo 주입 확인 (`kubectl logs deploy/game-server | grep "rooms dual-write"`)
+2. AI vs AI 배치가 실제 완료되었는지 확인
+3. 호스트가 UUID 형식인지 확인 (게스트 non-UUID 는 DB 쓰기 스킵이 정상 동작)
+4. persistGameResult 가 roomID 를 전달받는지 (I-14 wire 회귀 여부 확인)
+5. rooms/games 테이블이 AutoMigrate 되었는지 확인
+
+## 연관 문서
+
+- ADR: `work_logs/decisions/2026-04-22-rooms-postgres-phase1.md`
+- DB 설계: `docs/02-design/02-database-design.md` §2
+- 통합 테스트 전략: `docs/04-testing/05-integration-test-plan-v2.md`

--- a/src/game-server/e2e/game_flow_test.go
+++ b/src/game-server/e2e/game_flow_test.go
@@ -44,7 +44,7 @@ func buildTestRouter(t *testing.T, appEnv string) *gin.Engine {
 	gameStateRepo := repository.NewMemoryGameStateRepoAdapter()
 	roomRepo := repository.NewMemoryRoomRepo()
 
-	roomSvc := service.NewRoomService(roomRepo, gameStateRepo)
+	roomSvc := service.NewRoomService(roomRepo, gameStateRepo, nil)
 	gameSvc := service.NewGameService(gameStateRepo)
 	turnSvc := service.NewTurnService(gameStateRepo, gameSvc)
 

--- a/src/game-server/e2e/room_lifecycle_test.go
+++ b/src/game-server/e2e/room_lifecycle_test.go
@@ -52,7 +52,7 @@ func TestRoomLifecycle_FinishRoom_StatusBecomesFinished(t *testing.T) {
 	// (HTTP 엔드포인트가 없으므로 서비스 레이어를 직접 테스트)
 	roomRepo := repository.NewMemoryRoomRepo()
 	gameStateRepo := repository.NewMemoryGameStateRepoAdapter()
-	roomSvc := service.NewRoomService(roomRepo, gameStateRepo)
+	roomSvc := service.NewRoomService(roomRepo, gameStateRepo, nil)
 
 	// 별도 방을 만들어 FinishRoom 단위 동작 확인
 	finishRoom, err := roomSvc.CreateRoom(&service.CreateRoomRequest{
@@ -81,7 +81,7 @@ func TestRoomLifecycle_FinishRoom_StatusBecomesFinished(t *testing.T) {
 func TestRoomLifecycle_FinishRoom_Idempotent(t *testing.T) {
 	roomRepo := repository.NewMemoryRoomRepo()
 	gameStateRepo := repository.NewMemoryGameStateRepoAdapter()
-	roomSvc := service.NewRoomService(roomRepo, gameStateRepo)
+	roomSvc := service.NewRoomService(roomRepo, gameStateRepo, nil)
 
 	room, err := roomSvc.CreateRoom(&service.CreateRoomRequest{
 		Name:           "멱등성 테스트 방",
@@ -109,7 +109,7 @@ func TestRoomLifecycle_FinishRoom_Idempotent(t *testing.T) {
 func TestRoomLifecycle_FinishRoom_CancelledIsNoOp(t *testing.T) {
 	roomRepo := repository.NewMemoryRoomRepo()
 	gameStateRepo := repository.NewMemoryGameStateRepoAdapter()
-	roomSvc := service.NewRoomService(roomRepo, gameStateRepo)
+	roomSvc := service.NewRoomService(roomRepo, gameStateRepo, nil)
 
 	room, err := roomSvc.CreateRoom(&service.CreateRoomRequest{
 		Name:           "취소된 방",
@@ -142,7 +142,7 @@ func TestRoomLifecycle_FinishRoom_CancelledIsNoOp(t *testing.T) {
 func TestRoomLifecycle_FinishRoom_NotFound(t *testing.T) {
 	roomRepo := repository.NewMemoryRoomRepo()
 	gameStateRepo := repository.NewMemoryGameStateRepoAdapter()
-	roomSvc := service.NewRoomService(roomRepo, gameStateRepo)
+	roomSvc := service.NewRoomService(roomRepo, gameStateRepo, nil)
 
 	err := roomSvc.FinishRoom("non-existent-room-id")
 	require.Error(t, err)
@@ -160,7 +160,7 @@ func TestRoomLifecycle_ListRooms_ExcludesFinished(t *testing.T) {
 	// (중복 방 참가 제한으로 동일 사용자가 여러 방을 만들 수 없으므로 HTTP 부분은 생략)
 	roomRepo := repository.NewMemoryRoomRepo()
 	gameStateRepo := repository.NewMemoryGameStateRepoAdapter()
-	roomSvc := service.NewRoomService(roomRepo, gameStateRepo)
+	roomSvc := service.NewRoomService(roomRepo, gameStateRepo, nil)
 
 	activeRoom, err := roomSvc.CreateRoom(&service.CreateRoomRequest{
 		Name:           "활성 방",

--- a/src/game-server/e2e/rooms_persistence_test.go
+++ b/src/game-server/e2e/rooms_persistence_test.go
@@ -1,0 +1,367 @@
+// rooms_persistence_test.go — D-03 Phase 1 Dual-Write 통합 검증
+//
+// 목적: go-dev의 service 레벨 단위 테스트(5건)가 mock을 직접 호출하는 것과 달리,
+// 여기서는 실제 gin 라우터(HTTP 경계)를 거쳐 CreateRoom → JoinRoom → StartGame →
+// FinishRoom 의 조합 흐름이 mock PostgreSQL 레포지터리에 올바른 호출 시퀀스를
+// 발생시키는지 검증한다.
+//
+// 연관:
+//   - ADR: work_logs/decisions/2026-04-22-rooms-postgres-phase1.md §"검증 계획" → Integration Test
+//   - 단위: src/game-server/internal/service/room_service_test.go (D-03 섹션)
+//   - Verify 스크립트: scripts/verify-rooms-persistence.sh (실 K8s/PG 대상)
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/k82022603/RummiArena/game-server/internal/client"
+	"github.com/k82022603/RummiArena/game-server/internal/handler"
+	"github.com/k82022603/RummiArena/game-server/internal/middleware"
+	"github.com/k82022603/RummiArena/game-server/internal/model"
+	"github.com/k82022603/RummiArena/game-server/internal/repository"
+	"github.com/k82022603/RummiArena/game-server/internal/service"
+)
+
+// ---------------------------------------------------------------------------
+// mock PostgreSQL GameRepository — D-03 Dual-Write 통합 검증 전용
+// ---------------------------------------------------------------------------
+
+// mockPgRepo 테스트용 GameRepository. 호출 이력을 순서대로 기록하고,
+// 실패 플래그(failCreateRoomOnce)로 best-effort 경로를 강제할 수 있다.
+type mockPgRepo struct {
+	mu sync.Mutex
+
+	createRoomCalls []*model.Room
+	updateRoomCalls []*model.Room
+	createGameCalls []*model.Game
+	updateGameCalls []*model.Game
+
+	// failCreateRoomOnce == true 이면 첫 번째 CreateRoom 호출에서 error 반환 후 플래그 해제.
+	failCreateRoomOnce bool
+}
+
+// CreateGame: Phase 1 범위 밖 (games 는 ws_handler.persistGameResult 로 별도 기록).
+func (m *mockPgRepo) CreateGame(_ context.Context, g *model.Game) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *g
+	m.createGameCalls = append(m.createGameCalls, &cp)
+	return nil
+}
+
+func (m *mockPgRepo) GetGame(_ context.Context, _ string) (*model.Game, error) { return nil, nil }
+
+func (m *mockPgRepo) UpdateGame(_ context.Context, g *model.Game) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *g
+	m.updateGameCalls = append(m.updateGameCalls, &cp)
+	return nil
+}
+
+func (m *mockPgRepo) CreateRoom(_ context.Context, r *model.Room) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.failCreateRoomOnce {
+		m.failCreateRoomOnce = false
+		return errors.New("simulated postgres create room failure")
+	}
+	cp := *r
+	m.createRoomCalls = append(m.createRoomCalls, &cp)
+	return nil
+}
+
+func (m *mockPgRepo) GetRoom(_ context.Context, _ string) (*model.Room, error) { return nil, nil }
+
+func (m *mockPgRepo) UpdateRoom(_ context.Context, r *model.Room) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *r
+	m.updateRoomCalls = append(m.updateRoomCalls, &cp)
+	return nil
+}
+
+func (m *mockPgRepo) ListRooms(_ context.Context) ([]*model.Room, error) { return nil, nil }
+
+// snapshotCreateRooms 호출 이력의 스냅샷을 race-safe 로 반환한다.
+func (m *mockPgRepo) snapshotCreateRooms() []*model.Room {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]*model.Room, len(m.createRoomCalls))
+	copy(out, m.createRoomCalls)
+	return out
+}
+
+func (m *mockPgRepo) snapshotUpdateRooms() []*model.Room {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]*model.Room, len(m.updateRoomCalls))
+	copy(out, m.updateRoomCalls)
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// 테스트용 라우터 — mock pgGameRepo 를 주입하여 실제 HTTP 경계를 거치는 Dual-Write 흐름을 재현한다.
+// buildTestRouter(t,"dev") 와 구조 동일하되 pgGameRepo 만 mock 으로 교체.
+// ---------------------------------------------------------------------------
+
+// persistenceTestCtx 라우터 + 주입된 mock + roomSvc 참조를 묶은 구조체.
+// FinishRoom 은 HTTP 엔드포인트가 없으므로 roomSvc 를 직접 호출하기 위해 보관한다.
+type persistenceTestCtx struct {
+	router  *gin.Engine
+	mock    *mockPgRepo
+	roomSvc service.RoomService
+}
+
+// buildPersistenceRouter Dual-Write 통합 테스트용 라우터를 구축한다.
+// pgGameRepo 로 mockPgRepo 를 주입하여 실제 PG 없이도 호출 이력을 검증할 수 있다.
+func buildPersistenceRouter(t *testing.T, mock *mockPgRepo) *persistenceTestCtx {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+	logger := zap.NewNop()
+
+	gameStateRepo := repository.NewMemoryGameStateRepoAdapter()
+	roomRepo := repository.NewMemoryRoomRepo()
+
+	// D-03 Phase 1: 3번째 인자에 mock 주입 (프로덕션 main.go 와 동일 경로).
+	roomSvc := service.NewRoomService(roomRepo, gameStateRepo, mock)
+	gameSvc := service.NewGameService(gameStateRepo)
+	turnSvc := service.NewTurnService(gameStateRepo, gameSvc)
+
+	var aiClient client.AIClientInterface
+	wsHub := handler.NewHub(logger)
+
+	roomHandler := handler.NewRoomHandler(roomSvc)
+	gameHandler := handler.NewGameHandler(gameSvc)
+	wsHandler := handler.NewWSHandler(wsHub, roomSvc, gameSvc, turnSvc, aiClient, e2eJWTSecret, logger, 240)
+	authHandler := handler.NewAuthHandler(e2eJWTSecret)
+
+	router := gin.New()
+	router.Use(gin.Recovery())
+	router.GET("/health", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"status": "ok"}) })
+	router.GET("/ws", wsHandler.HandleWS)
+
+	api := router.Group("/api")
+	auth := api.Group("/auth")
+	auth.POST("/dev-login", authHandler.DevLogin)
+
+	rooms := api.Group("/rooms")
+	rooms.Use(middleware.JWTAuth(e2eJWTSecret))
+	{
+		rooms.POST("", roomHandler.CreateRoom)
+		rooms.GET("", roomHandler.ListRooms)
+		rooms.GET("/:id", roomHandler.GetRoom)
+		rooms.POST("/:id/join", roomHandler.JoinRoom)
+		rooms.POST("/:id/leave", roomHandler.LeaveRoom)
+		rooms.POST("/:id/start", roomHandler.StartGame)
+		rooms.DELETE("/:id", roomHandler.DeleteRoom)
+	}
+
+	games := api.Group("/games")
+	games.Use(middleware.JWTAuth(e2eJWTSecret))
+	{
+		games.GET("/:id", gameHandler.GetGameState)
+		games.POST("/:id/place", gameHandler.PlaceTiles)
+		games.POST("/:id/confirm", gameHandler.ConfirmTurn)
+		games.POST("/:id/draw", gameHandler.DrawTile)
+	}
+
+	return &persistenceTestCtx{router: router, mock: mock, roomSvc: roomSvc}
+}
+
+// ---------------------------------------------------------------------------
+// UUID 고정값 — D-03 FK 방어(isValidUUIDStr) 통과를 위해 유효 UUID 형식 사용.
+// 기존 e2e 상수(hostUserID="host-user-e2e-001")는 UUID 아니므로 재사용 불가.
+// ---------------------------------------------------------------------------
+const (
+	persistenceHostUUID  = "aaaaaaaa-1111-4aaa-8aaa-aaaaaaaaaaaa"
+	persistenceGuestUUID = "bbbbbbbb-2222-4bbb-8bbb-bbbbbbbbbbbb"
+	persistenceGuestName = "게스트"
+)
+
+// ---------------------------------------------------------------------------
+// 테스트 1 (우선순위 최상): HTTP 경계 전체 흐름 — CreateRoom → JoinRoom → StartGame → FinishRoom
+// ---------------------------------------------------------------------------
+
+// TestRoomsPersistence_FullFlow_HTTPBoundary
+// ADR D-03 §검증 계획: "AI vs AI 1판 대전 후 PostgreSQL 검증" 의 HTTP 레벨 재현.
+//
+// 기대 mock 호출 시퀀스:
+//  1. CreateRoom (HTTP POST /api/rooms)          → mock.CreateRoom 1회 (Status=WAITING)
+//  2. JoinRoom   (HTTP POST /api/rooms/:id/join) → mock.UpdateRoom 1회 (WAITING 유지)
+//  3. StartGame  (HTTP POST /api/rooms/:id/start)→ mock.UpdateRoom 1회 (Status=PLAYING, GameID 설정)
+//  4. FinishRoom (service 직접 호출)              → mock.UpdateRoom 1회 (Status=FINISHED)
+//
+// 총 createRoomCalls=1, updateRoomCalls>=3. 마지막 update 는 FINISHED 여야 한다.
+func TestRoomsPersistence_FullFlow_HTTPBoundary(t *testing.T) {
+	mock := &mockPgRepo{}
+	ctx := buildPersistenceRouter(t, mock)
+	srv := httptest.NewServer(ctx.router)
+	defer srv.Close()
+
+	hostToken := issueDevToken(t, persistenceHostUUID)
+	guestToken := issueDevToken(t, persistenceGuestUUID)
+
+	// ── Step 1: CreateRoom (HTTP)
+	createResp := doRequest(t, srv, http.MethodPost, "/api/rooms", hostToken, map[string]interface{}{
+		"playerCount":    2,
+		"turnTimeoutSec": 60,
+	})
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+	roomBody := decodeJSON(t, createResp)
+	roomID, _ := roomBody["id"].(string)
+	require.NotEmpty(t, roomID)
+
+	// mock 에 CreateRoom 1회 기록되어야 한다 (HostID 가 유효 UUID 이므로 스킵 안됨).
+	creates := mock.snapshotCreateRooms()
+	require.Len(t, creates, 1, "HTTP CreateRoom 후 mock.CreateRoom 1회 호출")
+	assert.Equal(t, roomID, creates[0].ID, "roomID 일치")
+	assert.Equal(t, persistenceHostUUID, creates[0].HostUserID, "HostID → HostUserID 매핑")
+	assert.Equal(t, 60, creates[0].TurnTimeout, "TurnTimeoutSec → TurnTimeout 매핑")
+	assert.Equal(t, model.RoomStatusWaiting, creates[0].Status, "CreateRoom 직후 Status=WAITING")
+
+	// ── Step 2: JoinRoom (HTTP)
+	joinResp := doRequest(t, srv, http.MethodPost, "/api/rooms/"+roomID+"/join", guestToken, map[string]string{
+		"displayName": persistenceGuestName,
+	})
+	require.Equal(t, http.StatusOK, joinResp.StatusCode)
+	joinResp.Body.Close() //nolint:errcheck
+
+	// JoinRoom 이후 mock.UpdateRoom 누적 1회 이상.
+	updatesAfterJoin := mock.snapshotUpdateRooms()
+	require.GreaterOrEqual(t, len(updatesAfterJoin), 1, "JoinRoom 후 UpdateRoom 최소 1회")
+
+	// ── Step 3: StartGame (HTTP)
+	startResp := doRequest(t, srv, http.MethodPost, "/api/rooms/"+roomID+"/start", hostToken, nil)
+	require.Equal(t, http.StatusOK, startResp.StatusCode)
+	startResp.Body.Close() //nolint:errcheck
+
+	// StartGame 후 마지막 UpdateRoom 은 Status=PLAYING + GameID != nil.
+	updatesAfterStart := mock.snapshotUpdateRooms()
+	require.Greater(t, len(updatesAfterStart), len(updatesAfterJoin), "StartGame 후 UpdateRoom 증가")
+	last := updatesAfterStart[len(updatesAfterStart)-1]
+	assert.Equal(t, model.RoomStatusPlaying, last.Status, "StartGame 후 상태=PLAYING")
+	assert.NotNil(t, last.GameID, "StartGame 후 GameID 설정됨")
+
+	// ── Step 4: FinishRoom (service 직접 호출 — HTTP 엔드포인트 없음)
+	require.NoError(t, ctx.roomSvc.FinishRoom(roomID))
+
+	updatesAfterFinish := mock.snapshotUpdateRooms()
+	require.Greater(t, len(updatesAfterFinish), len(updatesAfterStart), "FinishRoom 후 UpdateRoom 증가")
+	finishLast := updatesAfterFinish[len(updatesAfterFinish)-1]
+	assert.Equal(t, model.RoomStatusFinished, finishLast.Status, "FinishRoom 후 상태=FINISHED")
+	assert.Equal(t, roomID, finishLast.ID, "roomID 일치")
+
+	// ── 최종 검증: ADR 의 SQL 4가지에 상응하는 불변식
+	// 1) SELECT count(*) FROM rooms >= 1            → createRoomCalls >= 1
+	// 2) SELECT status WHERE id=$1 = 'FINISHED'     → 마지막 update.Status = FINISHED
+	// 3) games.room_id NOT NULL after I-14 wire     → ws_handler 별도 검증 (본 테스트 범위 밖)
+	// 4) JOIN rooms-games FK valid                  → ws_handler 별도 검증 (본 테스트 범위 밖)
+	assert.Len(t, mock.snapshotCreateRooms(), 1, "전체 흐름에서 CreateRoom 은 정확히 1회")
+}
+
+// ---------------------------------------------------------------------------
+// 테스트 2: Guest Host(non-UUID) 는 HTTP 경계를 거치더라도 mock 에 전혀 기록되지 않아야 한다.
+// (단위 테스트는 service 레벨에서 검증 → 여기서는 HTTP 경계 + JWT 미들웨어 조합을 함께 확인)
+// ---------------------------------------------------------------------------
+
+// TestRoomsPersistence_GuestHost_HTTPSkipsDB
+// non-UUID 사용자 ID 로 JWT 를 발급받아 방을 생성하면 roomStateToModel 이 nil 반환 →
+// mock.CreateRoom 은 호출되지 않는다. HTTP 응답은 201 Created 로 정상이어야 한다.
+func TestRoomsPersistence_GuestHost_HTTPSkipsDB(t *testing.T) {
+	mock := &mockPgRepo{}
+	ctx := buildPersistenceRouter(t, mock)
+	srv := httptest.NewServer(ctx.router)
+	defer srv.Close()
+
+	// 비-UUID 호스트 — 기존 상수 hostUserID="host-user-e2e-001" 와 같은 형식.
+	guestHostID := "qa-guest-non-uuid-001"
+	token := issueDevToken(t, guestHostID)
+
+	createResp := doRequest(t, srv, http.MethodPost, "/api/rooms", token, map[string]interface{}{
+		"playerCount":    2,
+		"turnTimeoutSec": 60,
+	})
+	require.Equal(t, http.StatusCreated, createResp.StatusCode, "비-UUID 호스트도 HTTP 응답은 성공")
+	createResp.Body.Close() //nolint:errcheck
+
+	// FK 방어로 mock 에 기록 없음.
+	assert.Len(t, mock.snapshotCreateRooms(), 0, "비-UUID 호스트는 mock.CreateRoom 미호출")
+	assert.Len(t, mock.snapshotUpdateRooms(), 0, "비-UUID 호스트는 mock.UpdateRoom 미호출")
+}
+
+// ---------------------------------------------------------------------------
+// 테스트 3: PostgreSQL CreateRoom 이 1회 실패해도 HTTP 응답은 201 Created.
+// best-effort 원칙 검증 + 로그 출력 캡처.
+// ---------------------------------------------------------------------------
+
+// TestRoomsPersistence_CreateRoomFailure_HTTPStillSucceeds
+// ADR D-03 §설계 §4 best-effort 에러 처리: "log.Error 만, 에러 반환 금지".
+// HTTP 레이어에서 관찰: 201 응답 + mock.createRoomCalls=0 + 로그에 실패 메시지 포함.
+func TestRoomsPersistence_CreateRoomFailure_HTTPStillSucceeds(t *testing.T) {
+	mock := &mockPgRepo{failCreateRoomOnce: true}
+	ctx := buildPersistenceRouter(t, mock)
+	srv := httptest.NewServer(ctx.router)
+	defer srv.Close()
+
+	// 로그 캡처 — best-effort 실패 시 room_service 가 log.Printf 로 기록한다.
+	var logBuf bytes.Buffer
+	prevOut := log.Writer()
+	prevFlags := log.Flags()
+	log.SetOutput(&logBuf)
+	log.SetFlags(0)
+	defer func() {
+		log.SetOutput(prevOut)
+		log.SetFlags(prevFlags)
+	}()
+
+	token := issueDevToken(t, persistenceHostUUID)
+	createResp := doRequest(t, srv, http.MethodPost, "/api/rooms", token, map[string]interface{}{
+		"playerCount":    2,
+		"turnTimeoutSec": 60,
+	})
+	require.Equal(t, http.StatusCreated, createResp.StatusCode, "PG 실패해도 HTTP 201")
+	body := decodeJSON(t, createResp)
+	roomID, _ := body["id"].(string)
+	require.NotEmpty(t, roomID, "메모리 저장은 성공하여 roomID 반환")
+
+	// mock 에는 기록 없음 (첫 호출이 실패 처리됨).
+	assert.Len(t, mock.snapshotCreateRooms(), 0, "PG 실패 호출은 createRoomCalls 에 누적되지 않음")
+
+	// log.Printf 로그 메시지 포함 확인 — "postgres create room best-effort failed".
+	// 로그가 비동기로 쓰일 수 있으므로 짧은 polling 으로 2초 대기.
+	deadline := time.Now().Add(2 * time.Second)
+	var logSnap string
+	for time.Now().Before(deadline) {
+		logSnap = logBuf.String()
+		if logSnap != "" {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	assert.Contains(t, logSnap, "postgres create room best-effort failed",
+		"best-effort 실패는 log.Printf 로 기록됨 (에러 반환 금지)")
+}
+
+// ---------------------------------------------------------------------------
+// package-level 도우미: persistence 테스트에서 쓰는 doRequest/decodeJSON/issueDevToken 은
+// game_flow_test.go 에서 이미 정의되어 있으므로 재정의 불필요.
+// 상수 e2eJWTSecret 도 동일 패키지(e2e) 내에서 공유.
+// ---------------------------------------------------------------------------
+
+// compile-time 인터페이스 준수 확인 — repository.GameRepository 변경 시 컴파일 에러로 감지.
+var _ repository.GameRepository = (*mockPgRepo)(nil)

--- a/src/game-server/internal/handler/timeout_cleanup_integration_test.go
+++ b/src/game-server/internal/handler/timeout_cleanup_integration_test.go
@@ -35,7 +35,7 @@ func newTurnLimitTestEnv(t *testing.T, maxTurns int) (*WSHandler, repository.Mem
 	gameSvc := service.NewGameService(gameRepo, service.WithMaxTurnsLimit(maxTurns))
 	turnSvc := service.NewTurnService(gameRepo, gameSvc)
 	roomRepo := repository.NewMemoryRoomRepo()
-	roomSvc := service.NewRoomService(roomRepo, repository.NewMemoryGameStateRepoAdapter())
+	roomSvc := service.NewRoomService(roomRepo, repository.NewMemoryGameStateRepoAdapter(), nil)
 	h := &WSHandler{
 		hub:           NewHub(zap.NewNop()),
 		roomSvc:       roomSvc,

--- a/src/game-server/internal/handler/ws_ai_timer_test.go
+++ b/src/game-server/internal/handler/ws_ai_timer_test.go
@@ -54,7 +54,7 @@ func newAITimerTestEnv(aiClient client.AIClientInterface) (*WSHandler, repositor
 	turnSvc := service.NewTurnService(gameRepo, gameSvc)
 	h := &WSHandler{
 		hub:           NewHub(zap.NewNop()),
-		roomSvc:       service.NewRoomService(repository.NewMemoryRoomRepo(), repository.NewMemoryGameStateRepoAdapter()),
+		roomSvc:       service.NewRoomService(repository.NewMemoryRoomRepo(), repository.NewMemoryGameStateRepoAdapter(), nil),
 		gameSvc:       gameSvc,
 		turnSvc:       turnSvc,
 		aiClient:      aiClient,

--- a/src/game-server/internal/handler/ws_cleanup_test.go
+++ b/src/game-server/internal/handler/ws_cleanup_test.go
@@ -26,7 +26,7 @@ func newCleanupTestEnv(aiClient client.AIClientInterface) (*WSHandler, repositor
 	gameSvc := service.NewGameService(gameRepo)
 	turnSvc := service.NewTurnService(gameRepo, gameSvc)
 	roomRepo := repository.NewMemoryRoomRepo()
-	roomSvc := service.NewRoomService(roomRepo, repository.NewMemoryGameStateRepoAdapter())
+	roomSvc := service.NewRoomService(roomRepo, repository.NewMemoryGameStateRepoAdapter(), nil)
 	h := &WSHandler{
 		hub:           NewHub(zap.NewNop()),
 		roomSvc:       roomSvc,

--- a/src/game-server/internal/handler/ws_game_start_test.go
+++ b/src/game-server/internal/handler/ws_game_start_test.go
@@ -23,7 +23,7 @@ func TestNotifyGameStarted_SendsGameStateAndTurnStart(t *testing.T) {
 	gameStateRepo := repository.NewMemoryGameStateRepoAdapter()
 	roomRepo := repository.NewMemoryRoomRepo()
 	gameSvc := service.NewGameService(gameStateRepo)
-	roomSvc := service.NewRoomService(roomRepo, gameStateRepo)
+	roomSvc := service.NewRoomService(roomRepo, gameStateRepo, nil)
 	turnSvc := service.NewTurnService(gameStateRepo, gameSvc)
 
 	wsHandler := &WSHandler{
@@ -122,7 +122,7 @@ func TestNotifyGameStarted_SetsConnectionGameID(t *testing.T) {
 	gameStateRepo := repository.NewMemoryGameStateRepoAdapter()
 	roomRepo := repository.NewMemoryRoomRepo()
 	gameSvc := service.NewGameService(gameStateRepo)
-	roomSvc := service.NewRoomService(roomRepo, gameStateRepo)
+	roomSvc := service.NewRoomService(roomRepo, gameStateRepo, nil)
 	turnSvc := service.NewTurnService(gameStateRepo, gameSvc)
 
 	wsHandler := &WSHandler{
@@ -175,7 +175,7 @@ func TestNotifyGameStarted_TurnStartHasCorrectSeat(t *testing.T) {
 	gameStateRepo := repository.NewMemoryGameStateRepoAdapter()
 	roomRepo := repository.NewMemoryRoomRepo()
 	gameSvc := service.NewGameService(gameStateRepo)
-	roomSvc := service.NewRoomService(roomRepo, gameStateRepo)
+	roomSvc := service.NewRoomService(roomRepo, gameStateRepo, nil)
 	turnSvc := service.NewTurnService(gameStateRepo, gameSvc)
 
 	wsHandler := &WSHandler{
@@ -251,6 +251,7 @@ func TestRoomHandler_WithGameStartNotifier(t *testing.T) {
 	roomSvc := service.NewRoomService(
 		repository.NewMemoryRoomRepo(),
 		repository.NewMemoryGameStateRepoAdapter(),
+		nil,
 	)
 	rh := NewRoomHandler(roomSvc)
 

--- a/src/game-server/internal/handler/ws_handler.go
+++ b/src/game-server/internal/handler/ws_handler.go
@@ -860,8 +860,8 @@ func (h *WSHandler) broadcastGameOver(conn *Connection, state *model.GameStateRe
 		zap.Int("winnerSeat", winnerSeat),
 	)
 
-	// I-14: 게임 결과 DB 영속화 (비동기)
-	go h.persistGameResult(state, endType)
+	// I-14 + D-03: 게임 결과 DB 영속화 (비동기, roomID 전달)
+	go h.persistGameResult(state, endType, conn.roomID)
 
 	// ELO 업데이트 (비동기)
 	go h.updateElo(state)
@@ -1622,8 +1622,8 @@ func (h *WSHandler) broadcastGameOverFromState(roomID string, state *model.GameS
 		zap.Int("winnerSeat", winnerSeat),
 	)
 
-	// I-14: 게임 결과 DB 영속화 (비동기)
-	go h.persistGameResult(state, endType)
+	// I-14 + D-03: 게임 결과 DB 영속화 (비동기, roomID 전달)
+	go h.persistGameResult(state, endType, roomID)
 
 	// ELO 업데이트 (비동기)
 	go h.updateElo(state)
@@ -1914,10 +1914,11 @@ func (h *WSHandler) updateEloRedis(ctx context.Context, ch engine.EloChange) {
 	)
 }
 
-// persistGameResult I-14: 게임 종료 시 games / game_players / game_events 테이블에 영속화한다.
+// persistGameResult I-14 + D-03: 게임 종료 시 games / game_players / game_events 테이블에 영속화한다.
 // pgGameRepo / pgGamePlayerRepo / pgGameEventRepo 중 하나라도 nil이면 해당 테이블은 건너뛴다.
+// roomID: rooms 테이블에 이미 존재하는 방 ID — games.room_id FK 정상화 (D-03).
 // 비동기 goroutine에서 호출된다 — 에러는 경고 로그로 처리하고 WS 흐름을 차단하지 않는다.
-func (h *WSHandler) persistGameResult(state *model.GameStateRedis, endType string) {
+func (h *WSHandler) persistGameResult(state *model.GameStateRedis, endType string, roomID string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -1951,8 +1952,20 @@ func (h *WSHandler) persistGameResult(state *model.GameStateRedis, endType strin
 		if winnerSeat >= 0 {
 			wSeatPtr = &winnerSeat
 		}
+		// D-03: rooms 테이블에 row가 있으면 FK 정상화 (roomID가 빈 문자열이면 nil 유지)
+		var roomIDPtr *string
+		roomCode := ""
+		if roomID != "" {
+			roomIDPtr = &roomID
+			// roomCode 조회: rooms 테이블에서 조회하거나 roomSvc를 통해 메모리에서 조회
+			if room, err := h.roomSvc.GetRoom(roomID); err == nil {
+				roomCode = room.RoomCode
+			}
+		}
 		game := &model.Game{
 			ID:          state.GameID,
+			RoomID:      roomIDPtr,
+			RoomCode:    roomCode,
 			Status:      model.GameStatusFinished,
 			PlayerCount: len(state.Players),
 			WinnerID:    wIDPtr,
@@ -2267,8 +2280,8 @@ func (h *WSHandler) forfeitAndBroadcast(roomID, gameID string, seat int, userID,
 			},
 		})
 
-		// I-14: 게임 결과 DB 영속화 (비동기)
-		go h.persistGameResult(state, endType)
+		// I-14 + D-03: 게임 결과 DB 영속화 (비동기, roomID 전달)
+		go h.persistGameResult(state, endType, roomID)
 
 		go h.updateElo(state)
 

--- a/src/game-server/internal/handler/ws_handler_ai_test.go
+++ b/src/game-server/internal/handler/ws_handler_ai_test.go
@@ -43,7 +43,7 @@ func newAITestHandler(aiClient client.AIClientInterface, gameSvc service.GameSer
 	hub := NewHub(zap.NewNop())
 	roomRepo := repository.NewMemoryRoomRepo()
 	gameStateRepo := repository.NewMemoryGameStateRepoAdapter()
-	roomSvc := service.NewRoomService(roomRepo, gameStateRepo)
+	roomSvc := service.NewRoomService(roomRepo, gameStateRepo, nil)
 	turnSvc := service.NewTurnService(gameStateRepo, gameSvc)
 
 	return &WSHandler{

--- a/src/game-server/internal/handler/ws_persist_test.go
+++ b/src/game-server/internal/handler/ws_persist_test.go
@@ -91,7 +91,7 @@ func newPersistTestHandler() (*WSHandler, *mockGameRepo, *mockGamePlayerRepo, *m
 	gameSvc := service.NewGameService(gameStateRepo)
 	turnSvc := service.NewTurnService(gameStateRepo, gameSvc)
 	roomRepo := repository.NewMemoryRoomRepo()
-	roomSvc := service.NewRoomService(roomRepo, repository.NewMemoryGameStateRepoAdapter())
+	roomSvc := service.NewRoomService(roomRepo, repository.NewMemoryGameStateRepoAdapter(), nil)
 
 	pgGame := &mockGameRepo{}
 	pgPlayer := &mockGamePlayerRepo{}
@@ -150,7 +150,7 @@ func TestPersistGameResult_NormalWin(t *testing.T) {
 	h, pgGame, pgPlayer, pgEvent := newPersistTestHandler()
 
 	state := makeFinishedState("game-001", testWinnerUUID, 0)
-	h.persistGameResult(state, "NORMAL")
+	h.persistGameResult(state, "NORMAL", "")
 
 	require.Len(t, pgGame.games, 1, "games 테이블 1건 삽입")
 	assert.Equal(t, "game-001", pgGame.games[0].ID)
@@ -192,7 +192,7 @@ func TestPersistGameResult_Stalemate(t *testing.T) {
 	}
 
 	// endType 인자가 "NORMAL"이어도 IsStalemate=true면 STALEMATE로 덮임
-	h.persistGameResult(state, "NORMAL")
+	h.persistGameResult(state, "NORMAL", "")
 
 	require.Len(t, pgGame.games, 1)
 	assert.Nil(t, pgGame.games[0].WinnerID, "교착 시 winner 없음 (타일 동점)")
@@ -211,7 +211,7 @@ func TestPersistGameResult_Forfeit(t *testing.T) {
 
 	state := makeFinishedState("game-003", testWinnerUUID, 0)
 
-	h.persistGameResult(state, "FORFEIT")
+	h.persistGameResult(state, "FORFEIT", "")
 
 	require.Len(t, pgGame.games, 1)
 	require.Len(t, pgEvent.events, 1)
@@ -232,7 +232,7 @@ func TestPersistGameResult_NilRepos(t *testing.T) {
 	state := makeFinishedState("game-004", testWinnerUUID, 0)
 
 	assert.NotPanics(t, func() {
-		h.persistGameResult(state, "NORMAL")
+		h.persistGameResult(state, "NORMAL", "")
 	})
 }
 
@@ -341,7 +341,7 @@ func TestPersistGameResult_AsyncSafe(t *testing.T) {
 		go func(gid string) {
 			defer wg.Done()
 			state := makeFinishedState(gid, testWinnerUUID, 0)
-			h.persistGameResult(state, "NORMAL")
+			h.persistGameResult(state, "NORMAL", "")
 		}(gameID)
 	}
 	wg.Wait()
@@ -394,7 +394,7 @@ func TestPersistGameResult_GuestUserID_NullInDB(t *testing.T) {
 		IsStalemate: false,
 	}
 
-	h.persistGameResult(state, "NORMAL")
+	h.persistGameResult(state, "NORMAL", "")
 
 	require.Len(t, pgPlayer.players, 2, "game_players 2건 삽입")
 	for _, gp := range pgPlayer.players {
@@ -436,7 +436,7 @@ func TestPersistGameResult_EmptyWinnerID_GameEventUsesNilUUID(t *testing.T) {
 		IsStalemate: false,
 	}
 
-	h.persistGameResult(state, "FORFEIT")
+	h.persistGameResult(state, "FORFEIT", "")
 
 	require.Len(t, pgEvent.events, 1)
 	playerID := pgEvent.events[0].PlayerID
@@ -473,7 +473,7 @@ func TestPersistGameResult_MixedPlayers_UUIDAndGuest(t *testing.T) {
 		IsStalemate: false,
 	}
 
-	h.persistGameResult(state, "NORMAL")
+	h.persistGameResult(state, "NORMAL", "")
 
 	require.Len(t, pgPlayer.players, 2)
 	for _, gp := range pgPlayer.players {

--- a/src/game-server/internal/service/room_converter.go
+++ b/src/game-server/internal/service/room_converter.go
@@ -1,0 +1,42 @@
+package service
+
+import (
+	"github.com/google/uuid"
+	"github.com/k82022603/RummiArena/game-server/internal/model"
+)
+
+// roomStateToModel RoomState(인메모리) → model.Room(GORM 영속) 변환.
+// HostID가 유효 UUID가 아닌 경우(게스트, QA 테스터 등) nil을 반환한다.
+// 반환값이 nil이면 호출자는 DB 쓰기를 스킵해야 한다.
+//
+// Phase 1 미매핑 필드:
+//   - Players/SeatStatus: Phase 2에서 JSONB 컬럼으로 추가 검토
+func roomStateToModel(state *model.RoomState) *model.Room {
+	// FK 방어: HostUserID → users.id 참조. 유효 UUID 아니면 DB 쓰기 스킵.
+	if !isValidUUIDStr(state.HostID) {
+		return nil
+	}
+	return &model.Room{
+		ID:          state.ID,
+		RoomCode:    state.RoomCode,
+		Name:        state.Name,
+		HostUserID:  state.HostID,
+		MaxPlayers:  state.MaxPlayers,
+		TurnTimeout: state.TurnTimeoutSec,
+		Status:      state.Status,
+		GameID:      state.GameID,
+		CreatedAt:   state.CreatedAt,
+		UpdatedAt:   state.UpdatedAt,
+	}
+}
+
+// isValidUUIDStr 문자열이 유효한 UUID v4 형식인지 확인한다.
+// handler.isValidUUID 와 동일한 로직이지만 service 패키지 내부에서 사용하기 위해 별도 정의한다.
+// (handler → service 단방향 의존 계층을 깨지 않기 위해 복사)
+func isValidUUIDStr(s string) bool {
+	if s == "" {
+		return false
+	}
+	_, err := uuid.Parse(s)
+	return err == nil
+}

--- a/src/game-server/internal/service/room_service.go
+++ b/src/game-server/internal/service/room_service.go
@@ -1,7 +1,9 @@
 package service
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"math/rand"
 	"time"
 
@@ -47,22 +49,26 @@ type CreateRoomRequest struct {
 }
 
 type roomService struct {
-	roomRepo  repository.MemoryRoomRepository
-	gameRepo  repository.MemoryGameStateRepository
-	gameState *gameService        // 게임 시작 시 gameService 사용
-	cooldown  CooldownChecker     // AI 게임 생성 쿨다운 (nil이면 비활성)
+	roomRepo      repository.MemoryRoomRepository
+	gameStateRepo repository.MemoryGameStateRepository // 인메모리 게임 상태 레포 (정본)
+	pgGameRepo    repository.GameRepository             // PostgreSQL best-effort 레포 (nil 허용)
+	gameState     *gameService                          // 게임 시작 시 gameService 사용
+	cooldown      CooldownChecker                       // AI 게임 생성 쿨다운 (nil이면 비활성)
 }
 
-// NewRoomService RoomService 구현체 생성자
+// NewRoomService RoomService 구현체 생성자.
+// pgGameRepo: nil이면 Dual-Write를 비활성화한다 (테스트/DB 미연결 환경에서 기존 동작 유지).
 func NewRoomService(
 	roomRepo repository.MemoryRoomRepository,
-	gameRepo repository.MemoryGameStateRepository,
+	gameStateRepo repository.MemoryGameStateRepository,
+	pgGameRepo repository.GameRepository,
 ) RoomService {
-	gs := &gameService{gameRepo: gameRepo, snapshots: make(map[string]*turnSnapshot)}
+	gs := &gameService{gameRepo: gameStateRepo, snapshots: make(map[string]*turnSnapshot)}
 	return &roomService{
-		roomRepo:  roomRepo,
-		gameRepo:  gameRepo,
-		gameState: gs,
+		roomRepo:      roomRepo,
+		gameStateRepo: gameStateRepo,
+		pgGameRepo:    pgGameRepo,
+		gameState:     gs,
 	}
 }
 
@@ -71,6 +77,42 @@ func NewRoomService(
 func SetCooldownChecker(svc RoomService, checker CooldownChecker) {
 	if rs, ok := svc.(*roomService); ok {
 		rs.cooldown = checker
+	}
+}
+
+// pgBestEffortCreateRoom PostgreSQL에 방 생성을 best-effort로 기록한다.
+// pgGameRepo가 nil이거나 HostID가 유효 UUID가 아니면 조용히 건너뛴다.
+// 실패 시 log.Printf로 기록하고 반환값은 없다 (게임 진행을 차단하지 않음).
+func (s *roomService) pgBestEffortCreateRoom(room *model.RoomState) {
+	if s.pgGameRepo == nil {
+		return
+	}
+	dbRoom := roomStateToModel(room)
+	if dbRoom == nil {
+		return // 비-UUID 호스트 → FK 위반 방지
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := s.pgGameRepo.CreateRoom(ctx, dbRoom); err != nil {
+		log.Printf("room_service: postgres create room best-effort failed (roomID=%s): %v", room.ID, err)
+	}
+}
+
+// pgBestEffortUpdateRoom PostgreSQL에 방 상태 변경을 best-effort로 기록한다.
+// pgGameRepo가 nil이거나 HostID가 유효 UUID가 아니면 조용히 건너뛴다.
+// 실패 시 log.Printf로 기록하고 반환값은 없다.
+func (s *roomService) pgBestEffortUpdateRoom(room *model.RoomState) {
+	if s.pgGameRepo == nil {
+		return
+	}
+	dbRoom := roomStateToModel(room)
+	if dbRoom == nil {
+		return // 비-UUID 호스트 → FK 위반 방지
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := s.pgGameRepo.UpdateRoom(ctx, dbRoom); err != nil {
+		log.Printf("room_service: postgres update room best-effort failed (roomID=%s): %v", room.ID, err)
 	}
 }
 
@@ -167,6 +209,9 @@ func (s *roomService) CreateRoom(req *CreateRoomRequest) (*model.RoomState, erro
 	// 사용자-방 매핑 설정
 	_ = s.roomRepo.SetActiveRoomForUser(req.HostUserID, roomID)
 
+	// Dual-Write: PostgreSQL best-effort 기록 (메모리 저장 성공 후)
+	s.pgBestEffortCreateRoom(room)
+
 	// AI 게임 생성 쿨다운 설정 (성공 후에만)
 	if len(req.AIPlayers) > 0 && s.cooldown != nil {
 		s.cooldown.SetCooldown(req.HostUserID)
@@ -245,6 +290,9 @@ func (s *roomService) JoinRoom(roomID, userID, displayName string) error {
 	// 사용자-방 매핑 설정
 	_ = s.roomRepo.SetActiveRoomForUser(userID, roomID)
 
+	// Dual-Write: PostgreSQL best-effort 업데이트
+	s.pgBestEffortUpdateRoom(room)
+
 	return nil
 }
 
@@ -294,6 +342,10 @@ func (s *roomService) LeaveRoom(roomID, userID string) (*model.RoomState, error)
 	if err := s.roomRepo.SaveRoom(room); err != nil {
 		return nil, fmt.Errorf("room_service: save room after leave: %w", err)
 	}
+
+	// Dual-Write: PostgreSQL best-effort 업데이트
+	s.pgBestEffortUpdateRoom(room)
+
 	return room, nil
 }
 
@@ -341,6 +393,9 @@ func (s *roomService) StartGame(roomID, hostUserID string) (*model.GameStateRedi
 		return nil, fmt.Errorf("room_service: save room after start: %w", err)
 	}
 
+	// Dual-Write: PostgreSQL best-effort 업데이트 (Status=PLAYING, GameID 설정됨)
+	s.pgBestEffortUpdateRoom(room)
+
 	return gameState, nil
 }
 
@@ -378,7 +433,14 @@ func (s *roomService) FinishRoom(roomID string) error {
 		}
 	}
 
-	return s.roomRepo.SaveRoom(room)
+	if err := s.roomRepo.SaveRoom(room); err != nil {
+		return err
+	}
+
+	// Dual-Write: PostgreSQL best-effort 업데이트 (Status=FINISHED)
+	s.pgBestEffortUpdateRoom(room)
+
+	return nil
 }
 
 // ClearActiveRoomForUser 특정 사용자의 활성 방 매핑을 제거한다.

--- a/src/game-server/internal/service/room_service_test.go
+++ b/src/game-server/internal/service/room_service_test.go
@@ -1,11 +1,15 @@
 package service
 
 import (
+	"context"
+	"errors"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/k82022603/RummiArena/game-server/internal/model"
 	"github.com/k82022603/RummiArena/game-server/internal/repository"
 )
 
@@ -13,7 +17,7 @@ func newRoomService(t *testing.T) RoomService {
 	t.Helper()
 	roomRepo := repository.NewMemoryRoomRepo()
 	gameRepo := repository.NewMemoryGameStateRepo()
-	return NewRoomService(roomRepo, gameRepo)
+	return NewRoomService(roomRepo, gameRepo, nil)
 }
 
 // ============================================================
@@ -317,7 +321,7 @@ func newRoomServiceWithCooldown(t *testing.T, checker CooldownChecker) RoomServi
 	t.Helper()
 	roomRepo := repository.NewMemoryRoomRepo()
 	gameRepo := repository.NewMemoryGameStateRepo()
-	svc := NewRoomService(roomRepo, gameRepo)
+	svc := NewRoomService(roomRepo, gameRepo, nil)
 	SetCooldownChecker(svc, checker)
 	return svc
 }
@@ -505,4 +509,198 @@ func TestAICooldown_DifferentUsers_Independent(t *testing.T) {
 		AIPlayers:      []AIPlayerRequest{{Type: "AI_CLAUDE", Difficulty: "hard"}},
 	})
 	require.NoError(t, err, "다른 사용자의 쿨다운은 서로 독립적이어야 한다")
+}
+
+// ============================================================
+// D-03 Phase 1: Dual-Write 단위 테스트
+// ============================================================
+
+// mockPgGameRepo D-03 테스트용 GameRepository mock.
+type mockPgGameRepo struct {
+	mu              sync.Mutex
+	createRoomCalls []*model.Room
+	updateRoomCalls []*model.Room
+	failCreateRoom  bool
+	failUpdateRoom  bool
+}
+
+func (m *mockPgGameRepo) CreateGame(_ context.Context, _ *model.Game) error { return nil }
+func (m *mockPgGameRepo) GetGame(_ context.Context, _ string) (*model.Game, error) {
+	return nil, nil
+}
+func (m *mockPgGameRepo) UpdateGame(_ context.Context, _ *model.Game) error { return nil }
+
+func (m *mockPgGameRepo) CreateRoom(_ context.Context, room *model.Room) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.failCreateRoom {
+		m.failCreateRoom = false
+		return errors.New("simulated postgres create room failure")
+	}
+	cp := *room
+	m.createRoomCalls = append(m.createRoomCalls, &cp)
+	return nil
+}
+
+func (m *mockPgGameRepo) GetRoom(_ context.Context, _ string) (*model.Room, error) {
+	return nil, nil
+}
+
+func (m *mockPgGameRepo) UpdateRoom(_ context.Context, room *model.Room) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.failUpdateRoom {
+		m.failUpdateRoom = false
+		return errors.New("simulated postgres update room failure")
+	}
+	cp := *room
+	m.updateRoomCalls = append(m.updateRoomCalls, &cp)
+	return nil
+}
+
+func (m *mockPgGameRepo) ListRooms(_ context.Context) ([]*model.Room, error) { return nil, nil }
+
+// newRoomServiceWithMockPg UUID 호스트 + mockPgGameRepo로 RoomService를 생성한다.
+func newRoomServiceWithMockPg(t *testing.T, mock repository.GameRepository) RoomService {
+	t.Helper()
+	roomRepo := repository.NewMemoryRoomRepo()
+	gameRepo := repository.NewMemoryGameStateRepo()
+	return NewRoomService(roomRepo, gameRepo, mock)
+}
+
+// TestRoomService_CreateRoom_WritesToPostgres CreateRoom 후 PostgreSQL에 방이 기록되는지 확인.
+func TestRoomService_CreateRoom_WritesToPostgres(t *testing.T) {
+	mock := &mockPgGameRepo{}
+	svc := newRoomServiceWithMockPg(t, mock)
+
+	// HostUserID는 유효 UUID여야 FK 방어를 통과한다.
+	hostID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	room, err := svc.CreateRoom(&CreateRoomRequest{
+		Name:           "테스트 방",
+		PlayerCount:    2,
+		TurnTimeoutSec: 60,
+		HostUserID:     hostID,
+	})
+	require.NoError(t, err)
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	require.Len(t, mock.createRoomCalls, 1, "PostgreSQL CreateRoom 1회 호출")
+	dbRoom := mock.createRoomCalls[0]
+	assert.Equal(t, room.ID, dbRoom.ID)
+	assert.Equal(t, hostID, dbRoom.HostUserID, "HostID → HostUserID 매핑 확인")
+	assert.Equal(t, 60, dbRoom.TurnTimeout, "TurnTimeoutSec → TurnTimeout 매핑 확인")
+	assert.Equal(t, model.RoomStatusWaiting, dbRoom.Status)
+}
+
+// TestRoomService_StartGame_UpdatesRoomStatus StartGame 후 PostgreSQL에 PLAYING 상태로 업데이트 확인.
+func TestRoomService_StartGame_UpdatesRoomStatus(t *testing.T) {
+	mock := &mockPgGameRepo{}
+	svc := newRoomServiceWithMockPg(t, mock)
+
+	hostID := "11111111-1111-1111-1111-111111111111"
+	guestID := "22222222-2222-2222-2222-222222222222"
+
+	// 방 생성 (CreateRoom → 1회 CreateRoom 호출)
+	room, err := svc.CreateRoom(&CreateRoomRequest{
+		Name:           "게임 시작 테스트 방",
+		PlayerCount:    2,
+		TurnTimeoutSec: 60,
+		HostUserID:     hostID,
+	})
+	require.NoError(t, err)
+
+	// 게스트 참가 (JoinRoom → 1회 UpdateRoom 호출)
+	err = svc.JoinRoom(room.ID, guestID, "게스트")
+	require.NoError(t, err)
+
+	// 게임 시작 (StartGame → 1회 UpdateRoom 호출)
+	_, err = svc.StartGame(room.ID, hostID)
+	require.NoError(t, err)
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+
+	// UpdateRoom 호출 중 마지막이 PLAYING 상태여야 한다
+	require.GreaterOrEqual(t, len(mock.updateRoomCalls), 1, "UpdateRoom 최소 1회 호출 (StartGame)")
+	lastUpdate := mock.updateRoomCalls[len(mock.updateRoomCalls)-1]
+	assert.Equal(t, model.RoomStatusPlaying, lastUpdate.Status, "StartGame 후 상태는 PLAYING")
+	assert.NotNil(t, lastUpdate.GameID, "GameID가 설정되어야 한다")
+}
+
+// TestRoomService_FinishRoom_UpdatesRoomStatusFinished FinishRoom 후 FINISHED 상태 업데이트 확인.
+func TestRoomService_FinishRoom_UpdatesRoomStatusFinished(t *testing.T) {
+	mock := &mockPgGameRepo{}
+	svc := newRoomServiceWithMockPg(t, mock)
+
+	hostID := "33333333-3333-3333-3333-333333333333"
+	room, err := svc.CreateRoom(&CreateRoomRequest{
+		Name:           "종료 테스트 방",
+		PlayerCount:    2,
+		TurnTimeoutSec: 60,
+		HostUserID:     hostID,
+	})
+	require.NoError(t, err)
+
+	// FinishRoom 호출
+	err = svc.FinishRoom(room.ID)
+	require.NoError(t, err)
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+
+	require.GreaterOrEqual(t, len(mock.updateRoomCalls), 1, "UpdateRoom 최소 1회 호출 (FinishRoom)")
+	lastUpdate := mock.updateRoomCalls[len(mock.updateRoomCalls)-1]
+	assert.Equal(t, model.RoomStatusFinished, lastUpdate.Status, "FinishRoom 후 상태는 FINISHED")
+}
+
+// TestRoomService_DualWrite_PostgresFailure_MemoryStillSucceeds
+// PostgreSQL 쓰기 실패 시 메모리 저장은 성공 (best-effort 원칙).
+func TestRoomService_DualWrite_PostgresFailure_MemoryStillSucceeds(t *testing.T) {
+	mock := &mockPgGameRepo{failCreateRoom: true} // 첫 번째 CreateRoom 호출 실패
+	svc := newRoomServiceWithMockPg(t, mock)
+
+	hostID := "44444444-4444-4444-4444-444444444444"
+	room, err := svc.CreateRoom(&CreateRoomRequest{
+		Name:           "PG 실패 테스트 방",
+		PlayerCount:    2,
+		TurnTimeoutSec: 60,
+		HostUserID:     hostID,
+	})
+	// PostgreSQL 실패에도 메모리 저장은 성공해야 한다
+	require.NoError(t, err, "PostgreSQL best-effort 실패해도 CreateRoom은 성공해야 한다")
+	require.NotNil(t, room)
+
+	// 메모리에서 조회 가능
+	fetched, err := svc.GetRoom(room.ID)
+	require.NoError(t, err, "메모리에서 방 조회 가능")
+	assert.Equal(t, room.ID, fetched.ID)
+
+	// PostgreSQL mock에는 기록 없음 (실패했으므로)
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	assert.Len(t, mock.createRoomCalls, 0, "PG 실패 시 createRoomCalls에 기록 없음")
+}
+
+// TestRoomService_DualWrite_GuestHost_SkipsDB
+// 비-UUID 호스트(게스트)가 방을 생성하면 DB 쓰기를 스킵한다.
+func TestRoomService_DualWrite_GuestHost_SkipsDB(t *testing.T) {
+	mock := &mockPgGameRepo{}
+	svc := newRoomServiceWithMockPg(t, mock)
+
+	// 게스트 ID (UUID 형식 아님) — FK 위반 방지를 위해 DB 쓰기 스킵해야 함
+	guestHostID := "qa-테스터-1234567890"
+	room, err := svc.CreateRoom(&CreateRoomRequest{
+		Name:           "게스트 호스트 방",
+		PlayerCount:    2,
+		TurnTimeoutSec: 60,
+		HostUserID:     guestHostID,
+	})
+	require.NoError(t, err, "게스트 호스트도 메모리 방 생성 성공")
+	require.NotNil(t, room)
+
+	// DB 쓰기는 스킵됨
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	assert.Len(t, mock.createRoomCalls, 0, "비-UUID 호스트는 DB 쓰기 스킵")
 }


### PR DESCRIPTION
## Summary

ADR **D-03** (PR #40 merged) 의 구현 PR. rooms 테이블 MVP 인메모리 → PostgreSQL Dual-Write 전환 Phase 1. 메모리 정본 + PostgreSQL best-effort 사후 기록.

**PR #38 의 `game.RoomID = nil` 우회 해소** — I-14 FK wire 병행.

## 구현 (go-dev + qa)

### 핵심 코드 (go-dev, 3 commits)

| Commit | 내용 |
|---|---|
| `6acba15` feat | `room_converter.go` 신규 + `NewRoomService` 3-arg 확장 (`pgGameRepo` nil 허용) + best-effort 헬퍼 |
| `34cce98` refactor | 17 call-site 시그니처 마이그레이션 (e2e 6, handler 8, service 2, main 1) + `persistGameResult(state, endType, roomID)` wire |
| `bee0511` test | Dual-Write 단위 테스트 5건 (Create/Start/Finish/PG failure/Guest host) |

### 검증 (qa, 2 commits)

| Commit | 내용 |
|---|---|
| `c4c4f58` test | Integration test 3 시나리오 (HTTP 경계 + mock PG) + e2e README |
| `bf0a4f7` chore | 배포 후 bash 검증 스크립트 `scripts/verify-rooms-persistence.sh` (SQL 5건 assertion) |

## 주요 설계 결정 (ADR §"설계")

1. **`NewRoomService(roomRepo, gameStateRepo, pgGameRepo)`** — 3번째 파라미터 nil 허용. `pgGameRepo: nil` 로 교체 시 즉시 Dual-Write 비활성화
2. **필드 네임 충돌 해소**: ADR 권장대로 기존 `gameRepo` → `gameStateRepo` 리네임 (MemoryGameStateRepository 의미 명확화)
3. **Best-effort 3초 타임아웃**: PG 실패 시 `log.Printf("room_service: postgres ... best-effort failed")` 후 게임 진행 유지
4. **FK 게스트 방어**: `isValidUUIDStr(state.HostID)` false 시 DB 쓰기 스킵 (`qa-테스터-xxx` 등 non-UUID host 방 제외)
5. **I-14 병행**: `persistGameResult` 시그니처 변경으로 `game.RoomID = &roomID` / `game.RoomCode = room.RoomCode` 정상화 → PR #38 nil 우회 해소

## Test plan

- [x] **Go build**: 에러 0
- [x] **Go vet**: 경고 0
- [x] **Unit tests** (go-dev): 신규 Dual-Write 5건 PASS
- [x] **Integration tests** (qa): HTTP 경계 + mock PG 3 시나리오 PASS
- [x] **전체 회귀**: `go test ./... -count=1 -timeout 90s` — **530 PASS / 0 FAIL** (7 packages ok)
- [x] **Bash syntax**: `bash -n scripts/verify-rooms-persistence.sh` OK
- [ ] **devops K8s smoke** (병렬 진행 중): 로컬 K8s 재배포 → AI vs AI 1판 → `verify-rooms-persistence.sh` 실행 → SQL 5건 assertion PASS 결과를 PR comment 로 첨부 예정

## Rollback

```go
// src/game-server/cmd/server/main.go:103
roomSvc := service.NewRoomService(roomRepo, gameStateRepo, nil)  // pgRoomRepo → nil
```

재컴파일 → Dual-Write 즉시 비활성화. DB 스키마 마이그레이션 롤백 불필요 (rooms 테이블 이미 존재).

## 변경 범위

- **16 파일**, +1017 / -44
- 신규: `room_converter.go`, `rooms_persistence_test.go`, `e2e/README.md`, `verify-rooms-persistence.sh`
- 주요 수정: `room_service.go`, `ws_handler.go`, `main.go`, `room_service_test.go`
- 테스트 마이그레이션: e2e 2개 + handler 5개 (시그니처 nil 추가)

## 관련

- 선행 ADR: PR #40 (D-03, merged)
- 선행 배경: PR #38 (backend P0 I-14/I-15, merged) — `game.RoomID = nil` 우회 상태 해소
- 계획서: 심야 실측 정리 문서 §"후속 조치 A" (rooms 전환 실행 계획)
- 후속 (별도): pm 에이전트가 GitHub Issue I-17 생성 + PR #38 description 정정 + Sprint 7 백로그 반영 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)