### PR TITLE
docs(testing): 분석 산출물 3건 (74/75/76) — 다음 세션 구현 자산

### DIFF
--- a/docs/04-testing/74-warn-items-impact-assessment.md
+++ b/docs/04-testing/74-warn-items-impact-assessment.md
@@ -1,0 +1,259 @@
+# 74. WARN Items Impact Assessment (PR #41 / #42 Regression Plan §11)
+
+- **작성일**: 2026-04-22 (Sprint 7 D+1)
+- **작성자**: architect (Opus 4.7 xhigh)
+- **브랜치**: `hotfix/finding-01-i18-rollback-2026-04-23` (read-only 평가)
+- **목적**: `docs/04-testing/71-pr41-42-regression-test-plan.md` §11.2 에 Flagged 된 4개 WARN 항목의 **심각도·수정 시급성**을 판정하여 main 세션의 triage 를 지원한다.
+- **범위**: READ-ONLY — 코드 수정 없음, 브랜치 생성 없음.
+- **SSOT 준수**: `docs/02-design/31-game-rule-traceability.md`, `docs/02-design/30-error-management-policy.md`
+
+---
+
+## 1. Executive Summary
+
+| 집계 | 건수 | 항목 |
+|------|------|------|
+| **FIX NOW (Sprint 7 Day 1~2)** | **1건** | WARN-03 (조커 중복 push 방어) — 5분 S-size 패치 |
+| **Sprint 7 backlog** | **2건** | WARN-01 (LeaveRoom/StartGame race), WARN-02 (TURN_END race) |
+| **Permanent WONTFIX + docs** | **1건** | WARN-04 (게스트 방 DB 미기록) — ADR 필요 |
+| **총계** | **4건** | — |
+
+### 1.1 한 줄 요약
+
+- **WARN-01**: 이론적 race 는 있으나 현재 비-UUID HostID 가 실무상 없고 best-effort pg 경로라서 **사용자 영향 invisible**. Sprint 7 backlog 에 race 재현 단위 테스트 추가.
+- **WARN-02**: TURN_END 수신 시 `resetPending` 이 **TURN_START 에서만** 호출됨. 2초 fallback 도 있어 실제 race window 는 매우 좁음. 현 증상 없음 → backlog.
+- **WARN-03**: `addRecoveredJoker` 가 중복 push 를 막지 않음 — **잠재적 데드락**. `filter(.includes)` 는 `indexOf/splice` 로 1장씩 제거되므로 중복 2회 push 시 1회 배치로도 여전히 차단됨. **FIX NOW 권고** (S-size).
+- **WARN-04**: 게스트 방이 DB rooms 에 안 남는 것은 **FK 설계상 정상**. admin 현재 UI 는 memory repo 만 조회하므로 **현 UX 영향 없음**. 향후 DB-backed admin 도입 시 재평가 — ADR 필요.
+
+### 1.2 Cross-WARN 상호작용 리스크
+
+- **WARN-02 ↔ WARN-03**: TURN_END → (race window) → pendingRecoveredJokers 중복 push 시나리오가 이론적으로 가능. 단 TURN_END 경로에서는 `pendingRecoveredJokers` 에 쓰기가 없음 (store 단계 조회). 상호작용 무시 가능.
+- **WARN-01 ↔ WARN-04**: 둘 다 PG Dual-Write best-effort 실패 경로. 게임 진행 차단 없음 + 공통 로그 포맷 (`room_service: postgres ... best-effort failed`). 장애 식별 용이.
+
+---
+
+## 2. WARN-01 — `LeaveRoom during StartGame` race
+
+### 2.1 실제 재현 가능성: **theoretical**
+
+- **근거**: `src/game-server/internal/service/room_service.go` L302~350 (LeaveRoom) + L355~400 (StartGame).
+- 둘 다 `s.roomRepo.GetRoom(roomID)` 으로 메모리 repo 조회. memory_repo 는 `sync.RWMutex` (repository/memory_repo.go L25, L41 `Lock()`). **GetRoom + SaveRoom 두 호출 사이에는 락이 해제된다** (transactional 아님).
+- 따라서 다음 interleaving 이 논리적으로 가능:
+  1. StartGame goroutine A: `GetRoom()` → status=WAITING 확인 → gameService.newGame() (락 밖)
+  2. LeaveRoom goroutine B: `GetRoom()` → 호스트 퇴장 → status=CANCELLED → `SaveRoom()`
+  3. StartGame A: `SaveRoom()` (status=PLAYING 덮어씀)
+- 하지만 **실제 호출 경로**에서 HTTP handler 가 동일 roomID 에 대해 StartGame(호스트) + LeaveRoom(호스트)를 **동시에 발사**할 수 있는 UI 경로는 확인되지 않음. 게스트 UI 는 StartGame 권한이 없고, 호스트 UI 는 "방 나가기" 버튼이 게임 시작 버튼과 동시 클릭 불가.
+- **직접 공격 벡터**: curl 수동 공격자가 정확한 타이밍에 두 요청을 동시 발사하면 재현 가능 — 그러나 영향 = 방 상태 불일치 (게임은 이미 시작됨 + room.Status=CANCELLED → 방에는 못 들어감). 심각한 게임 무결성 파괴는 아님.
+
+### 2.2 사용자 영향: **invisible** (공격 시나리오만 annoyance)
+
+- 정상 사용자 경로에서는 발생 불가
+- pg Dual-Write 는 best-effort (L104 `pgBestEffortUpdateRoom`) 이므로 게임 흐름 차단 없음
+- **실측 로그**: 프로덕션에서 "room_service: postgres update room best-effort failed" 로그가 반복 발생한 이력 없음 (현 Sprint 7 시작 전 devops smoke 5/5 clean)
+
+### 2.3 수정 비용: **M** (half-day)
+
+- **옵션 A (정합성 전면 개편)**: RoomService 에 `sync.Mutex` per-room 도입 → GetRoom+Save 를 transactional 로 감싸기. 변경 지점 = StartGame, LeaveRoom, JoinRoom, FinishRoom 4개. 예상 4~5시간.
+- **옵션 B (최소 방어)**: LeaveRoom 내에서 `room.Status != WAITING` 체크 엄격화. 현재 L308 `RoomStatusFinished || RoomStatusCancelled` 만 차단. **PLAYING 상태에서도 LeaveRoom 금지하면 race 제거 가능** (기권은 WS 경로 사용). 예상 1시간.
+
+### 2.4 권고: **Sprint 7 backlog** (P2, W1 말)
+
+- 옵션 B 를 기본 권고. 단 PLAYING 중 LeaveRoom 금지 시 "기권" UX 가 막히지 않는지 확인 필요 (기존 FORFEIT 경로는 WS 로 `handleForfeit` 다른 핸들러 호출).
+- Sprint 7 backlog 에 `V-SPRINT7-RACE-01` 이슈 등록:
+  - 범위: room_service.go LeaveRoom PLAYING-block + 단위 테스트 race 시뮬레이션 (`mockPgRepo.createRoomCalls` 순서 검증)
+  - 담당: go-dev (구현) + architect (설계 리뷰)
+
+### 2.5 FIX NOW 시 담당 에이전트
+
+N/A (backlog)
+
+---
+
+## 3. WARN-02 — `TURN_END` WS race
+
+### 3.1 실제 재현 가능성: **very theoretical**
+
+- **근거**: `src/frontend/src/hooks/useWebSocket.ts` L184~282.
+- TURN_END 리듀서는 `gameState.tableGroups`, `players[].tileCount`, `myTiles` (서버값 우선) 등을 업데이트하지만 **`pendingMyTiles`/`pendingTableGroups`/`pendingRecoveredJokers` 는 건드리지 않음**.
+- `resetPending()` 호출은 오직 TURN_START (L192) + BUG-WS-001 fallback (L276, 2초 대기) + AI_THINKING fallback (L436) 에서만.
+- 따라서 race window = "사용자가 `handleConfirm` 버튼을 눌러 WS `CONFIRM_TURN` 송신 중, 서버에서 TURN_END 응답이 도착 → TURN_START 가 뒤이어 도착 → `resetPending()` 실행" 의 아주 짧은 구간 (<200ms 예상).
+- **실제 문제는 `CONFIRM_TURN` 송신 이후 `resetPending` 이 TURN_START 올 때까지는 pending 유지**. 이 사이 사용자가 **다시 handleConfirm 버튼을 누를 수 있는가?** — `handleConfirm` 안에 이중 차단 없음. 다만 TURN_END 수신으로 `currentSeat` 이 다음 사람으로 바뀌므로, `isMyTurn` 기반 UI 비활성화가 일어남 (확정 버튼 disabled).
+
+### 3.2 사용자 영향: **invisible → annoyance (이중 클릭 시)**
+
+- 정상 흐름: 확정 클릭 → WS 송신 → (네트워크 RTT) → TURN_END → TURN_START → resetPending.
+- 비정상 흐름: 확정 클릭 → 반응 없다고 재클릭 → TURN_END 도착과 겹침 → 2번째 CONFIRM_TURN 이 서버 INVALID_MOVE 반환 (다른 플레이어 턴이므로) → ErrorToast 표시.
+- 영향 = ErrorToast 한 번 노출 (UX 손상 경미, 실데이터 무결성 파괴 없음).
+- **Playwright 재현 불가 이유 정확**: WS 메시지 순서를 mock 으로 재현해야 하는데 mock 시뮬레이션 밖.
+
+### 3.3 수정 비용: **S** (<2h)
+
+- `handleConfirm` 진입 시 `isConfirmInFlight` state 추가. WS ACK (TURN_END 또는 INVALID_MOVE) 수신 시까지 버튼 disabled.
+- 변경 파일 1개: `src/frontend/src/app/game/[roomId]/GameClient.tsx`. 약 15라인.
+- 단위 테스트: Jest 2건 (flight 중 2번째 확정 차단 / INVALID_MOVE 수신 시 해제).
+
+### 3.4 권고: **Sprint 7 backlog** (P3, W1~W2)
+
+- 현 증상 없음 + Playwright 재현 어려움. SKILL `ui-regression` 실측 바탕으로 추가 증상 발견 시 FIX NOW 로 승격.
+- Sprint 7 backlog 에 `V-SPRINT7-RACE-02` 이슈 등록:
+  - 범위: GameClient.tsx handleConfirm in-flight lock + Jest 단위 2건
+  - 담당: frontend-dev (구현)
+
+### 3.5 FIX NOW 시 담당 에이전트
+
+N/A (backlog)
+
+---
+
+## 4. WARN-03 — `pendingRecoveredJokers` 중복 push 가능성
+
+### 4.1 실제 재현 가능성: **possible** (엣지 시나리오에서 높음)
+
+- **근거**: `src/frontend/src/store/gameStore.ts` L166~178.
+- `addRecoveredJoker(code)` 는 **guard 없이 `push`**: `[...state.pendingRecoveredJokers, code]`. `removeRecoveredJoker` 는 `indexOf` + `splice(idx, 1)` 로 **1회 제거**.
+- **재현 시나리오**:
+  1. 사용자가 서버 런 `[R5, JK1, R7]` 에 R6 를 드롭 → `tryJokerSwap` 성공 → `addRecoveredJoker("JK1")` → `pendingRecoveredJokers = ["JK1"]`, `pendingMyTiles += ["JK1"]`
+  2. 사용자가 JK1 을 pending 그룹 A 에 드롭 → pendingMyTiles 에서 JK1 제거 → `unplacedRecoveredJokers = ["JK1"].filter(jk => [].includes(jk)) = []` (OK)
+  3. **사용자가 "되돌리기" 클릭** (가상 기능) 또는 `setPendingTableGroups` 재설정으로 JK1 이 pendingMyTiles 에 재삽입됨
+  4. 이 경로에서 `addRecoveredJoker("JK1")` 가 **다시 호출되면** → `pendingRecoveredJokers = ["JK1", "JK1"]`
+  5. 사용자가 JK1 을 다시 보드에 배치 → pendingMyTiles 에서 1장 제거 → `unplacedRecoveredJokers = ["JK1","JK1"].filter(jk => [].includes(jk)) = []` (OK)
+  6. **하지만** 실제 기본 시나리오에서 JK1 이 pendingMyTiles 에 2장 있을 수는 없으므로 filter 는 빈 배열 반환 → 차단 안 됨 → 정상
+  7. **진짜 위험**: JK1 이 pendingMyTiles 에 1장 남아있는 상태에서 `pendingRecoveredJokers = ["JK1","JK1"]` 이면 `filter(jk => ["JK1",...].includes(jk)) = ["JK1","JK1"]` → 차단. 사용자가 JK1 을 보드에 한 번 배치하면 pendingMyTiles 에서 제거 → filter 결과 `[]` → 차단 해제. **데드락 없음**.
+- **현 상황**: 되돌리기 기능 아직 없음 + `addRecoveredJoker` 호출 경로는 L789 `tryJokerSwap` 성공 1곳뿐. 중복 push 를 만드는 코드 경로는 **현재 존재하지 않음**.
+- **미래 회귀 리스크**: "되돌리기"/"취소" 기능 추가 시 addRecoveredJoker 가 재호출될 수 있으며, guard 가 없으면 중복이 쌓임.
+
+### 4.2 사용자 영향: **invisible (현재) → potential annoyance (되돌리기 추가 시)**
+
+- 현재 경로에서 중복 push 가 발생할 수 없음 → 영향 없음
+- 다만 방어 코드 없이 미래 기능 도입 시 경고 배너 (`JokerSwapIndicator`) 에 "JK1" 이 2번 중복 표시되거나 `filter` 결과가 예상 외로 커져 UX 혼란 가능
+
+### 4.3 수정 비용: **S** (<30m)
+
+- gameStore.ts L166~168 에 중복 guard 1줄 추가:
+  ```ts
+  addRecoveredJoker: (code) =>
+    set((state) => {
+      if (state.pendingRecoveredJokers.includes(code)) return {};
+      return { pendingRecoveredJokers: [...state.pendingRecoveredJokers, code] };
+    }),
+  ```
+- Jest 테스트 2건 추가 (중복 push 무시 / 정상 push 유지). 기존 `gameStore.test.ts` 에 append.
+
+### 4.4 권고: **FIX NOW** (Sprint 7 Day 1)
+
+- 5~10분 패치 + 방어적 변경. 회귀 리스크 극소 (Set-like 동작은 기존 `indexOf + splice` 시맨틱을 더 견고하게 만든다).
+- Finding #5 로 이슈 등록 + 별도 hotfix PR 권고. PR 본문에 "WARN-03 사전 방어" 명시.
+- **중요**: 본 변경은 V-07 / V-13e 규칙 로직과 독립 — 게임룰 영향 없음.
+
+### 4.5 FIX NOW 시 담당 에이전트
+
+- **frontend-dev** (구현 + Jest 2건)
+- 검증: **qa** (기존 Jest 182건 유지 + 신규 2건 PASS)
+
+---
+
+## 5. WARN-04 — 비-UUID 호스트 방 rooms 미기록 (Admin UX)
+
+### 5.1 실제 재현 가능성: **very likely (설계상 의도)**
+
+- **근거**: `src/game-server/internal/service/room_converter.go` L14~18. `isValidUUIDStr(state.HostID)` false → nil 반환 → `pgBestEffortCreateRoom`/`UpdateRoom` 에서 스킵 (room_service.go L91, L109).
+- 게스트 사용자 (`qa-테스터-xxx` 접두 ID) 는 UUID 형식이 아님 → 항상 DB rooms 에 INSERT 안 됨.
+- **확정**: 설계 의도. FK `rooms.host_user_id → users.id` 보호용 + 게스트는 users 테이블에 row 없음 → FK 위반 방지.
+
+### 5.2 사용자 영향: **invisible (현재) → future concern**
+
+- **현재 상태 확인** (2026-04-22):
+  - admin handler (`src/game-server/internal/handler/admin_handler.go`) 에는 rooms 관련 엔드포인트 **없음**.
+  - 공개 `/api/rooms` (room_handler.go L104 ListRooms) 는 **memory repo** 만 조회 (`h.roomSvc.ListRooms()` → `s.roomRepo.ListRooms()`) → 게스트 방도 보임.
+  - 따라서 현 Admin Dashboard 에 "게스트 방 누락" UX 이슈 **없음**.
+- **미래 상태 우려**:
+  - `docs/02-design/32-admin-dashboard-component-spec.md` (2026-04-12 작성) 가 향후 DB-backed admin rooms 관제를 제안하면 그때 이 이슈가 표면화.
+  - 운영 어드민이 "어제의 방 목록" (memory repo 에서 이미 만료된 방) 을 재구성하려면 DB rooms 가 필요 → 게스트 방은 복구 불가.
+
+### 5.3 수정 비용: **L** (>1 day, 단 지금은 수정 불필요)
+
+- **옵션 A (게스트도 DB 기록)**: `users` 테이블에 게스트 row 선삽입 (temp user) → FK 유지. 별도 설계 필요 + Sprint 7 범위 초과.
+- **옵션 B (rooms.host_user_id 를 nullable 로)**: FK 제약 완화. 스키마 변경 마이그레이션 + admin 쿼리 수정.
+- **옵션 C (현상 유지 + ADR 문서화)**: 비용 0 + 미래 요구 시점에 재평가.
+
+### 5.4 권고: **Permanent WONTFIX + ADR 문서화**
+
+- 현 Sprint 7 에서는 수정 **불필요**. 단 다음 둘을 Day 1 내에 처리:
+  1. **ADR 작성**: `docs/02-design/34-adr-025-guest-room-persistence.md` (신규)
+     - Context: FK 보호 + 게스트 UUID 미보장
+     - Decision: 게스트 방은 DB rooms 에 기록하지 않는다 (memory-only)
+     - Consequences: Admin Dashboard 에서 게스트 방 히스토리 조회 불가 + 로그 기반 재구성 필요 시 별도 game_events 테이블 활용
+     - Alternatives: 옵션 A/B (위 §5.3)
+  2. **Admin Dashboard FAQ**: `docs/06-operations/` 에 "게스트 방이 왜 rooms 테이블에 없는가" 항목 추가. 현재 `docs/06-operations/` 는 2문서뿐이므로 새 파일 `03-admin-faq.md` 생성 권고.
+- 향후 게스트 방 DB 기록이 요구되면 ADR 개정 + 별도 Sprint 에서 구현.
+
+### 5.5 FIX NOW 시 담당 에이전트
+
+- **architect** (ADR 작성) — 1시간 이내
+- **pm** 또는 **architect** (Admin Dashboard FAQ) — 30분 이내
+- 코드 변경 없음.
+
+---
+
+## 6. Recommended Action Plan
+
+### 6.1 Sprint 7 Day 1 (2026-04-22, 오늘~내일)
+
+| 항목 | 담당 | 소요 | 완료 기준 |
+|------|------|------|----------|
+| **WARN-03 hotfix PR** | frontend-dev | 30분 | gameStore.ts addRecoveredJoker guard + Jest 2건 신규 / Jest 184+/184+ PASS |
+| **WARN-04 ADR-025 작성** | architect | 1시간 | `docs/02-design/34-adr-025-guest-room-persistence.md` |
+| **WARN-04 Admin FAQ** | architect | 30분 | `docs/06-operations/03-admin-faq.md` §"게스트 방 rooms 누락" |
+
+### 6.2 Sprint 7 backlog (W1 말까지)
+
+| 항목 | 담당 | 소요 | 완료 기준 |
+|------|------|------|----------|
+| **WARN-01 race 방어** | go-dev + architect review | 2시간 | LeaveRoom PLAYING-block + 단위 race 테스트 / Go 689→691 |
+| **WARN-02 confirm in-flight lock** | frontend-dev | 1시간 | GameClient.tsx in-flight state + Jest 2건 |
+
+### 6.3 Sprint 7 Day 2~Week 1 (거부/연기)
+
+- WARN-04 옵션 A/B (게스트 DB 기록) — **WONTFIX**. 필요 시점 도달까지 보류.
+
+---
+
+## 7. Rationale Summary
+
+### 7.1 왜 WARN-03 만 FIX NOW 인가
+
+- **비용 최소** (5~10분 패치) + **회귀 리스크 극소** (기존 동작에 Set-like 강화, 기존 테스트 모두 유지)
+- **미래 회귀 방어**: 되돌리기/취소 기능이 Sprint 8+ 에 추가될 가능성이 Phase 1 UI roadmap 에 있음 → 선제적 방어가 효율적
+- 다른 3건은 재현성이 낮거나 (WARN-01/02) 설계 의도 (WARN-04) 이므로 추가 분석 후 처리가 적절
+
+### 7.2 왜 WARN-04 는 ADR 인가
+
+- 설계 결정이 명시적으로 문서화되지 않은 상태 — "게스트 방은 DB 기록 안 함" 이 코드에만 존재
+- 미래 운영팀/신규 개발자가 버그로 오해할 가능성 매우 높음 → ADR 로 고착
+- Admin Dashboard 가 아직 DB rooms 를 조회하지 않으므로 **지금 기록하는 것이 저비용**
+
+### 7.3 Confidence
+
+- WARN-01 재현 가능성 판정: **HIGH** (코드 직접 검증)
+- WARN-02 race window 크기 판정: **MEDIUM** (네트워크 RTT 변수)
+- WARN-03 FIX NOW 권고: **HIGH** (수정 소비용 vs 미래 방어 가치 명확)
+- WARN-04 WONTFIX 근거: **HIGH** (현 admin 코드 실측 확인)
+
+---
+
+## 8. References
+
+- `docs/04-testing/71-pr41-42-regression-test-plan.md` §11.2 — WARN 원본
+- `docs/04-testing/72-pr41-42-regression-test-report.md` — qa 실행 결과 (본 문서 작성 시점 기준 실행 완료 가정)
+- `docs/02-design/31-game-rule-traceability.md` — V-07, V-13e (WARN-03 관련)
+- `docs/02-design/30-error-management-policy.md` — INVALID_MOVE / FK 에러 정책
+- `src/game-server/internal/service/room_service.go` — WARN-01 본체
+- `src/game-server/internal/service/room_converter.go` — WARN-04 본체
+- `src/frontend/src/hooks/useWebSocket.ts` — WARN-02 본체
+- `src/frontend/src/store/gameStore.ts` — WARN-03 본체
+
+---
+
+## 9. 변경 이력
+
+- **2026-04-22 v1.0**: architect 최초 작성 (WARN 4건 심각도 평가 + Action Plan)

--- a/docs/04-testing/75-sec-day12-impact-and-plan.md
+++ b/docs/04-testing/75-sec-day12-impact-and-plan.md
@@ -1,0 +1,457 @@
+# 75. SEC-REV-013 + Day 12 Backend P0 — 통합 영향 분석 및 실행 계획서
+
+- **작성일**: 2026-04-22 (Sprint 7 Day 1 착수 직전)
+- **작성자**: Software Architect (architect agent, Opus 4.7 xhigh)
+- **모드**: Read-only 영향 분석. 본 문서는 계획서이며 코드 수정 / 커밋 / 브랜치 생성 없음.
+- **선행 참조**:
+  - `docs/04-testing/70-sec-rev-013-dependency-audit-report.md` (SEC-REV-013 감사 리포트)
+  - PR #38 (`hotfix/backend-p0-2026-04-22`, merged 2026-04-22 07:25 UTC)
+  - PR #42 (`feat/rooms-postgres-phase1-impl`, merged 2026-04-22 10:12 UTC)
+- **범위**: 5개 항목 — SEC-A (Go bump), SEC-B (Next bump), SEC-C (npm audit fix), Day 12 P0-1 (game_results persistence), Day 12 P0-2 (WS GAME_OVER broadcast)
+
+---
+
+## 1. Executive Summary
+
+| ID | 항목 | 판정 | 근거 요약 |
+|----|------|------|---------|
+| **SEC-A** | Go toolchain 1.24.1 → 1.25.9 + go-redis v9.7.0 → v9.7.3 | **PROCEED** | govulncheck code-called 25건 중 24건 stdlib + 1건 go-redis CVE. PR 1건으로 일괄 해소. 리스크 LOW. |
+| **SEC-B** | Next bump — frontend 15.2.9 → 15.5.15, admin 16.1.6 → 16.2.4 | **PROCEED (주의)** | High 6건 (서버컴포넌트 DoS CVSS 7.5 등) 해소. Non-semver-major 패치이지만 15.2 → 15.5 는 **3단계 minor 점프**, Playwright 회귀 필수. 리스크 MEDIUM. |
+| **SEC-C** | `npm audit fix` non-breaking (ai-adapter + frontend + admin) | **PROCEED** | axios moderate 2건 + brace-expansion 등 자동 해소. SEC-B 와 병합하여 lockfile 1회 재생성 권장. 리스크 LOW. |
+| **P0-1** | `game_results` persistence 설계/구현 | **ALREADY DONE** (PR #38 + PR #42) | `game_results` 라는 별도 테이블은 존재하지 않음. 실제 영속 대상은 `games / game_players / game_events` 3테이블이며 `persistGameResult` 헬퍼로 wire 완료 (`ws_handler.go:1917~`). PR #38 에서 로컬 실측 `games 58→60, game_events 0→2` 검증됨. 재실행 불필요. |
+| **P0-2** | WS `game_over` broadcast 점검 | **ALREADY DONE** (PR #38) | `broadcastGameOver` / `broadcastGameOverFromState` 가 win/stalemate/forfeit 4개 경로에서 호출됨 (`ws_handler.go:474, 522, 1006, 1062, 1109, 1271, 1466`). 프론트엔드 `useWebSocket.ts:322` 에서 `GAME_OVER` case reducer 연결 확인. I-15 winnerId 버그까지 수정 완료 (`c4b566a`). |
+
+**Go/No-Go 결론**: SEC-A / SEC-B / SEC-C 3개만 실제 작업. Day 12 P0 2건은 **이미 해결된 상태**로 Sprint 7 TODO 에서 제거 권장.
+
+---
+
+## 2. Per-item Detailed Analysis
+
+### 2.1 SEC-A — Go toolchain 1.24.1 → 1.25.9 + go-redis v9.7.0 → v9.7.3
+
+#### Current state
+- `src/game-server/go.mod` line 3: `go 1.24`
+- `src/game-server/go.mod` line 10: `github.com/redis/go-redis/v9 v9.7.0`
+- `src/game-server/Dockerfile` line 10: `FROM golang:1.24-alpine AS deps`
+- `.gitlab-ci.yml` line 162: `image: golang:1.24-alpine` (lint-go 스테이지)
+- govulncheck 결과: **code-called 25건** 중 24건이 stdlib (crypto/tls, crypto/x509, net/http, net/url, html/template), 1건이 go-redis/v9 (GO-2025-3540, out-of-order responses)
+
+#### Actual change scope
+| 파일 | 변경 | 예상 LOC |
+|------|------|--------|
+| `src/game-server/go.mod` | `go 1.24` → `go 1.25` + `go-redis/v9 v9.7.0` → `v9.7.3` | 2 |
+| `src/game-server/go.sum` | `go mod tidy` 재생성 | ~6 (추가·삭제) |
+| `src/game-server/Dockerfile` | `golang:1.24-alpine` → `golang:1.25-alpine` (2 곳: line 10) + 주석 line 3 | 2 |
+| `.gitlab-ci.yml` | `golang:1.24-alpine` → `golang:1.25-alpine` (lint-go 잡) | 1 |
+
+**Total: 4 files, ~11 LOC**
+
+#### Risk level: **LOW**
+- go-redis 는 patch bump (v9.7.0 → v9.7.3), API 호환성 유지
+- Go 1.24 → 1.25 는 minor bump 이지만 Go 는 **strict backward compatibility** 약속. 실 파손 이력 거의 없음
+- 감사 리포트 §4.1 권장안이 1.24.13 또는 1.25.9 둘 다 허용하지만, 1.25 로 가면 **GO-2026 계열 8건 (지난 6일 공개)** 까지 일괄 해소되므로 1.25.9 가 경제적
+
+#### Breaking change flags
+- **없음 (예상)**. `go vet` 현재 exit 0 유지, 689개 테스트 regression 없을 것으로 예상
+- 다만 `toolchain` directive 추가 시 GitLab Runner 캐시 miss 가능성 — lint-go 첫 실행 시 캐시 재빌드
+
+#### Verification plan
+1. `cd src/game-server && go mod tidy`
+2. `go build ./...` (로컬)
+3. `go test ./... -count=1 -timeout 90s` → **530 PASS** 유지
+4. `go vet ./...` → exit 0
+5. `govulncheck -mode=source ./...` → **code-called 0건** 확인 (또는 잔여가 있다면 별도 advisory 확인)
+6. Docker 로컬 빌드: `docker build -t rummiarena/game-server:sec-a src/game-server/`
+7. CI 파이프라인 17/17 GREEN 유지 확인
+
+#### Estimated duration: **S (< 1h)**
+- 코드 변경 5분, 로컬 테스트 15분, CI 실행 25분, 검증 10분
+
+#### Recommended agent: **devops** (Dockerfile + CI) + **go-dev** (go.mod / tidy)
+- devops 가 메인 집행, go-dev 는 code-called 0 확인 보조
+
+#### Branch naming: `chore/sec-a-go-toolchain-bump`
+
+#### Dependencies: 없음 (독립)
+
+---
+
+### 2.2 SEC-B — Next.js bump (frontend 15.2.9 → 15.5.15, admin 16.1.6 → 16.2.4)
+
+#### Current state
+- `src/frontend/package.json` line 22: `"next": "15.2.9"` + line 38: `"eslint-config-next": "15.2.9"`
+- `src/admin/package.json` line 14: `"next": "16.1.6"` + line 25: `"eslint-config-next": "16.1.6"`
+- lockfile 존재: frontend 10,768 lines / admin 7,059 lines (재생성 필요)
+
+#### Actual change scope
+| 파일 | 변경 | 예상 LOC |
+|------|------|--------|
+| `src/frontend/package.json` | `"next": "15.2.9"` → `"^15.5.15"` + `eslint-config-next` 동일 | 2 |
+| `src/frontend/package-lock.json` | `npm install` 재생성 | ~500~2000 (변경 라인) |
+| `src/admin/package.json` | `"next": "16.1.6"` → `"^16.2.4"` + `eslint-config-next` 동일 | 2 |
+| `src/admin/package-lock.json` | `npm install` 재생성 | ~200~800 (변경 라인) |
+
+**Total: 4 files, 4 직접 LOC + 대량 lockfile diff**
+
+#### Risk level: **MEDIUM**
+감사 리포트에는 "non-semver-major" 라고 명시되었지만 실제로는:
+- frontend: **15.2 → 15.5** (3 minor 점프). Next 15.3 / 15.4 내부에서 Image, middleware, Server Actions 동작 변화 가능성 있음
+- admin: **16.1 → 16.2** (1 minor). 낮은 리스크
+
+#### Breaking change flags
+- [ ] **middleware redirect 동작 변화** (GHSA-4342-x723-ch2f 패치 과정에서 SSRF 수정) — `middleware.ts` / `src/middleware.ts` 존재 시 트래픽 흐름 재확인
+- [ ] **next/image remotePatterns DoS 수정** (GHSA-9g9p-9gw9-jx7f) — 외부 이미지 도메인 설정 영향
+- [ ] **Server Actions null origin CSRF 수정** (GHSA-mq59-m269-xvcx, admin 측) — CSRF 토큰 요구 강화 가능
+- [ ] **Request smuggling 패치** — rewrites 설정 검증 필요
+- [ ] Node 22.x 런타임 호환 (현재 CI golang:1.25 Dockerfile 에는 영향 없음, frontend Dockerfile 별도 확인)
+
+#### Verification plan
+1. `cd src/frontend && npm install` (lockfile 재생성)
+2. `npm test` → Jest 182/182 PASS 유지
+3. `npm run build` → production 빌드 성공 + 경고 개수 회귀 없음
+4. **Playwright E2E 전체 재실행** → 376 PASS / 4 Known FAIL (Ollama) 유지 확인
+5. `cd src/admin && npm install && npm run build` → admin 빌드 성공
+6. `npm audit --audit-level=high --omit=dev` → production 경로 **exit 0** 확인
+7. 로컬 K8s 배포 후 smoke: 로그인 → 로비 → AI vs Human 1판 → 결과 화면 수동 확인
+8. 의심 영역 수동 점검:
+   - `src/frontend/src/app/api/auth/[...nextauth]/route.ts` — NextAuth v4 with Next 15.5 호환성
+   - `src/frontend/next.config.ts` — images / rewrites / redirects 설정
+   - `src/admin/next.config.ts` — 동일
+
+#### Estimated duration: **M (1~3h)**
+- lockfile 재생성 20분, Jest 10분, Playwright E2E 45분 (전체), 빌드 15분, K8s smoke 30분, 이슈 트러블슈팅 여유 60분
+
+#### Recommended agent: **frontend-dev** (메인) + **qa** (Playwright 리그레션)
+- frontend-dev 가 package.json / lockfile / 빌드 에러 처리
+- qa 가 E2E 및 K8s smoke
+
+#### Branch naming: `chore/sec-b-next-bump`
+
+#### Dependencies:
+- **SEC-C 와 묶음 권장** — 같은 lockfile 을 두 번 재생성하지 않기 위해. 한 브랜치에서 둘 다 처리하거나, SEC-B 를 먼저 merge 한 뒤 SEC-C 가 `npm audit fix` 를 실행하는 순서
+- SEC-A 와는 독립 (Go/Node 분리)
+
+---
+
+### 2.3 SEC-C — npm audit fix non-breaking (ai-adapter + frontend + admin)
+
+#### Current state
+- ai-adapter: production 경로 **High 0 / Moderate 6** (axios 2, @nestjs/core 1, file-type 2, follow-redirects 1)
+- frontend: lockfile 내 transitive moderate (brace-expansion 등)
+- admin: lockfile 내 transitive moderate (brace-expansion, picomatch)
+
+#### Actual change scope
+| 파일 | 변경 | 예상 LOC |
+|------|------|--------|
+| `src/ai-adapter/package-lock.json` | `npm audit fix` 로 axios `^1.6.0` → `>=1.15.0` lockfile bump | ~50~150 |
+| `src/frontend/package-lock.json` | `npm audit fix` (transitive only) | ~30~80 |
+| `src/admin/package-lock.json` | `npm audit fix` (transitive only) | ~20~50 |
+
+**주의**: `package.json` 자체는 변경 없음 (semver 범위는 그대로, lockfile 만 갱신)
+
+**Total: 3 files, 0 package.json LOC + lockfile diff**
+
+#### Risk level: **LOW**
+- `--omit=dev` 기준으로 production runtime 은 현재도 Critical/High 0건
+- axios `^1.6.0` 범위 내 자동 bump 이므로 API 호환성 유지
+- transitive 패키지 변경은 빌드 계층에만 영향
+
+#### Breaking change flags
+- 없음 (예상)
+- `@typescript-eslint/*` 는 dev-only High 라 본 PR 에서 **의도적 제외** (별도 P1 PR 로 처리)
+- `@nestjs/cli` 메이저 bump 도 제외 (dev-only)
+
+#### Verification plan
+1. `cd src/ai-adapter && npm audit fix && npm test` → 428/428 PASS 유지
+2. `cd src/ai-adapter && npm audit --audit-level=high --omit=dev` → 0 High (production) 확인
+3. `cd src/frontend && npm audit fix && npm test` → 182/182 PASS 유지
+4. `cd src/admin && npm audit fix && npm run build`
+5. **주의**: SEC-B 와 동시 merge 시 lockfile 충돌 가능 → **SEC-B 먼저 merge 후 SEC-C 실행** 또는 **같은 브랜치에서 연속 실행**
+
+#### Estimated duration: **S (< 1h)**
+- 각 프로젝트 `npm audit fix` 5분, 테스트 15분 × 3 = 45분
+
+#### Recommended agent: **node-dev** (ai-adapter) + **frontend-dev** (frontend/admin)
+- 간단한 작업이므로 한 명이 3개 프로젝트 모두 처리해도 무방
+
+#### Branch naming: `chore/sec-c-npm-audit-fix`
+
+#### Dependencies:
+- **SEC-B 와 같은 브랜치 또는 순차 실행 권장** (lockfile 충돌 방지)
+
+---
+
+### 2.4 P0-1 — `game_results` persistence — **ALREADY DONE**
+
+#### Current state 확인 결과
+리포트 모체의 주장("게임 결과 영속화 누락")은 **Day 12 아침 시점 기준**이었으며 같은 날 PR #38 + PR #42 로 해소 완료.
+
+검증 근거:
+1. **테이블 네이밍**: `game_results` 라는 별도 테이블은 존재하지 않음. 실제 영속 모델은 `models/game.go` 의 `Game / GamePlayer / GameEvent` 3테이블 구조
+2. **persistGameResult 헬퍼**: `src/game-server/internal/handler/ws_handler.go:1917~2284`
+   - 시그니처: `func (h *WSHandler) persistGameResult(state *model.GameStateRedis, endType string, roomID string)`
+   - 3개 테이블 순차 INSERT (games → game_players → game_events)
+   - UUID 정규화 헬퍼 `isValidUUID` 포함 (게스트 ID "qa-테스터-xxx" 방어)
+   - best-effort 10초 timeout (context.WithTimeout)
+3. **호출 지점 4곳**:
+   - `ws_handler.go:864` — `broadcastGameOver` 내부
+   - `ws_handler.go:1626` — `broadcastGameOverFromState` 내부
+   - `ws_handler.go:2284` — forfeit 경로
+   - (I-14 로 추가된 win/stalemate/forfeit 3 경로 커버 완료)
+4. **PR #38 merge 시 실측 증거** (PR 본문 인용):
+   > games: 58 → 60 (+2), game_players: 58 → 62 (+4), game_events: **0 → 2** (+2, GAME_END event 기록) ← 1주일 미스터리 해결
+5. **PR #42 보강**: `persistGameResult(state, endType, roomID)` — roomID 파라미터 추가로 `games.room_id FK` 정상화. D-03 Dual-Write 연계
+6. **단위 테스트 존재**: `ws_persist_test.go` 에 17개 시나리오 (NORMAL, STALEMATE, FORFEIT, AsyncSafe, UUID 정규화 포함)
+
+#### Actual change scope: **0 LOC** (이미 반영됨)
+
+#### Risk level: **N/A**
+
+#### Verification plan (회귀 방지용 수동 점검만)
+- [ ] 다음 K8s 실측 때 `SELECT COUNT(*) FROM game_events WHERE event_type='GAME_END'` 증가 확인
+- [ ] PR #38 본문의 "PK 충돌 방어 — `games` INSERT 에 `ON CONFLICT DO NOTHING` 추가 필요" TODO 는 Sprint 7 이관 상태 유지
+
+#### Estimated duration: **0h** (작업 없음)
+
+#### Recommended agent: 없음 (해제)
+
+#### Branch naming: N/A
+
+#### 권장 조치: **Sprint 7 TODO 에서 "Day 12 backend P0-1" 항목 삭제** 또는 "ALREADY DONE (PR #38 + PR #42)" 주석 추가
+
+---
+
+### 2.5 P0-2 — WS `game_over` broadcast 점검 — **ALREADY DONE**
+
+#### Current state 확인 결과
+
+**게임서버 측 (broadcast)**:
+- `broadcastGameOver(conn, state)` — `ws_handler.go:822`
+- `broadcastGameOverFromState(roomID, state)` — `ws_handler.go:1585`
+- 호출 경로 8곳 (win / stalemate / forfeit / timeout / AI draw pile exhaustion 등):
+  - `ws_handler.go:474, 522` — 일반 종료
+  - `ws_handler.go:1006, 1062, 1109, 1271, 1466` — stalemate/timeout/AI 경로
+- I-15 버그 (winnerId 빈 문자열) 은 commit `c4b566a` 에서 `resolveWinnerFromState` 헬퍼로 해결
+- 테스트: `ws_cleanup_test.go:312` + `timeout_cleanup_integration_test.go:96` 에서 broadcast → cleanup 체인 검증
+
+**WS 메시지 정의**:
+- `ws_message.go:26` — `S2CGameOver = "GAME_OVER"`
+- `ws_message.go:193` — `GameOverPayload` struct
+
+**프론트엔드 측 (reducer)**:
+- `src/frontend/src/hooks/useWebSocket.ts:322~328` — `case "GAME_OVER"` 완전 연결:
+  ```typescript
+  case "GAME_OVER": {
+    const payload = msg.payload as GameOverPayload;
+    console.info("[WS] GAME_OVER", payload);
+    useGameStore.getState().setGameOverResult(payload);
+    setGameEnded(true);
+    break;
+  }
+  ```
+- `src/frontend/src/store/gameStore.ts:87` — `gameOverResult` state 선언
+- `src/frontend/src/store/gameStore.ts:184` — `setGameOverResult` action
+- `src/frontend/src/app/game/[roomId]/GameClient.tsx:466, 1277` — UI 렌더링 연결
+
+#### Actual change scope: **0 LOC** (이미 반영됨)
+
+#### Risk level: **N/A**
+
+#### Verification plan (회귀 방지용 수동 점검만)
+- [ ] K8s 실측 때 승자 모달이 win/stalemate/forfeit 3경로 모두 정상 표시되는지 확인 (Day 11 실측에서 확인 완료)
+- [ ] PR #45 회귀 테스트 결과 재검토 (`docs/04-testing/72-pr41-42-regression-test-report.md`)
+
+#### Estimated duration: **0h** (작업 없음)
+
+#### Recommended agent: 없음 (해제)
+
+#### Branch naming: N/A
+
+#### 권장 조치: **Sprint 7 TODO 에서 "Day 12 backend P0-2" 항목 삭제**
+
+---
+
+## 3. Parallel Execution Matrix
+
+### 3.1 실제 작업 3개 (SEC-A / SEC-B / SEC-C) 병렬성 분석
+
+```mermaid
+flowchart TB
+    Start(["Sprint 7 Day 1 Start"]) --> A["SEC-A\n(go.mod + Dockerfile + .gitlab-ci)\ndevops + go-dev\nBranch: chore/sec-a-go-toolchain-bump"]
+    Start --> BC["SEC-B + SEC-C 통합 브랜치\n(프론트 lockfile 1회 재생성)\nfrontend-dev + qa\nBranch: chore/sec-bc-npm-next-bump"]
+    A --> Merge1(["Merge SEC-A to main"])
+    BC --> Merge2(["Merge SEC-BC to main"])
+    Merge1 --> CI["CI 17/17 GREEN 확인"]
+    Merge2 --> CI
+```
+
+### 3.2 병렬성 매트릭스
+
+| 항목 A | 항목 B | 병렬 가능? | 이유 |
+|-------|-------|---------|-----|
+| SEC-A | SEC-B | YES | Go/Node 완전 분리, 파일 충돌 없음 |
+| SEC-A | SEC-C | YES | Go/Node 완전 분리 |
+| SEC-B | SEC-C | NO (순차 또는 동일 브랜치) | 동일 lockfile 충돌 가능성 |
+
+### 3.3 권장 실행 형태
+
+**옵션 A (권장, 2 worktree 병렬)**:
+1. `chore/sec-a-go-toolchain-bump` (devops + go-dev, 1시간)
+2. `chore/sec-bc-npm-next-bump` (frontend-dev + qa, 3시간)
+
+→ 두 PR 을 각각 다른 worktree 에서 동시 진행, 총 소요 시간 ≈ **3시간 (wall-clock)**
+
+**옵션 B (보수적, 순차)**:
+SEC-A → merge → SEC-B → merge → SEC-C → merge.
+총 소요 시간 ≈ **4~5시간 (wall-clock)**
+
+**옵션 C (리스크 분리)**:
+SEC-A 병렬, SEC-B 와 SEC-C 를 별 PR 로 순차. 리뷰 granularity 증가.
+총 소요 시간 ≈ **4시간 (wall-clock)**
+
+→ **옵션 A 를 기본 권장**. SEC-BC 통합 PR 은 reviewer 가 "lockfile 변경은 `npm install` + `npm audit fix` 두 번 실행의 산물" 임을 본문에 명시하면 검수 가능.
+
+---
+
+## 4. Risk Budget
+
+### 4.1 최악의 경우 (Worst-case) 소요 시간
+
+| 단계 | SEC-A | SEC-B | SEC-C | 합계 (순차) | 합계 (병렬) |
+|-----|-------|-------|-------|----------|----------|
+| 코드 변경 | 10m | 20m | 15m | 45m | 20m (max) |
+| 로컬 테스트 | 20m | 60m | 45m | 2h 05m | 60m (max) |
+| CI 파이프라인 | 25m | 25m | 25m | 1h 15m | 25m (max) |
+| K8s smoke | 0 | 30m | 30m | 60m | 30m (max) |
+| 리뷰 대기 / 수정 | 20m | 40m | 20m | 1h 20m | 40m (max) |
+| **합계** | **1h 15m** | **2h 55m** | **2h 15m** | **6h 25m** | **2h 55m** |
+
+### 4.2 리스크 시나리오
+
+| 시나리오 | 가능성 | 영향 | 대응 |
+|---------|------|-----|-----|
+| Next 15.5 Playwright 회귀 5건 이상 | 중 | HIGH | qa 가 failing test 수집 → frontend-dev 가 next 15.5 release note 검토 → 부분 롤백 또는 패치 |
+| Go 1.25 에서 gorilla/websocket 호환 이슈 | 낮음 | MED | 테스트 4건 fail 시 go-redis 만 먼저 bump, Go 는 1.24.13 으로 downgrade |
+| @nestjs/core v10 과 axios v1.15 간 peer dependency 충돌 | 낮음 | LOW | `--legacy-peer-deps` 로 우회 (ai-adapter 는 이미 허용 중) |
+| lockfile diff 가 너무 커서 리뷰 보류 | 중 | LOW | PR 본문에 `diff --stat` 요약 + "lockfile 은 `npm install` 재생성 산물" 명시 |
+| CI runner 캐시 miss 로 파이프라인 20m → 40m | 중 | LOW | 첫 실행만 느림, 2회차부터 정상화 |
+
+### 4.3 Rollback 계획
+
+- **SEC-A**: `git revert` 1 커밋. go.mod / Dockerfile 간단 복귀
+- **SEC-B**: `git revert` 1 커밋. lockfile 포함 revert
+- **SEC-C**: `git revert` 1 커밋. lockfile 복귀만
+
+Production 영향 지표:
+- game-server: govulncheck regression
+- frontend/admin: Playwright smoke, Real User Monitoring 에러율
+
+---
+
+## 5. Phase 2 Recommendation — Go Now vs. Need User Decision
+
+### 5.1 **즉시 착수 가능 (Go Now)**
+
+| 항목 | 근거 |
+|-----|------|
+| **SEC-A** | 리스크 LOW, 감사 리포트 §4.1 P0 1순위, 독립 실행 가능. `devops` agent 로 바로 위임 가능 |
+| **SEC-C** | 리스크 LOW, 자동화 `npm audit fix`, SEC-B 와 한 브랜치로 묶을 것 |
+| **P0-1 / P0-2 항목 삭제** | 이미 완료 상태 확인, Sprint 7 TODO 정리만 하면 됨. pm 에이전트에게 위임 권장 |
+
+### 5.2 **사용자 결정 필요 (Need User GO)**
+
+| 항목 | 결정 사항 |
+|-----|---------|
+| **SEC-B 실행 형태** | Option A (SEC-BC 통합) vs. Option B (분리)? MEDIUM 리스크이므로 사용자가 리뷰 granularity 선호 방향 결정 권장 |
+| **Next 15.2 → 15.5 대신 15.3 단계적 upgrade?** | 감사 리포트는 15.5.15 직행을 권장. 단계적으로 하려면 15.3.x 거쳐 테스트 반복 필요 — 시간 소비 증가. 기본값 "15.5.15 직행" 권장 |
+| **Playwright E2E 4 FAIL 허용 게이트** | 현재 Ollama Known 4 FAIL 이 SEC-B 이후 다시 failing 할 수도 있음. "4 FAIL + 신규 0" 기준으로 GO 결정 필요 |
+| **CI `sca-npm-audit` + `sca-govulncheck` 신규 잡 추가** | 감사 리포트 §6 제안. SEC-A~C 마감 후 Sprint 7 Week 1 에 별도 PR 로 추가 (본 계획에는 포함하지 않음) |
+
+### 5.3 실행 순서 요약
+
+```mermaid
+gantt
+    title Sprint 7 Day 1 — 의존성 패치 실행 계획
+    dateFormat HH:mm
+    axisFormat %H:%M
+    section SEC-A (devops + go-dev)
+    go.mod bump          :a1, 09:00, 10m
+    go mod tidy          :a2, after a1, 5m
+    로컬 테스트          :a3, after a2, 20m
+    CI 파이프라인        :a4, after a3, 25m
+    리뷰 및 merge        :a5, after a4, 15m
+    section SEC-BC (frontend-dev + qa)
+    next+audit fix 조합    :b1, 09:00, 20m
+    npm install 재생성     :b2, after b1, 20m
+    Jest 실행              :b3, after b2, 15m
+    Playwright E2E         :b4, after b3, 45m
+    K8s smoke              :b5, after b4, 30m
+    리뷰 및 merge          :b6, after b5, 30m
+```
+
+**예상 완료**: **Day 1 오전 9시 시작 → 12~13시 두 PR 모두 merge 완료**. 이후 Day 12 backend 작업은 **P0 2건 모두 이미 해소**되어 추가 구현 불필요하므로, 오후 시간은 **Day 12 P2 잔여** (V-13a `ErrNoRearrangePerm` orphan 리팩터, V-13e 조커 재드래그 UX) 로 이관.
+
+---
+
+## 6. 후속 이슈 예방 체크리스트
+
+### 6.1 패치 완료 후 (Sprint 7 Week 1 중)
+
+- [ ] `.gitlab-ci.yml` 에 `sca-npm-audit` + `sca-govulncheck` + `weekly-dependency-audit` 잡 추가 (감사 리포트 §6)
+- [ ] `@nestjs/cli` 메이저 bump 11.x (P1, dev-only High 해소)
+- [ ] `@typescript-eslint/*` 7.6.0 bump (P1, dev-only High 해소)
+- [ ] `jest-environment-jsdom` 30.3.0 bump (P1, dev-only low × 4)
+- [ ] PR #38 본문의 `games ON CONFLICT DO NOTHING` PK 충돌 방어 (Sprint 7 Week 1 이관 TODO)
+
+### 6.2 Sprint 7 Week 2+
+
+- [ ] `@nestjs/core` 10.x → 11.x 메이저 bump (moderate injection 해소)
+- [ ] `gorm.io/gorm` v1.25 → v1.31, `pgx/v5` v5.6 → v5.9 (P3 drift 해소)
+- [ ] `cloud.google.com/go/*` 사용 여부 점검 후 미사용 시 제거
+
+---
+
+## 7. 최종 결론
+
+| 질문 | 답변 |
+|-----|-----|
+| 5개 항목 중 실제 작업 대상 | **3개** (SEC-A, SEC-B, SEC-C) |
+| 이미 해결된 항목 | **2개** (P0-1 `game_results` 는 `persistGameResult` + 3테이블로 완료, P0-2 `GAME_OVER` broadcast 는 8곳 경로 + frontend reducer 모두 wire 완료) |
+| 병렬 실행 시 총 소요 | **~3시간** (wall-clock) |
+| 순차 실행 시 총 소요 | **~6~7시간** |
+| 사용자 GO 필요 항목 | SEC-B (MEDIUM 리스크, 실행 형태 결정) |
+| 즉시 착수 항목 | SEC-A, SEC-C (SEC-B 와 통합 브랜치로 묶인 경우 포함) |
+
+**권장 실행 결정**:
+1. 본 계획서 read-only 검토 완료 후, 사용자 승인 즉시 **옵션 A (2 병렬 worktree)** 로 진행
+2. `devops` agent → SEC-A, `frontend-dev` + `qa` → SEC-BC
+3. Sprint 7 TODO 에서 "Day 12 backend P0-1/P0-2" 항목 제거 (pm 에이전트 후속)
+4. 감사 리포트 §6 의 CI 게이트 추가 건은 별도 Sprint 7 Week 1 PR 로 분리
+
+---
+
+## 부록 A. 변경 없음으로 판정한 근거 파일 Inventory
+
+| 항목 | 확인한 파일 | 결론 근거 |
+|-----|----------|---------|
+| P0-1 | `src/game-server/internal/handler/ws_handler.go:1917~2284` (persistGameResult) | 3테이블 INSERT 완전 wire, PR #38 merged |
+| P0-1 | `src/game-server/internal/handler/ws_persist_test.go` | 17개 시나리오 단위 테스트 |
+| P0-1 | `src/game-server/e2e/rooms_persistence_test.go` | 3 통합 시나리오 (PR #42) |
+| P0-1 | `src/game-server/internal/repository/postgres_repo.go` | CreateGame / CreateGamePlayer / CreateGameEvent 메서드 |
+| P0-2 | `src/game-server/internal/handler/ws_handler.go:474, 522, 822, 1006, 1062, 1109, 1271, 1466, 1585, 1626` | broadcast 8 경로 + FromState variant |
+| P0-2 | `src/game-server/internal/handler/ws_message.go:26, 193` | S2CGameOver + GameOverPayload |
+| P0-2 | `src/frontend/src/hooks/useWebSocket.ts:322` | Frontend reducer case |
+| P0-2 | `src/frontend/src/store/gameStore.ts:87, 136, 184` | gameOverResult state + action |
+| P0-2 | `src/frontend/src/app/game/[roomId]/GameClient.tsx:466, 1277` | UI 렌더링 |
+
+## 부록 B. 감사 리포트와의 역추적
+
+| 감사 리포트 §4.1 권장 | 본 계획서 매핑 |
+|-------------------|-------------|
+| (1) Go toolchain bump | SEC-A |
+| (2) go-redis bump | SEC-A (번들) |
+| (3) next (frontend) bump | SEC-B |
+| (4) next (admin) bump | SEC-B |
+| (5) axios update | SEC-C |
+
+감사 리포트 §4.2 P1 (typescript-eslint / @nestjs/cli / jest-env-jsdom bump) 는 본 계획서 §6.1 로 이관.

--- a/docs/04-testing/76-issue-47-48-49-impact-and-plan.md
+++ b/docs/04-testing/76-issue-47-48-49-impact-and-plan.md
@@ -1,0 +1,394 @@
+# Issue #47 / #48 / #49 — 영향 분석 및 수정 계획서
+
+- **작성일**: 2026-04-22 (Sprint 7 Day 1)
+- **작성자**: architect agent (Opus 4.7 xhigh)
+- **대상 이슈**: #47 (V-SPRINT7-RACE-01), #48 (V-SPRINT7-RACE-02), #49 (FINDING-02)
+- **출력 성격**: Read-only 영향 분석 + 수정 계획. **코드 수정 없음**.
+- **참조 문서**:
+  - `docs/04-testing/73-finding-01-root-cause-analysis.md` (architect 원 판정)
+  - `docs/04-testing/74-warn-items-impact-assessment.md` (WARN 평가)
+
+---
+
+## 1. Executive summary
+
+| Issue | 제목 | 판정 | 사유 요약 |
+|-------|------|------|-----------|
+| #47 | LeaveRoom PLAYING guard | **PROCEED** | 2h, 깨끗한 서버 측 방어 계층. checkDuplicateRoom 자기 호출(L478)과 충돌 없음을 확인 |
+| #48 | handleConfirm in-flight lock | **PROCEED** | 1h, 순수 클라이언트 state, WS 계약 변경 없음. PR #51(A3/A4) 위에 깔끔히 얹힘 |
+| #49 | day11 fixture 결함 | **ALTERNATIVE (옵션 A)** | 옵션 B는 PracticeBoard 리팩터 150+ LOC, 옵션 A 는 30 LOC. 설계 관점에서 practice 모드에 pending 개념 불필요 |
+
+전체 소요 시간: **3h ~ 4h** (병렬 실행 시 실질 2h)
+
+---
+
+## 2. Issue #47 — V-SPRINT7-RACE-01 LeaveRoom PLAYING guard
+
+### 2.1 Current state
+
+**파일**: `src/game-server/internal/service/room_service.go` L302-350
+
+```go
+func (s *roomService) LeaveRoom(roomID, userID string) (*model.RoomState, error) {
+	room, err := s.roomRepo.GetRoom(roomID)
+	// ...
+	if room.Status == model.RoomStatusFinished || room.Status == model.RoomStatusCancelled {
+		return nil, &ServiceError{Code: "INVALID_REQUEST", ...}
+	}
+	// PLAYING 체크 없음 → race window
+```
+
+**발견된 유의사항** (architect 분석):
+
+1. **Self-call at L478** — `checkDuplicateRoom` 는 WAITING 방에 참가 중인 사용자가 새 방을 만들 때 기존 방에서 자동 퇴장시키기 위해 `s.LeaveRoom(existingRoomID, userID)` 를 호출한다. 이 경로는 **WAITING** 방만 대상으로 가드된다(L475-479). PLAYING 가드를 추가해도 이 self-call 은 WAITING 상태에서만 실행되므로 영향 없음.
+2. **Frontend caller** (`WaitingRoomClient.tsx` L245) — 실패해도 로비로 이동하도록 try/catch 로 감싸져 있어(L246) 새 에러 코드가 새어 나와도 UX 깨지지 않음.
+3. **RoomHandler** (`room_handler.go` L191-204) — ServiceError 를 그대로 상태 코드로 매핑하므로 409 반환 동작 자연스러움.
+
+### 2.2 Proposed fix
+
+`room.Status == model.RoomStatusPlaying` 일 때 `GAME_IN_PROGRESS` 에러로 차단. **단, 호스트는 취소(forfeit) 로직으로 별도 경로를 이미 가진다** — LeaveRoom 은 "대기실 방 나가기" 용도로 의미를 좁힌다.
+
+```go
+// PLAYING 상태에서는 LeaveRoom 차단 (V-SPRINT7-RACE-01)
+// 게임 진행 중 이탈은 FORFEIT 경로를 통해서만 허용한다.
+if room.Status == model.RoomStatusPlaying {
+	return nil, &ServiceError{
+		Code:    "GAME_IN_PROGRESS",
+		Message: "게임 진행 중에는 방을 나갈 수 없습니다. 기권 기능을 이용하세요.",
+		Status:  409,
+	}
+}
+```
+
+에러 코드는 **`GAME_IN_PROGRESS`** 신설. 409 Conflict.
+
+### 2.3 Risk level
+
+- **LOW**. 서버 측 방어 추가만, 기존 정상 경로 변경 없음.
+- **Breaking change flag**: 없음. 현재 정상 UI(WaitingRoomClient)는 PLAYING 상태에서 LeaveRoom 호출을 발생시키지 않는다. GameClient 의 기권/종료 경로는 LeaveRoom 대신 `FinishRoom` 또는 WS 이벤트를 사용한다.
+- **잠재 회귀**: `room_service_test.go` 기존 테스트(L118)는 WAITING 방에서 퇴장 → 영향 없음.
+
+### 2.4 Verification plan
+
+**신규 테스트 3건** (`room_service_test.go`):
+
+1. `TestLeaveRoom_RejectsPlayingStatus` — CreateRoom → JoinRoom(2인) → StartGame → LeaveRoom(호스트/게스트) → **모두 409 GAME_IN_PROGRESS 반환**.
+2. `TestLeaveRoom_AllowsWaitingStatus` — 기존 회귀 보호. WAITING 에서 정상 퇴장.
+3. `TestCheckDuplicateRoom_StillWorksOnWaiting` — WAITING 방 자동 퇴장 경로(L478) 회귀 방지.
+
+기존 E2E 에 끼칠 영향 없음 (UI에서 PLAYING 중 LeaveRoom 버튼 노출 없음).
+
+### 2.5 Estimated duration
+
+**2h** (분석/계획 완료, 구현 30m + 테스트 60m + 검증 30m).
+
+### 2.6 Recommended agent
+
+**go-dev** (sonnet-4-6).
+
+### 2.7 Branch naming
+
+`fix/issue-47-leave-room-playing-guard`
+
+---
+
+## 3. Issue #48 — V-SPRINT7-RACE-02 handleConfirm in-flight lock
+
+### 3.1 Current state
+
+**파일**: `src/frontend/src/app/game/[roomId]/GameClient.tsx` L1139-1240 (handleConfirm)
+
+```tsx
+const handleConfirm = useCallback(() => {
+  if (!pendingTableGroups) return;
+  if (!pendingMyTiles) return;
+  // ... 검증 로직 ...
+  send("PLACE_TILES", { ... });
+  send("CONFIRM_TURN", { ... });
+}, [...]);
+```
+
+**발견된 사실**:
+
+1. **No in-flight lock**. 버튼은 `!isMyTurn || !hasPending || !allGroupsValid` 으로만 비활성화됨 (`ActionBar.tsx` L124). ACK 대기 상태는 없음.
+2. **TURN_END → pending reset** 은 TURN_START 핸들러에서 이루어짐 (주석 L1136-1138). 따라서 서버가 TURN_END 보내기 전에 사용자가 확정 버튼을 재클릭하면 동일한 PLACE_TILES + CONFIRM_TURN 이 중복 발사됨.
+3. **서버 측**: 중복 CONFIRM_TURN 은 이미 서버 턴이 넘어간 상태에서 오면 INVALID_MOVE 로 반려됨 → ErrorToast 1회 노출. 실제 게임 진행은 깨지지 않음.
+4. **Auth/세션/WS 전역 상태**: `useWSStore` 는 connected/lastError/disconnectedPlayers 만 관리. in-flight 개념 미존재 → 추가는 로컬 state 로 국한.
+
+### 3.2 Proposed fix
+
+**로컬 `confirmBusy` state + 두 해제 경로**.
+
+```tsx
+const [confirmBusy, setConfirmBusy] = useState(false);
+
+const handleConfirm = useCallback(() => {
+  if (confirmBusy) return;               // [1] 중복 클릭 차단
+  if (!pendingTableGroups) return;
+  if (!pendingMyTiles) return;
+  // ... 기존 검증 ...
+
+  setConfirmBusy(true);                  // [2] 전송 직전 락
+  send("PLACE_TILES", { ... });
+  send("CONFIRM_TURN", { ... });
+}, [confirmBusy, ...]);
+
+// 락 해제 — TURN_START(성공) 또는 INVALID_MOVE(실패) 후
+useEffect(() => {
+  if (!pendingTableGroups && confirmBusy) {
+    setConfirmBusy(false);               // [3] reset 트리거 후 해제
+  }
+}, [pendingTableGroups, confirmBusy]);
+```
+
+**ActionBar 에 prop 추가**:
+
+```tsx
+<ActionBar
+  ...
+  confirmBusy={confirmBusy}
+  onConfirm={handleConfirm}
+/>
+
+// ActionBar.tsx
+disabled={!isMyTurn || !hasPending || !allGroupsValid || confirmBusy}
+```
+
+**대안 검토 및 기각**:
+- ❌ Ref-based lock (useRef) — state 변경으로 버튼 disabled 재렌더 필요.
+- ❌ Promise.race with timeout — WS `send` 는 fire-and-forget. timeout 없이 TURN_START/INVALID_MOVE 이벤트 기반 해제가 더 정확.
+- ❌ useWSStore 에 globalBusy 추가 — handleConfirm 한 곳만 필요. 지역 state 로 스코프 최소화.
+
+### 3.3 Risk level
+
+- **LOW**. 기존 로직 변경 없음, 순수 가산.
+- **Breaking change flag**: 없음. ActionBar prop 추가는 optional prop으로 설계 (`confirmBusy?: boolean`).
+- **잠재 회귀**: `confirmBusy` 해제 조건이 잘못되면 버튼 영구 disabled 위험. effect 의존성에 `pendingTableGroups` 포함 필수. 테스트로 방어.
+
+### 3.4 Verification plan
+
+**Jest 단위 테스트 2건** (ActionBar.test.tsx):
+1. `confirmBusy=true` 일 때 확정 버튼 disabled.
+2. `confirmBusy=false` + 기존 조건 만족 시 enabled.
+
+**Playwright E2E 1건** (신규 `hotfix-confirm-busy.spec.ts`):
+- 확정 버튼 연속 2회 클릭 시 WS 메시지 카운트 = 2 (PLACE_TILES + CONFIRM_TURN). 기존 구현에서는 4가 나와야 회귀 감지 가능.
+- 단, WS mock 설정이 복잡하므로 Jest 로 대체 가능.
+
+### 3.5 Estimated duration
+
+**1h** (구현 20m + 테스트 25m + 검증 15m).
+
+### 3.6 Recommended agent
+
+**frontend-dev** (sonnet-4-6).
+
+### 3.7 Branch naming
+
+`fix/issue-48-confirm-busy-lock`
+
+---
+
+## 4. Issue #49 — FINDING-02 day11 fixture 결함 (특별 분석)
+
+### 4.1 Current state
+
+**실패 테스트 3건** (`src/frontend/e2e/day11-ui-bug-fixes.spec.ts`):
+
+| 테스트 | 기대 | 실제 동작 | 원인 |
+|--------|------|-----------|------|
+| T-B1-01 | 보드 첫 타일 드롭 후 "미확정" 라벨 표시 | 라벨 미표시 | PracticeBoard → GameBoard 에 `pendingGroupIds` prop 미전달 → `isPending=false` → 라벨 `return null` |
+| T-BNEW-01 | 단일 타일 드롭 시 "미확정" 라벨 | 라벨 미표시 | 동일 |
+| T7-02 | `R1a` 드래그 후 확정 버튼 disabled | `dragTileToBoard` 에서 `R1a` 타일 locator 못 찾음 → timeout / silent fail | stage 1 hand 에 `R1a` 없음 (`["R7a", "B7a", "Y7a", "K7a", "R3a", "B5a"]`) |
+
+### 4.2 코드 검증 (증거)
+
+**GameBoard.tsx L313, L333** (라벨 렌더 조건):
+```tsx
+const isPending = pendingGroupIds.has(group.id);
+// ...
+const pendingLabelText = (() => {
+  if (!isPending) return null;   // ← practice 모드에서 항상 null
+  // ...
+})();
+```
+
+**PracticeBoard.tsx L353-359** (prop 전달):
+```tsx
+<GameBoard
+  tableGroups={tableGroups}
+  isMyTurn
+  isDragging={isDragging}
+  groupsDroppable
+  className="flex-1 min-h-[180px]"
+  // ← pendingGroupIds 미전달 → default Set<string>() (빈 세트)
+/>
+```
+
+### 4.3 Option A vs B vs C 평가
+
+#### Option A — 테스트 기대치 수정 (권장)
+
+테스트를 "practice 모드에서는 미확정 라벨이 없다" 라는 설계 사실에 맞춰 재작성한다.
+
+- **수정 범위**: `day11-ui-bug-fixes.spec.ts` 3개 테스트만.
+- **LOC**: ~30 lines (삭제 + 보드 타일 존재 DOM 검사로 대체).
+- **PracticeBoard/GameBoard 변경**: 없음.
+- **설계 정합성**: 높음. Practice 모드는 서버 없이 로컬 검증만 하므로 "서버 미확정" 개념 자체가 부적절.
+- **리스크**: 매우 낮음. Practice-mode-only UI 테스트로 축소.
+
+#### Option B — PracticeBoard 리팩터
+
+PracticeBoard 에 pending/committed 개념 도입. 타일 드롭 → pending → "확정" 버튼 → committed.
+
+- **수정 범위**:
+  - PracticeBoard.tsx: 신규 state `pendingGroupIds: Set<string>`, drop 시 추가, reset 시 비우기.
+  - GameBoard prop 전달.
+  - 확정 핸들러에서 pendingGroupIds 정리.
+  - 모든 스테이지 E2E 흐름 영향 (확정 버튼 UX 변경 가능성).
+- **LOC**: ~120~150 lines + 기존 practice E2E 회귀 리스크.
+- **설계 정합성**: 낮음. Practice 는 단일 플레이어 로컬 연습이며 서버 round-trip 없다. "미확정" 은 서버 검증 대기 상태를 시각화하는 장치 → practice 에서는 잘못된 의미 전달.
+- **리스크**: 중. 기존 practice E2E (StageSelector, TutorialOverlay, Stage 1~6 완주 테스트) 회귀 가능성.
+
+#### Option C — T7-02 타일 코드 교체 (부분 적용)
+
+T7-02 만 `R1a` → `R7a` (stage 1 실제 hand) 로 교체. B-1/B-NEW 는 별도 처리 필요.
+
+- **수정 범위**: 1줄.
+- **LOC**: 1 line.
+- **적용성**: T7-02 에만 국한. B-1/B-NEW 는 여전히 FAIL.
+
+### 4.4 권장 — **Option A + C 결합**
+
+**근거**:
+1. 설계 정합성: Practice 모드는 "서버 미확정" 개념 불필요. Option B 는 practice 의 도메인 의미를 왜곡.
+2. 비용 효율: Option A 30 LOC vs Option B 150 LOC. 5배 차이.
+3. 안전성: 기존 practice 스테이지 스펙 회귀 리스크 제거.
+4. 테스트 본래 목적 달성: "day11 UI 버그 수정 검증" — 버그 자체는 이미 수정됐고, 테스트 fixture 만 stage 1 실제 환경에 맞추면 된다.
+
+### 4.5 구체적 수정안
+
+**B-1 (T-B1-01, T-B1-02)** — 기대치 변경:
+
+```tsx
+// 기존: await expect(pendingLabel).toBeVisible();
+// 변경: 타일이 보드에 배치됐음을 확인 (role="img" 카운트)
+const boardTiles = page.locator('section[aria-label="게임 테이블"] [role="img"]');
+await expect(boardTiles).toHaveCount(1, { timeout: 3000 });  // 첫 드롭 후 1개
+```
+
+**B-NEW (T-BNEW-01, T-BNEW-02)** — 기대치 변경:
+
+```tsx
+// T-BNEW-01: 단일 타일 드롭 시 그룹 라벨 "그룹" 또는 "런" 단독 (미확정 suffix 없음)
+const groupLabel = page.locator('section[aria-label="게임 테이블"]').locator('text=/^(그룹|런)$/');
+await expect(groupLabel.first()).toBeVisible({ timeout: 3000 });
+
+// T-BNEW-02: 같은 색 연속 드롭 → 보드 타일 2개
+const boardTiles = page.locator('section[aria-label="게임 테이블"] [role="img"]');
+await expect(boardTiles).toHaveCount(2, { timeout: 3000 });
+```
+
+**T7-02** — 타일 코드 교체:
+
+```tsx
+// 기존: await dragTileToBoard(page, "R1a");
+// 변경: stage 1 실제 hand 에 있는 R7a
+await dragTileToBoard(page, "R7a");
+// 나머지 assertion 동일 (1개 타일이므로 클리어 불가 → 확정 disabled)
+```
+
+### 4.6 PracticeBoard 리팩터 LOC 추정 (Option B 기각 근거)
+
+| 수정 항목 | 예상 LOC |
+|-----------|----------|
+| `pendingGroupIds: Set<string>` state 추가 + clear/add 핸들러 | ~30 |
+| handleDragEnd 3경로(기존그룹추가/새그룹/보드→랙)에 pendingGroupIds 업데이트 | ~40 |
+| handleConfirm 성공 시 pendingGroupIds 비우기 + committed 로직 | ~30 |
+| handleReset / handleUndo 경로에 초기화 추가 | ~15 |
+| GameBoard prop 전달 + 검증 | ~10 |
+| 기존 practice E2E 회귀 수정 (StageSelector/Tutorial 플로우) | ~25 |
+| **합계** | **~150 LOC** |
+
+### 4.7 Risk level
+
+- **VERY LOW** (Option A+C). 테스트 전용 수정, 프로덕션 코드 변경 없음.
+
+### 4.8 Verification plan
+
+1. `npx playwright test e2e/day11-ui-bug-fixes.spec.ts` 3건 PASS 확인.
+2. 기존 PASS 테스트(T-B1/B-NEW/T7 외) 회귀 없음 확인.
+3. Full E2E 스위트 (Jest + Playwright) 통과.
+
+### 4.9 Estimated duration
+
+- **Option A+C**: **1.5h** (수정 30m + E2E 검증 + 회귀 40m + 문서 20m).
+- Option B 는 **4~6h**.
+
+### 4.10 Recommended agent
+
+**qa** (Opus 4.7 xhigh — 테스트 설계 의도 판단 필요) + **frontend-dev** (sonnet-4-6, 수정 실행).
+
+### 4.11 Branch naming
+
+`fix/issue-49-day11-fixture`
+
+---
+
+## 5. Parallel execution matrix
+
+| 이슈 | 파일 디렉토리 | 에이전트 | 의존성 | 병렬 가능? |
+|------|---------------|----------|--------|-----------|
+| #47 | `src/game-server/` | go-dev | — | ✅ |
+| #48 | `src/frontend/src/app/game/` + `components/game/ActionBar.tsx` | frontend-dev | — | ✅ |
+| #49 | `src/frontend/e2e/` | qa + frontend-dev | — | ⚠️ #48 과 디렉토리 겹침 |
+
+### 5.1 Worktree 분리 전략
+
+**권장 구성**:
+
+```
+/mnt/d/Users/KTDS/Documents/06.과제/RummiArena           (main)
+/mnt/d/Users/KTDS/Documents/06.과제/RummiArena-i47       (worktree: fix/issue-47-leave-room-playing-guard)
+/mnt/d/Users/KTDS/Documents/06.과제/RummiArena-i48-49    (worktree: fix/issue-48-49-frontend-batch)
+```
+
+- #47: 완전 독립 (game-server 전용) → 병렬 가능.
+- #48 + #49: **frontend 영역 중복** (특히 #48 이 ActionBar.tsx 건드리고 #49 가 practice E2E 만 건드리지만, 같은 frontend 빌드 사이클). 같은 worktree 에서 **순차 실행** 또는 별도 worktree 2개.
+
+**Simplest path**: worktree 2개 (#47 단독, #48+#49 batch). PR 은 각자 분리.
+
+### 5.2 PR 분리 전략
+
+- **PR A**: #47 — backend only, 작고 명확.
+- **PR B**: #48 — frontend logic only.
+- **PR C**: #49 — E2E fixture only.
+
+(또는 #48+#49 한 PR 로 묶어도 가능하나, 리뷰 관점에서 분리 권장)
+
+---
+
+## 6. "Go now" vs "Need user decision"
+
+### 6.1 Go now (architect 권한 내 즉시 진행)
+
+- ✅ **#47** — 설계 명확, 에러 코드 `GAME_IN_PROGRESS` 신설 정당화됨. go-dev 할당.
+- ✅ **#48** — 설계 명확, ActionBar prop 추가 scope 명확. frontend-dev 할당.
+- ✅ **#49 Option A+C** — 테스트 fixture 수정만. 프로덕션 코드 무변경. qa+frontend-dev 할당.
+
+### 6.2 Need user decision
+
+- ❓ **Practice 모드 "pending" 도입 여부** (향후 로드맵 판단) — Option B 를 채택하지 않는다는 것은 "practice 는 서버 round-trip 없는 단일 플레이어 연습" 이라는 설계 고정을 의미. 향후 "practice 모드에서도 확정 플로우를 연습시켜야 한다" 는 요구가 생기면 별도 리팩터 검토 필요. 현 시점 사용자 확인 없이 Option A 로 가도 무방 (설계 원 의도가 그러했음).
+- ❓ **#47 커버리지 — FORFEIT/기권 경로 전면 점검 여부** — LeaveRoom 을 PLAYING 에서 차단하면 "게임 중 나가기" UX 는 모두 FORFEIT 로 몰림. FORFEIT UI/로직이 충분한지는 Sprint 7 별도 점검 과제. **이번 PR 범위는 가드 추가로 한정 권장**.
+
+---
+
+## 7. 부록 — 향후 연관 작업
+
+- Sprint 7 Week 2: FORFEIT 경로 완결성 점검 (#47 후속)
+- Sprint 7 Week 2: `pendingGroupIds` 가 practice 에서 의미 없다는 사실을 `docs/02-design/` 에 명시 (설계 문서화)
+- Sprint 8 후보: ActionBar disabled 상태 전수 점검 (confirmBusy 외 다른 race 존재 여부)
+
+---
+
+**문서 끝.**


### PR DESCRIPTION
## Summary

이번 세션(2026-04-22) 에서 수행된 3건 영향도 분석 문서를 main 에 자산화. 다음 세션에서 구현 착수 시 참조.

## 문서

| 파일 | 내용 | 라인 |
|---|---|---|
| `74-warn-items-impact-assessment.md` | WARN-01~04 triage 결과 (PR #50 참조) | 274 |
| `75-sec-day12-impact-and-plan.md` | SEC-REV-013 3PR + Day 12 P0 영향도 + 병렬 실행 계획 | 457 |
| `76-issue-47-48-49-impact-and-plan.md` | Issue #47/#48/#49 수정 명세 | 379 |

## 핵심 발견 (architect 분석)

### Day 12 backend P0 재평가
- **P0-1** (game_results persistence): **이미 해결됨** — `game_results` 테이블 부재 확인, `persistGameResult` 는 games/game_players/game_events 에 기록 (PR #38 + #42)
- **P0-2** (GAME_OVER broadcast): **이미 해결됨** — 8 broadcast call-sites + frontend reducer 연결 확인 (PR #38 commit c4b566a)

→ **Sprint 7 Day 1 오후 자유로워짐** (V-13a refactor + V-13e joker UX 이동 가능)

### SEC-REV-013 실행 계획
- SEC-A (Go 1.25.9 + go-redis 9.7.3): LOW risk, 4 파일 ~11 LOC
- SEC-B (Next 15.2→15.5 + admin 16.1→16.2): MEDIUM risk, 3-minor jump, Playwright regression 필수
- SEC-C (npm audit fix): SEC-B 와 동일 브랜치 권장 (lockfile 충돌 방지)
- 병렬 실행 시 wall-clock ~3h

### Issue #47/#48/#49
- #47 LeaveRoom PLAYING guard — 2h, go-dev
- #48 handleConfirm confirmBusy state — 1h, frontend-dev
- #49 FINDING-02 **Option A+C 권장** — test fixture 수정 (~30 LOC), PracticeBoard 리팩터 기각 (150 LOC, 설계 왜곡)
- 병렬 실행 시 wall-clock ~2h

## 다음 세션 재개 가이드

1. `docs/04-testing/75-*.md` 읽고 SEC-A + SEC-BC 2 워크트리 분할
2. `docs/04-testing/76-*.md` 읽고 #47 (go-dev backend) + #48/#49 (frontend) 병렬
3. 각 구현 에이전트에 SKILL 매핑 명시: `code-modification` + `ui-regression`/`layered-architecture-enforcer` + `simplify` + `pre-deploy-playbook` + `pr-workflow`

## Test plan

- [x] 3개 문서 마크다운 문법 검증 (architect 작성)
- 코드 변경 없음 — 문서 자산만

## 머지 전략

**L6 auto squash merge** — docs 전용, 리스크 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)