### PR TITLE
fix(#48): handleConfirm confirmBusy state로 중복 확정 방지

### DIFF
--- a/src/frontend/src/app/game/[roomId]/GameClient.tsx
+++ b/src/frontend/src/app/game/[roomId]/GameClient.tsx
@@ -1132,11 +1132,24 @@ export default function GameClient({ roomId }: GameClientProps) {
     [pendingMyTiles, setPendingMyTiles, setMyTiles]
   );
 
+  // Issue #48: CONFIRM_TURN 전송 후 서버 응답(TURN_START or INVALID_MOVE) 대기 중 락
+  // — pendingTableGroups 가 null 로 reset 되면(TURN_START 핸들러) 자동 해제
+  const [confirmBusy, setConfirmBusy] = useState(false);
+
+  // 락 해제: pendingTableGroups 가 null/undefined 로 초기화될 때 (TURN_START 성공 또는 INVALID_MOVE 후)
+  // 의존성 배열: [pendingTableGroups, confirmBusy] 이 둘만 — 다른 값 포함 시 과도한 실행
+  useEffect(() => {
+    if (!pendingTableGroups && confirmBusy) {
+      setConfirmBusy(false);
+    }
+  }, [pendingTableGroups, confirmBusy]);
+
   // 턴 확정: 프리뷰 상태를 서버에 전송 후 확정
   // BUG-UI-006: pending 상태를 즉시 커밋하지 않음.
   // 서버가 TURN_END(성공)를 보내면 TURN_START 핸들러에서 resetPending() 으로 정리되고,
   // INVALID_MOVE(실패)를 보내면 resetPending() + ErrorToast 가 사유를 표시한다.
   const handleConfirm = useCallback(() => {
+    if (confirmBusy) return;               // [Issue #48] 서버 응답 대기 중 중복 클릭 차단
     if (!pendingTableGroups) return;
     // M-4: pendingMyTiles가 null이면 확정 차단
     if (!pendingMyTiles) return;
@@ -1220,6 +1233,8 @@ export default function GameClient({ roomId }: GameClientProps) {
     const tilesFromRack = myTiles.filter(
       (t) => !pendingMyTiles.includes(t)
     );
+    // [Issue #48] 전송 직전 락 설정 — TURN_START 또는 INVALID_MOVE 수신 시 useEffect 에서 해제
+    setConfirmBusy(true);
     // 1단계: 이번 턴 배치 내용을 서버에 전송
     send("PLACE_TILES", {
       tableGroups: pendingTableGroups,
@@ -1231,6 +1246,7 @@ export default function GameClient({ roomId }: GameClientProps) {
       tilesFromRack,
     });
   }, [
+    confirmBusy,
     pendingTableGroups,
     pendingMyTiles,
     pendingRecoveredJokers,
@@ -1544,6 +1560,7 @@ export default function GameClient({ roomId }: GameClientProps) {
                 hasPending={!!pendingTableGroups}
                 allGroupsValid={allGroupsValid}
                 drawPileCount={gameState?.drawPileCount}
+                confirmBusy={confirmBusy}
                 onDraw={handleDraw}
                 onUndo={handleUndo}
                 onConfirm={handleConfirm}

--- a/src/frontend/src/components/game/ActionBar.tsx
+++ b/src/frontend/src/components/game/ActionBar.tsx
@@ -9,6 +9,8 @@ export interface ActionBarProps {
   /** 모든 pending 그룹의 타일 수가 3개 이상인지 여부 */
   allGroupsValid?: boolean;
   drawPileCount?: number;
+  /** CONFIRM_TURN 전송 후 서버 응답 대기 중 여부 — 중복 클릭 방지 (Issue #48) */
+  confirmBusy?: boolean;
   onDraw: () => void;
   onUndo: () => void;
   onConfirm: () => void;
@@ -33,6 +35,7 @@ const ActionBar = memo(function ActionBar({
   hasPending,
   allGroupsValid = true,
   drawPileCount,
+  confirmBusy = false,
   onDraw,
   onUndo,
   onConfirm,
@@ -118,10 +121,11 @@ const ActionBar = memo(function ActionBar({
             </button>
 
             {/* 확정 버튼: C-3: 내 턴이고, pending 배치가 있고, 모든 그룹이 유효할 때만 활성 */}
+            {/* Issue #48: confirmBusy=true 이면 서버 응답 대기 중 — 중복 클릭 차단 */}
             <button
               type="button"
               onClick={onConfirm}
-              disabled={!isMyTurn || !hasPending || !allGroupsValid}
+              disabled={!isMyTurn || !hasPending || !allGroupsValid || confirmBusy}
               className={[
                 "flex-1 py-2.5 rounded-xl font-bold text-tile-sm",
                 "bg-warning text-gray-900 hover:bg-yellow-400",

--- a/src/frontend/src/components/game/__tests__/ActionBar.test.tsx
+++ b/src/frontend/src/components/game/__tests__/ActionBar.test.tsx
@@ -144,6 +144,38 @@ describe("ActionBar — 드로우/패스 버튼", () => {
   });
 });
 
+describe("ActionBar — confirmBusy (Issue #48 in-flight lock)", () => {
+  it("confirmBusy=true 이면 확정 버튼 disabled (서버 응답 대기 중)", () => {
+    render(
+      <ActionBar
+        isMyTurn={true}
+        hasPending={true}
+        allGroupsValid={true}
+        confirmBusy={true}
+        onDraw={noop}
+        onUndo={noop}
+        onConfirm={noop}
+      />
+    );
+    expect(screen.getByRole("button", { name: /확정/ })).toBeDisabled();
+  });
+
+  it("confirmBusy=false + 기존 조건 만족 시 확정 활성", () => {
+    render(
+      <ActionBar
+        isMyTurn={true}
+        hasPending={true}
+        allGroupsValid={true}
+        confirmBusy={false}
+        onDraw={noop}
+        onUndo={noop}
+        onConfirm={noop}
+      />
+    );
+    expect(screen.getByRole("button", { name: /확정/ })).toBeEnabled();
+  });
+});
+
 describe("ActionBar — 초기화 버튼", () => {
   it("hasPending=false → 초기화 비활성", () => {
     render(


### PR DESCRIPTION
## Summary

- `GameClient.tsx`: `confirmBusy` useState + useEffect 해제 로직 추가. CONFIRM_TURN 전송 직전 락 설정, pendingTableGroups null 리셋 시 자동 해제
- `ActionBar.tsx`: `confirmBusy?: boolean` optional prop 추가, disabled 조건에 포함
- `ActionBar.test.tsx`: Issue #48 신규 테스트 2건 추가

Closes #48

## 영향 분석

`docs/04-testing/76-issue-47-48-49-impact-and-plan.md` §3 참조

## 변경 파일

- `src/frontend/src/app/game/[roomId]/GameClient.tsx` — confirmBusy state + useEffect + handleConfirm guard + ActionBar prop 전달
- `src/frontend/src/components/game/ActionBar.tsx` — confirmBusy prop 추가, disabled 조건 확장
- `src/frontend/src/components/game/__tests__/ActionBar.test.tsx` — 신규 테스트 2건

## 의존성 배열 검증 로그

- `useEffect` deps: `[pendingTableGroups, confirmBusy]` 이 둘만.
  - `pendingTableGroups`: null 전환이 해제 트리거 조건이므로 필수
  - `confirmBusy`: effect 내부에서 참조하므로 필수 (eslint-react-hooks 규칙 준수)
  - 다른 값 없음: setConfirmBusy는 stable reference(useState setter), 포함 불필요
- `handleConfirm` useCallback deps: 기존 6개 + `confirmBusy` = 7개
  - confirmBusy 추가 이유: 함수 내부에서 `if (confirmBusy) return` 조건 참조

## 테스트 결과

Jest 203/203 PASS (기존 201 + 신규 2)
빌드: `npm run build` exit code 0

## 리스크

**LOW** — 순수 가산 변경. 기존 로직 변경 없음. ActionBar optional prop 추가로 기존 caller 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)