### PR TITLE
fix(v13a): ErrNoRearrangePerm 호출 경로 추가 — 최초 등록 전 재배치 시도 차단

### DIFF
--- a/docs/02-design/31-game-rule-traceability.md
+++ b/docs/02-design/31-game-rule-traceability.md
@@ -72,7 +72,7 @@ V-13은 단일 권한 검증이 아니라 **재배치 권한 + 4가지 재배치
 
 | 규칙 ID | 검증 항목 | Engine 구현 | Engine 테스트 | UI 구현 | UI 테스트(E2E) | Playtest | 종합 |
 |---------|----------|-----------|------------|--------|-------------|---------|------|
-| **V-13a** | 재배치 권한 (hasInitialMeld) | ⚠️ **간접 구현** — `ErrNoRearrangePerm` 상수 정의만 존재(`engine/errors.go:52`), 실제로는 `validator.go:100-104 validateInitialMeld` → `ErrInitialMeldSource`가 대체 차단 (review 2026-04-10 §2.7.1) | ✅ `game_rules_comprehensive_test.go:574` + `validator_test.go:208-229` (V-05 간접) | ✅ `GameClient.tsx:644` `if (!hasInitialMeld) return` 재배치 차단 가드 | ✅ `e2e/rearrangement.spec.ts` TC-RR-02/TC-RR-04 Negative(최초 등록 전 시도 차단) PASS | ✅ AI 대전에서 자연 관찰 | ⚠️ |
+| **V-13a** | 재배치 권한 (hasInitialMeld) | ✅ **직접 구현** — `validator.go validateInitialMeld` 에 V-13a 분기 추가 (`ErrNoRearrangePerm` 직접 반환, 2026-04-23 PR fix/v13a-err-no-rearrange-perm-wiring) | ✅ `validator_test.go` V-13a 전용 2건 신규 + V-05 기존 테스트 에러 코드 검증 강화 (`ErrNoRearrangePerm`) + `turn_service_test.go:553` 기대값 갱신 | ✅ `GameClient.tsx:644` `if (!hasInitialMeld) return` 재배치 차단 가드 | ✅ `e2e/rearrangement.spec.ts` TC-RR-02/TC-RR-04 Negative(최초 등록 전 시도 차단) PASS | ✅ AI 대전에서 자연 관찰 | ✅ |
 | **V-13b** | 유형 1: 세트 분할 (split) | ✅ V-06 보존 + V-01 유효성 | ✅ `conservation_test.go` 간접 | ✅ `f3eedb9` tilesDraggable 프롭 + DraggableTile 렌더링 + `handleDragEnd` 내 table→다른 group 이동 + pending→rack 되돌리기 landed | ⚠️ TC-RR-04 Negative **PASS** (회귀 가드) + TC-RR-03 Happy **fixme** (프론트 재배포 대기) | ❌ S4 미실행 | **부분** |
 | **V-13c** | 유형 2: 세트 합병 (merge) — **본 사건** | ✅ V-01 4색 그룹 + V-06 보존 | ✅ 그룹 유효성 테스트 다수 | ✅ `23e770a` `GameClient.tsx handleDragEnd` 서버 확정 그룹 머지 분기 landed | ⚠️ `adf0d84` TC-RR-01 Happy **fixme** + TC-RR-02 Negative **PASS** | ❌ S4 미실행 | **부분** |
 | **V-13d** | 유형 3: 타일 이동 (move) | ✅ V-06 보존 + V-01/V-02 최종 유효성 | ✅ `conservation_test.go` 간접 | ✅ `f3eedb9` tilesDraggable + `handleDragEnd` 내 table→다른 group 이동 분기 landed | ❌ 전용 TC 없음 (TC-RR-03 간접 커버 예정, 현재 fixme) | ❌ S4 미실행 | **부분** |
@@ -241,7 +241,7 @@ V-13은 단일 권한 검증이 아니라 **재배치 권한 + 4가지 재배치
 - V-11 (교착): ⚠️ → ✅ (TC-LF-E07 E2E 발굴로 승격 — 동일하게 반영 누락)
 - V-12 (승리): ⚠️ → ✅ (TC-LF-E05/E09 + A-11 발굴로 승격 — 동일)
 - V-09 (턴 타임아웃): ⚠️ 유지 — TC-GF-008/009는 **설정 값만** 검증, 실제 타임아웃→강제 드로우 전이 E2E는 여전히 0건
-- V-13a (재배치 권한): ⚠️ 유지 — TC-RR-02/04 Negative는 UI 차단 가드만 검증, **엔진은 V-05 간접 차단으로 `ErrNoRearrangePerm` 미사용** (정확도 gap)
+- V-13a (재배치 권한): ⚠️ → ✅ (2026-04-23) — `validateInitialMeld` 에 V-13a 분기 직접 추가, `ErrNoRearrangePerm` 호출 경로 0 → 1건, 기술부채 해소
 
 > 위 합계는 V-13을 V-13a~e의 5건으로 분해한 결과(총 19건 기준, V-13 통합 행은 카운트에서 제외)이다.
 > **Sprint 6 Day 2 진전**: 2026-04-13 기준 ❌ 3건(V-13b/c/d) → 0건 해소.

--- a/src/game-server/internal/engine/validator.go
+++ b/src/game-server/internal/engine/validator.go
@@ -118,15 +118,16 @@ func ValidateTurnConfirm(req TurnConfirmRequest) error {
 	return nil
 }
 
-// validateInitialMeld enforces V-04 and V-05.
+// validateInitialMeld enforces V-04, V-05, and V-13a.
 func validateInitialMeld(req TurnConfirmRequest) error {
-	// V-05: table-before tiles must still be intact and unmoved.
 	beforeCodes := collectTileCodes(req.TableBefore)
 	afterCodes := collectTileCodes(req.TableAfter)
 
+	// V-13a: 최초 등록 전에는 기존 테이블 타일을 재배치할 수 없다.
+	// table-before 타일이 table-after에서 감소했다면 재배치 시도로 간주한다.
 	for code := range beforeCodes {
 		if afterCodes[code] < beforeCodes[code] {
-			return newValidationError(ErrInitialMeldSource, ErrorMessages[ErrInitialMeldSource])
+			return newValidationError(ErrNoRearrangePerm, ErrorMessages[ErrNoRearrangePerm])
 		}
 	}
 

--- a/src/game-server/internal/engine/validator_test.go
+++ b/src/game-server/internal/engine/validator_test.go
@@ -208,23 +208,82 @@ func TestValidateTurnConfirm_V04_AboveThirty(t *testing.T) {
 // ─── V-05: 최초 등록 시 랙 타일만 사용 ────────────────────────────────────
 
 // TestValidateTurnConfirm_V05_RearrangeBeforeMeld 최초 등록 전 테이블 재배치 시도는 실패한다 (T-06).
+// V-13a: 에러 코드는 ErrNoRearrangePerm이어야 한다.
+// 주의: V-03(랙 타일 미추가)에 걸리지 않으려면 tableAfter 타일 수가 tableBefore보다 많아야 한다.
 func TestValidateTurnConfirm_V05_RearrangeBeforeMeld(t *testing.T) {
-	// 테이블에 기존 타일 R7a가 있는데, 최초 등록 전에 그것을 재배치
+	// 테이블에 기존 세트 [R7a, B7a, K7b]가 있다.
+	// 최초 등록 전 플레이어가 R7a를 제거하고 자신의 랙 타일로 새 세트 2개를 구성 (재배치 시도).
+	// tableAfter 타일 수(7) > tableBefore 타일 수(3) → V-03 통과, V-13a에서 차단.
 	existingSet := makeSet(t, "g0", []string{"R7a", "B7a", "K7b"})
 
-	// 제출 테이블에서 기존 타일이 사라졌음 (재배치 시도)
 	req := TurnConfirmRequest{
 		TableBefore: []*TileSet{existingSet},
 		TableAfter: []*TileSet{
-			// R7a 가 B7a 로 분리된 새 구성 — R7a 타일 수 감소
-			makeSet(t, "g1", []string{"R10a", "B10a", "K10b"}),
+			// R7a 사라짐 (재배치 시도), B7a + K7b 유지
+			makeSet(t, "g0", []string{"B7a", "K7b", "Y7a"}),   // B7a, K7b 재사용 + Y7a 추가
+			makeSet(t, "g1", []string{"R10a", "B10a", "K10b"}), // 랙 타일 새 세트
 		},
-		RackBefore:     []string{"R10a", "B10a", "K10b"},
+		RackBefore:     []string{"Y7a", "R10a", "B10a", "K10b"},
 		RackAfter:      []string{},
 		HasInitialMeld: false,
 	}
 	err := ValidateTurnConfirm(req)
-	assert.Error(t, err, "V-05: 최초 등록 전 테이블 재배치는 실패해야 한다")
+	assert.Error(t, err, "V-13a: 최초 등록 전 테이블 재배치는 실패해야 한다")
+	ve, ok := err.(*ValidationError)
+	require.True(t, ok, "ValidationError 타입이어야 한다")
+	assert.Equal(t, ErrNoRearrangePerm, ve.Code, "V-13a: 재배치 시도는 ErrNoRearrangePerm이어야 한다")
+}
+
+// TestValidateInitialMeld_RejectsRearrangeBeforeInitialMeld
+// 최초 등록 전, 테이블 기존 타일이 감소하면 ErrNoRearrangePerm을 반환한다 (V-13a).
+func TestValidateInitialMeld_RejectsRearrangeBeforeInitialMeld(t *testing.T) {
+	// 테이블에 [R5a, R6a, R7a] 런이 이미 존재한다.
+	// 최초 등록 미완료 플레이어가 R5a를 제거하고 자신의 랙 타일로 새 세트를 추가하려 한다.
+	req := TurnConfirmRequest{
+		TableBefore: []*TileSet{
+			makeSet(t, "r0", []string{"R5a", "R6a", "R7a"}),
+		},
+		TableAfter: []*TileSet{
+			// R5a 가 사라짐 (재배치 시도)
+			makeSet(t, "r0", []string{"R6a", "R7a", "R8a"}),
+			makeSet(t, "g1", []string{"B10a", "Y10a", "K10b"}),
+		},
+		RackBefore:     []string{"R8a", "B10a", "Y10a", "K10b"},
+		RackAfter:      []string{},
+		HasInitialMeld: false,
+	}
+	err := ValidateTurnConfirm(req)
+	require.Error(t, err, "V-13a: 최초 등록 전 재배치 시도는 반드시 실패해야 한다")
+	ve, ok := err.(*ValidationError)
+	require.True(t, ok, "ValidationError 타입이어야 한다")
+	assert.Equal(t, ErrNoRearrangePerm, ve.Code, "재배치 권한 없음 에러 코드여야 한다")
+}
+
+// TestValidateInitialMeld_StillRejectsRackShortage
+// 최초 등록 전, 테이블 타일은 온전하지만 30점 미달 시 ErrInitialMeldScore로 차단한다 (V-04 회귀 가드).
+func TestValidateInitialMeld_StillRejectsRackShortage(t *testing.T) {
+	// 최초 등록 전, 테이블 기존 타일은 그대로이며 랙에서 타일을 추가하지만 30점 미달.
+	// → ErrInitialMeldScore (V-04) 로 차단되어야 한다.
+	req := TurnConfirmRequest{
+		TableBefore: []*TileSet{
+			makeSet(t, "g0", []string{"R7a", "B7a", "K7b"}),
+		},
+		TableAfter: []*TileSet{
+			// 기존 세트 온전 유지
+			makeSet(t, "g0", []string{"R7a", "B7a", "K7b"}),
+			// 랙 타일로 새 세트 추가 — 9점 (30점 미달)
+			makeSet(t, "g1", []string{"R3a", "B3a", "K3b"}),
+		},
+		RackBefore:     []string{"R3a", "B3a", "K3b"},
+		RackAfter:      []string{},
+		HasInitialMeld: false,
+	}
+	err := ValidateTurnConfirm(req)
+	require.Error(t, err, "30점 미달 최초 등록은 실패해야 한다")
+	ve, ok := err.(*ValidationError)
+	require.True(t, ok, "ValidationError 타입이어야 한다")
+	assert.Equal(t, ErrInitialMeldScore, ve.Code, "점수 미달이므로 ErrInitialMeldScore여야 한다")
+	assert.NotEqual(t, ErrNoRearrangePerm, ve.Code, "테이블 온전 — ErrNoRearrangePerm이 아닌 ErrInitialMeldScore여야 한다")
 }
 
 // ─── V-06: 테이블 타일 유실 없음 ─────────────────────────────────────────────

--- a/src/game-server/internal/service/turn_service_test.go
+++ b/src/game-server/internal/service/turn_service_test.go
@@ -494,11 +494,11 @@ func TestConfirmTurn_InitialMeld_ExactlyThirty(t *testing.T) {
 }
 
 func TestConfirmTurn_InitialMeld_ModifyExistingSet(t *testing.T) {
-	// V-05: HasInitialMeld=false 상태에서 기존 테이블 세트의 타일을 제거(재배치) 시도 -> ErrInitialMeldSource
+	// V-13a: HasInitialMeld=false 상태에서 기존 테이블 세트의 타일을 제거(재배치) 시도 -> ErrNoRearrangePerm
 	// 시나리오: 테이블에 상대가 내려놓은 세트(R10a-R11a-R12a-R13a)가 존재하는 상태에서
 	// 최초 등록 미완료 플레이어가 R13a를 테이블에서 완전히 제거하고
 	// 자신의 랙 타일로만 구성한 세트를 추가.
-	// V-05는 beforeCodes[code] > afterCodes[code] 이면 ERR_INITIAL_MELD_SOURCE를 반환.
+	// V-13a: beforeCodes[code] > afterCodes[code] 이면 ERR_NO_REARRANGE_PERM을 반환.
 	existingTable := []*model.SetOnTable{
 		{ID: "existing-1", Tiles: []*model.Tile{
 			{Code: "R10a"}, {Code: "R11a"}, {Code: "R12a"}, {Code: "R13a"},
@@ -548,9 +548,10 @@ func TestConfirmTurn_InitialMeld_ModifyExistingSet(t *testing.T) {
 		TilesFromRack: tilesFromRack,
 	})
 	// 규칙 S6.1: 검증 실패 → 패널티 드로우 + 턴 종료
+	// V-13a: 재배치 시도이므로 ErrNoRearrangePerm (기존 ErrInitialMeldSource에서 변경)
 	require.NoError(t, err)
 	assert.True(t, result.Success)
-	assert.Equal(t, engine.ErrInitialMeldSource, result.ErrorCode)
+	assert.Equal(t, engine.ErrNoRearrangePerm, result.ErrorCode)
 	assert.Greater(t, result.PenaltyDrawCount, 0)
 }
 


### PR DESCRIPTION
## 변경 요약

`docs/02-design/49-v13a-v13e-refactor.md` §1.3 옵션 A 채택.

- `engine/errors.go:52` 에 정의만 있고 호출 경로가 0건이었던 `ErrNoRearrangePerm` 상수를 실제로 반환하도록 수정
- `validateInitialMeld` (validator.go) 에 V-13a 분기 추가: table-before 타일이 table-after에서 감소 → `ErrNoRearrangePerm` 반환
- 기존 코드는 이 케이스를 `ErrInitialMeldSource`("랙 외 타일 사용")로 처리해 UX 메시지가 부정확했음

## 수정 파일

| 파일 | 변경 |
|------|------|
| `src/game-server/internal/engine/validator.go` | `validateInitialMeld` V-13a 분기 추가 (~5 LOC) |
| `src/game-server/internal/engine/validator_test.go` | 신규 테스트 2건 + 기존 V-05 테스트 에러 코드 검증 강화 |
| `src/game-server/internal/service/turn_service_test.go` | L553 기대값 `ErrInitialMeldSource` → `ErrNoRearrangePerm` |
| `docs/02-design/31-game-rule-traceability.md` | V-13a 행 ⚠️ → ✅ 갱신 |

## 신규 테스트

- `TestValidateInitialMeld_RejectsRearrangeBeforeInitialMeld` — table-before 타일 감소 → `ErrNoRearrangePerm`
- `TestValidateInitialMeld_StillRejectsRackShortage` — 30점 미달은 여전히 `ErrInitialMeldScore` (회귀 가드)

## 검증 결과

```
go test ./... -count=1   전체 PASS (engine + service + handler + e2e 모두)
go vet ./...             클린
```

## 롤백

```bash
git revert 75646de
```

Refs: `docs/02-design/49-v13a-v13e-refactor.md` §1.3
Relates: Sprint 7 Day 2 V-13a 백로그

🤖 Generated with [Claude Code](https://claude.com/claude-code)