### PR TITLE
fix(#47): LeaveRoom PLAYING 상태 가드 추가 (GAME_IN_PROGRESS 409)

### DIFF
--- a/src/game-server/internal/service/room_service.go
+++ b/src/game-server/internal/service/room_service.go
@@ -309,6 +309,16 @@ func (s *roomService) LeaveRoom(roomID, userID string) (*model.RoomState, error)
 		return nil, &ServiceError{Code: "INVALID_REQUEST", Message: "이미 종료된 방입니다.", Status: 400}
 	}
 
+	// PLAYING 상태에서는 LeaveRoom 차단 (V-SPRINT7-RACE-01)
+	// 게임 진행 중 이탈은 FORFEIT 경로를 통해서만 허용한다.
+	if room.Status == model.RoomStatusPlaying {
+		return nil, &ServiceError{
+			Code:    "GAME_IN_PROGRESS",
+			Message: "게임 진행 중에는 방을 나갈 수 없습니다. 기권 기능을 이용하세요.",
+			Status:  409,
+		}
+	}
+
 	found := false
 	for i, p := range room.Players {
 		if p.UserID == userID {

--- a/src/game-server/internal/service/room_service_test.go
+++ b/src/game-server/internal/service/room_service_test.go
@@ -704,3 +704,113 @@ func TestRoomService_DualWrite_GuestHost_SkipsDB(t *testing.T) {
 	defer mock.mu.Unlock()
 	assert.Len(t, mock.createRoomCalls, 0, "비-UUID 호스트는 DB 쓰기 스킵")
 }
+
+// ============================================================
+// Issue #47 — V-SPRINT7-RACE-01: LeaveRoom PLAYING 상태 가드
+// ============================================================
+
+// TestLeaveRoom_RejectsPlayingStatus
+// PLAYING 상태 방에서 LeaveRoom을 호출하면 409 GAME_IN_PROGRESS를 반환한다.
+// 호스트와 게스트 모두 동일하게 차단된다.
+func TestLeaveRoom_RejectsPlayingStatus(t *testing.T) {
+	svc := newRoomService(t)
+
+	// 방 생성 (호스트)
+	room, err := svc.CreateRoom(&CreateRoomRequest{
+		Name:           "진행 중 방",
+		PlayerCount:    2,
+		TurnTimeoutSec: 60,
+		HostUserID:     "host-playing-guard",
+	})
+	require.NoError(t, err)
+
+	// 게스트 참가
+	err = svc.JoinRoom(room.ID, "guest-playing-guard", "게스트")
+	require.NoError(t, err)
+
+	// 게임 시작 → PLAYING 상태
+	_, err = svc.StartGame(room.ID, "host-playing-guard")
+	require.NoError(t, err)
+
+	// 호스트 LeaveRoom 시도 → 차단
+	_, err = svc.LeaveRoom(room.ID, "host-playing-guard")
+	require.Error(t, err, "PLAYING 상태에서 호스트 LeaveRoom은 에러를 반환해야 한다")
+	se, ok := IsServiceError(err)
+	require.True(t, ok, "ServiceError 타입이어야 한다")
+	assert.Equal(t, "GAME_IN_PROGRESS", se.Code)
+	assert.Equal(t, 409, se.Status)
+
+	// 게스트 LeaveRoom 시도 → 차단
+	_, err = svc.LeaveRoom(room.ID, "guest-playing-guard")
+	require.Error(t, err, "PLAYING 상태에서 게스트 LeaveRoom은 에러를 반환해야 한다")
+	se, ok = IsServiceError(err)
+	require.True(t, ok, "ServiceError 타입이어야 한다")
+	assert.Equal(t, "GAME_IN_PROGRESS", se.Code)
+	assert.Equal(t, 409, se.Status)
+}
+
+// TestLeaveRoom_AllowsWaitingStatus
+// WAITING 상태 방에서 LeaveRoom은 정상 동작한다 (회귀 방지).
+func TestLeaveRoom_AllowsWaitingStatus(t *testing.T) {
+	svc := newRoomService(t)
+
+	// 방 생성
+	room, err := svc.CreateRoom(&CreateRoomRequest{
+		Name:           "대기 중 방",
+		PlayerCount:    2,
+		TurnTimeoutSec: 60,
+		HostUserID:     "host-waiting-leave",
+	})
+	require.NoError(t, err)
+
+	// 게스트 참가
+	err = svc.JoinRoom(room.ID, "guest-waiting-leave", "게스트")
+	require.NoError(t, err)
+
+	// 게스트 LeaveRoom → WAITING 상태이므로 정상 퇴장
+	result, err := svc.LeaveRoom(room.ID, "guest-waiting-leave")
+	require.NoError(t, err, "WAITING 상태에서 LeaveRoom은 성공해야 한다")
+	require.NotNil(t, result)
+	assert.Equal(t, room.ID, result.ID)
+
+	// seat이 EMPTY로 초기화됐는지 확인
+	found := false
+	for _, p := range result.Players {
+		if p.UserID == "guest-waiting-leave" {
+			found = true
+			break
+		}
+	}
+	assert.False(t, found, "퇴장한 게스트는 Players 목록에서 제거돼야 한다")
+}
+
+// TestCheckDuplicateRoom_StillWorksOnWaiting
+// checkDuplicateRoom의 self-call(L478) 경로 — WAITING 방 자동 퇴장이 정상 동작하는지 확인.
+// PLAYING 가드 추가 후에도 이 경로는 영향받지 않아야 한다.
+func TestCheckDuplicateRoom_StillWorksOnWaiting(t *testing.T) {
+	svc := newRoomService(t)
+
+	// user가 WAITING 방 A를 생성
+	roomA, err := svc.CreateRoom(&CreateRoomRequest{
+		Name:           "방 A",
+		PlayerCount:    2,
+		TurnTimeoutSec: 60,
+		HostUserID:     "host-dup-check",
+	})
+	require.NoError(t, err)
+
+	// 같은 user가 방 B를 생성 시도 → checkDuplicateRoom이 WAITING 방 A에서 자동 퇴장 후 성공
+	_, err = svc.CreateRoom(&CreateRoomRequest{
+		Name:           "방 B",
+		PlayerCount:    2,
+		TurnTimeoutSec: 60,
+		HostUserID:     "host-dup-check",
+	})
+	require.NoError(t, err, "WAITING 방 A 자동 퇴장 후 방 B 생성은 성공해야 한다")
+
+	// 방 A는 CANCELLED 상태가 됐어야 한다 (호스트가 떠났으므로)
+	roomAState, err := svc.GetRoom(roomA.ID)
+	require.NoError(t, err)
+	assert.Equal(t, model.RoomStatusCancelled, roomAState.Status,
+		"호스트가 자동 퇴장한 방 A는 CANCELLED 상태여야 한다")
+}


### PR DESCRIPTION
## Summary

Closes #47

- `LeaveRoom` 함수에 PLAYING 상태 차단 가드 추가 (V-SPRINT7-RACE-01)
- PLAYING 방에서 LeaveRoom 호출 시 409 `GAME_IN_PROGRESS` 반환
- 게임 진행 중 이탈은 FORFEIT 경로를 통해서만 허용하도록 의미 명확화

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `src/game-server/internal/service/room_service.go` | LeaveRoom에 PLAYING 가드 10줄 추가 |
| `src/game-server/internal/service/room_service_test.go` | 신규 테스트 3건 (+110줄) |

## 영향 분석

- 영향 분석 문서: `docs/04-testing/76-issue-47-48-49-impact-and-plan.md` §2
- `checkDuplicateRoom` L478 self-call은 WAITING 방만 대상 → 영향 없음 확인
- 프론트엔드 `WaitingRoomClient.tsx` L245의 LeaveRoom 호출자는 PLAYING 상태에서 LeaveRoom 버튼을 노출하지 않음 → Breaking change 없음

## 테스트 결과

신규 테스트 3건:
- `TestLeaveRoom_RejectsPlayingStatus` — 호스트/게스트 모두 409 GAME_IN_PROGRESS 반환 확인
- `TestLeaveRoom_AllowsWaitingStatus` — WAITING 방 정상 퇴장 회귀 방지
- `TestCheckDuplicateRoom_StillWorksOnWaiting` — self-call(L478) WAITING 자동 퇴장 경로 회귀 방지

전체 테스트: **533/533 PASS** (기존 530 + 신규 3)

```
ok  github.com/k82022603/RummiArena/game-server/e2e
ok  github.com/k82022603/RummiArena/game-server/internal/client
ok  github.com/k82022603/RummiArena/game-server/internal/config
ok  github.com/k82022603/RummiArena/game-server/internal/engine
ok  github.com/k82022603/RummiArena/game-server/internal/handler
ok  github.com/k82022603/RummiArena/game-server/internal/middleware
ok  github.com/k82022603/RummiArena/game-server/internal/service
```

`go vet ./...` 경고 없음.

## 리스크

**LOW** — 서버 방어 계층 추가만. 기존 정상 경로 (WAITING 퇴장, 게임 종료 후 방 나가기) 무변경.
롤백: `git revert b44050a`

🤖 Generated with [Claude Code](https://claude.com/claude-code)