### PR TITLE
docs(sprint7): Day 2 저녁 Sprint 7 final push 문서 12건

### DIFF
--- a/docs/01-planning/day3-execution-plan.md
+++ b/docs/01-planning/day3-execution-plan.md
@@ -1,0 +1,421 @@
+# Day 3 (2026-04-24) 집행 계획서 — Production 기준 Sprint 7 전면 완결 착수
+
+- **문서**: `docs/01-planning/day3-execution-plan.md`
+- **Sprint**: 7 / **Day**: 3 (Sprint 7 Week 1 Day 3)
+- **Owner**: 애벌레 (PM/Dev, 1인)
+- **상태**: 집행 전 (사전 계획 — Production 기준 재작성)
+- **작성**: 2026-04-23 Day 2 마감 직후
+- **재작성**: 2026-04-23 오후 (사용자 지시 — 이관 없음, Production 기준)
+- **대원칙**: **내일까지 프로그램 외 전부 완료**. **프로그램은 오류 0 까지 반복**. **UI 수정은 architect + frontend-dev 페어 의무**.
+
+---
+
+## 0. 재작성 근거 (2026-04-23 오후 사용자 지시)
+
+1. 이관 / WONTFIX / Sprint 8 후보 / Week 2 이월 표현 전면 삭제 → Sprint 7 내 전부 처리
+2. Scope 전제 변경: Production 기준. dev-only low 도 해소 대상
+3. 일정 전제 변경:
+   - **프로그램 외 (문서·인프라·감사·의존성)**: Day 3 ~ Day 4 오전 사이 **완료 목표 확정**
+   - **프로그램 (기능·메이저 bump·마이그레이션·Auth 이주)**: **오류 0 까지 재시도** (Sprint 7 Week 2 마감까지)
+4. 본 계획서의 SP 상한 삭제. 성공 기준 단일화: "A = Production 기준 해소 진행". B/C 단계 구분 삭제.
+
+---
+
+## 1. Executive Summary (재작성 버전)
+
+### 1.1 Day 2 실측 속도 (재확인)
+- **Day 2 결과**: 5 PR 머지 (32분 구간), 8.5 SP 소화, 1.5h 집중
+- **환산 속도**: 5.7 SP/h (architect 사전 분석 효과). 일반일 평균 2.0 SP/h.
+- **Day 3 의 장애물**: 신규 설계·조사 항목 비중이 오늘보다 크다 (next-auth ADR, Phase 2a shadow). 실속도는 2.0~3.5 SP/h 예상.
+
+### 1.2 Day 3 Scope (Production 기준, 이관 없음)
+
+| 구분 | 항목 | SP | 기한 |
+|---|---|---|---|
+| **문서/인프라 (반드시 Day 3~ Day 4 오전)** | A, C, I, G, J, P2_ADR | 17 SP | Day 4 오전 까지 |
+| **프로그램 (오류 0 반복)** | B, D, E, F | 13 SP | 오류 0 까지 (Day 3~ 반복) |
+| **프로그램 Day 3 착수 후 반복** | H (Phase 2a), NA (next-auth v5 이주 시작) | 16 SP | Sprint 7 Week 2 마감 |
+| **Day 3 합계 착수 범위** | | **46 SP** | |
+
+### 1.3 성공 기준 (단일)
+
+- Day 3 종료 시점 (20:00) 기준:
+  - 문서/인프라 17 SP 중 **최소 13 SP 머지** (80%+)
+  - 프로그램 13 SP 중 **최소 8 SP 머지** 또는 **명확한 revert+재시도 계획 수립**
+  - H (Phase 2a shadow read) **관찰 시작** 또는 **다음 재시도 일정 확정**
+  - NA (next-auth v5 이주 ADR) **머지**
+- **모든 Playwright/Jest/Go 테스트 회귀 0**
+
+**Production 기준이므로 "SP 40 이상이면 S, 30 이상이면 A" 와 같은 단계 구분은 삭제**. 해소가 완료되지 않으면 **다음 날 재시도**.
+
+---
+
+## 2. Day 3 작업 매트릭스 (Production 기준)
+
+### 2.1 대상 12건 (Day 3 착수 기준, Sprint 7 전체는 sprint7-decisions.md §3 참조)
+
+| ID | 작업 | SP | 리스크 | 분류 | 기한 구분 |
+|---|---|---|---|---|---|
+| **A** | CI/CD 감사 잡 3건 (sca-npm-audit + sca-govulncheck + weekly-dep-audit) | 5 | LOW | 인프라 | 내일까지 |
+| **B** | V-13a `ErrNoRearrangePerm` orphan 리팩터 | 2 | LOW | 프로그램 | 오류 0 |
+| **C** | dev-only deps 3건 (@typescript-eslint + @nestjs/cli + jest+jest-env-jsdom 동반) | 3 | LOW-MED | 의존성 | 내일까지 |
+| **D** | V-13e 조커 재드래그 UX (**architect + frontend-dev 페어**) | 3 | MED | 프로그램/UI | 오류 0 |
+| **E** | @nestjs/core v11 + file-type transitive bump | 7 | MED-HIGH | 의존성 | 오류 0 (반복) |
+| **F** | FORFEIT 경로 완결성 점검 (Issue #47 후속) | 3 | MED | 프로그램 | 오류 0 |
+| **G** | Istio DestinationRule 세밀 조정 | 2 | LOW | 인프라 | 내일까지 |
+| **H** | D-03 Phase 2a shadow read (rooms PostgreSQL) | 8 | **HIGH** | 프로그램/인프라 | 오류 0 (Week 2 까지 반복) |
+| **I** | PostgreSQL 001 마이그레이션 staging dry-run | 2 | MED | 인프라 | 내일까지 |
+| **J** | Playwright 전수 회귀 + 회귀 보고서 81 | 2 | LOW | QA | 내일까지 (저녁) |
+| **P2_ADR** | next-auth v5 (Auth.js) 이주 ADR 선행 | 3 | LOW (ADR) | 문서 | 내일까지 |
+| **NA_START** | next-auth v5 이주 실구현 착수 (ADR 승인 후) | 8 | **HIGH** | 프로그램/Auth | 오류 0 (Week 2 까지 반복) |
+| **합계 Day 3** | | **48 SP** | | | |
+
+**제외**: Day 3 에 시작하지 않는 항목은 sprint7-decisions.md §3 (H2, P3, M1, M2, DS, Istio5.2, PRB, MODEL) 로 이관. 하지만 Sprint 7 밖으로 는 **이관 없음**.
+
+### 2.2 리스크 레벨별 분류 및 완화책 (Production 기준)
+
+| Risk | 항목 | 완화책 |
+|---|---|---|
+| **HIGH** | H (Phase 2a shadow read) | 저녁 블록 시작. ai-adapter 안정 후. drift 모니터링 1일 후 Phase 2b/2c. **오류 감지 시 즉시 중단 후 익일 재시도** (Week 2 내 반드시) |
+| **HIGH** | NA_START (next-auth v5 이주 실구현) | ADR 승인 후에만 착수. frontend 인증 Playwright 스펙 전수 회귀 필수. 실패 시 revert 후 재설계 |
+| **MED-HIGH** | E (@nestjs/core v11) | 오후 초반. Jest 회귀 1건 발생 시 revert. **Sprint 7 내 재시도 의무** (dev-only WONTFIX 금지) |
+| **MED** | D (V-13e), F (FORFEIT), I (마이그레이션), C (jest 30 동반) | 각 단일 PR. 실패 시 독립 revert + 재시도 |
+| **LOW** | A, B, G, J, P2_ADR | 병렬 실행 |
+
+### 2.3 "이관 없음" 원칙의 실무 적용
+
+- 이전 계획: "Jest 30 동반 bump 리스크 → Week 2 후반 WONTFIX 고려"
+- 재작성 후: Jest 30 동반 bump 는 **Day 3 오전 병렬 트랙 C 에서 착수**. 회귀 발생 시 단독 revert 하되 **Day 5 오전 재시도 예정** (Sprint 7 내 반드시 해소)
+- 이전 계획: "Phase 2b/2c 는 WONTFIX Week 3 이월 검토"
+- 재작성 후: Phase 2b/2c 는 Day 4 ~ Day 6 내 반드시 완료. drift 관찰 결과에 따라 Day 순서만 조정
+
+---
+
+## 3. 시간표 (블록 기반, 09:00 ~ 20:00, Production 기준)
+
+```mermaid
+gantt
+    title Day 3 (2026-04-24) 11h 집행 Gantt (Production 재작성)
+    dateFormat HH:mm
+    axisFormat %H:%M
+
+    section 오전 09:00-13:00 병렬 5트랙
+    A CI/CD 감사 잡        :a1, 09:00, 180m
+    B V-13a orphan         :b1, 09:00, 120m
+    C dev-only deps (+jest30) :c1, 09:00, 180m
+    D V-13e UX (페어)       :d1, 09:00, 240m
+    I Postgres 001 dry     :i1, 11:00, 60m
+    P2_ADR next-auth v5    :adr, 10:00, 180m
+
+    section 점심 13:00-14:00
+    점심+산책               :lunch, 13:00, 60m
+
+    section 오후 14:00-18:00
+    E @nestjs/core v11      :e1, 14:00, 150m
+    F FORFEIT 점검           :f1, 14:00, 120m
+    휴식 15분 ×2            :rest1, 16:00, 15m
+    G Istio DR               :g1, 16:30, 60m
+    오후 머지 일괄            :merge1, 17:00, 60m
+
+    section 저녁 18:00-20:00
+    저녁식사                  :dinner, 18:00, 30m
+    H Phase 2a shadow        :h1, 18:30, 75m
+    NA_START 이주 착수        :na, 19:00, 60m
+    K8s smoke + J Playwright  :smoke, 19:45, 15m
+```
+
+### 3.1 오전 (09:00 ~ 13:00) — 독립 5+1 트랙 병렬 (Production 기준)
+
+| Worktree | 에이전트 | 항목 | 예상 종료 | 분류 |
+|---|---|---|---|---|
+| `worktree-a` | go-dev + devops | **A** CI/CD 감사 잡 (.gitlab-ci.yml) | 12:00 | 내일까지 |
+| `worktree-b` | go-dev (별도 세션) | **B** V-13a orphan 리팩터 | 11:00 | 오류 0 |
+| `worktree-c` | node-dev + frontend-dev | **C** dev-only deps 3건 + jest 30 동반 bump | 12:00 | 내일까지 |
+| `worktree-d` | **architect + frontend-dev 페어** | **D** V-13e 조커 재드래그 UX | 13:00 | 오류 0 |
+| main (11:00~) | devops | **I** Postgres 001 staging dry-run | 12:00 | 내일까지 |
+| 병렬 ADR (10:00~) | architect + security | **P2_ADR** next-auth v5 이주 ADR | 13:00 | 내일까지 |
+
+**오전 머지 목표**: A, B, C, I, P2_ADR → 5 PR + 1 ADR 문서 (약 15 SP)
+
+**D 는 오전 내 머지 권장하나 페어 리뷰 시간 포함 시 오후 이월 허용**
+
+### 3.2 점심 (13:00 ~ 14:00) — 필수 휴식
+
+- 식사 30분 + 산책/음악 30분
+- **화면 완전 차단**. 카톡/메일 금지
+- 번아웃 방지선. Production 기준이라도 휴식은 단축 금지
+
+### 3.3 오후 (14:00 ~ 18:00) — 중간 난이도 + 머지 일괄
+
+| 시간 | 트랙 | 항목 | 비고 |
+|---|---|---|---|
+| 14:00~16:30 | 메인 | **E** @nestjs/core v11 메이저 | Jest 전수 통과 필수. 실패 시 revert → Day 5 오전 재시도 |
+| 14:00~16:00 | 병렬 | **F** FORFEIT 경로 점검 | 2h |
+| 16:00~16:15 | 휴식 | 15분 | 필수 |
+| 16:30~17:30 | 여유 | **G** Istio DR 조정 | 내일까지 기한 |
+| 17:00~18:00 | 머지 | 오후 PR 일괄 머지 + main pull | E/F/D/G 순 |
+
+**오후 머지 목표**: D (오전 못 끝냈으면), E, F, G → 최대 4 PR (약 13 SP)
+
+### 3.4 저녁 (18:00 ~ 20:00) — HIGH risk + 마감
+
+| 시간 | 항목 | 비고 |
+|---|---|---|
+| 18:00~18:30 | 저녁식사 | 30분 |
+| 18:30~19:45 | **H** D-03 Phase 2a shadow read | 1.25h. 오류 시 중단 후 Day 4 재시도 |
+| 19:00~20:00 | **NA_START** next-auth v5 이주 실구현 착수 (ADR 승인 후) | 병렬. 오류 시 Day 4 이후 반복 |
+| 19:00~20:00 | **J** Playwright 전수 + 보고서 81 | qa 병렬 세션 |
+| 19:45~20:00 | K8s smoke + main 최종 pull | 마감 점검 |
+
+**저녁 머지 목표**: H, NA_START, J → 2~3 PR (약 17 SP 착수)
+
+### 3.5 식사/휴식 총계
+
+- 점심 60분 (필수)
+- 오후 휴식 15분 × 2 = 30분
+- 저녁 30분
+- **총 휴식 2h** (목표 유지. 단축 금지)
+
+---
+
+## 4. 에이전트 투입 매트릭스 (Production 재편)
+
+| 에이전트 | 모델 | Day 3 투입 | 담당 |
+|---|---|---|---|
+| **pm** | Opus 4.7 xhigh | 1 세션 | 이 계획서 + 마감 데일리 |
+| **architect** | Opus 4.7 xhigh | **3~4 세션** | P2_ADR 설계 + D 페어 + E/H 블로커 대기 |
+| **ai-engineer** | Opus 4.7 xhigh | 0 | 대기 |
+| **security** | Opus 4.7 xhigh | 2 세션 | A 검토 + P2_ADR 리뷰 |
+| **qa** | Opus 4.7 xhigh | 2 세션 | J + 각 PR 회귀 게이트 |
+| **go-dev** | Sonnet 4.6 | **3 세션** (병렬) | A + B + F |
+| **node-dev** | Sonnet 4.6 | **2 세션** (시차) | C + E |
+| **frontend-dev** | Sonnet 4.6 | **2 세션** | D 페어 + NA_START |
+| **devops** | Sonnet 4.6 | **3 세션** | A 지원 + I + H K8s smoke |
+| **designer** | Sonnet 4.6 | 0 | 미사용 |
+
+**총 세션**: 약 **16~18 개**. 이전 계획 (12~14) 대비 증가는 페어 코딩(D) + ADR 동시 진행(P2_ADR) + NA_START 착수 반영.
+
+**페어 코딩 세션 운영 (D)**:
+1. architect 가 먼저 설계 세션 (30분) → ADR 코멘트 또는 PR description 에 근거 기록
+2. frontend-dev 가 구현 (2~3h)
+3. architect 가 PR 리뷰 + 회귀 체크리스트 검증 후 approve → 머지
+
+---
+
+## 5. PR 머지 순서 + 의존성 (재편)
+
+### 5.1 머지 순서 (권장)
+
+```mermaid
+flowchart TB
+    subgraph morning["오전 머지 12:00~13:00"]
+        A["A: CI 감사 잡"]
+        B["B: V-13a"]
+        C["C: dev-only deps + jest30"]
+        I["I: Postgres 001 dry"]
+        P2["P2_ADR: next-auth v5 ADR"]
+    end
+
+    subgraph afternoon["오후 머지 17:00"]
+        D["D: V-13e UX (페어)"]
+        E["E: @nestjs/core v11"]
+        F["F: FORFEIT 점검"]
+        G["G: Istio DR"]
+    end
+
+    subgraph evening["저녁 18:30~19:45"]
+        H["H: D-03 Phase 2a"]
+        NA["NA_START: next-auth v5 이주"]
+        J["J: Playwright 81"]
+    end
+
+    A --> E
+    C --> E
+    E --> H
+    A --> H
+    D --> G
+    F --> H
+    P2 --> NA
+
+    style A fill:#d4edda
+    style E fill:#fff3cd
+    style H fill:#f8d7da
+    style NA fill:#f8d7da
+    style J fill:#cce5ff
+    style P2 fill:#cce5ff
+```
+
+### 5.2 의존성 주요 포인트
+
+1. **A → E**: CI sca-npm-audit 가 머지되어야 E 의 audit 게이트 확인 가능
+2. **C → E**: @nestjs/cli (dev) 와 @nestjs/core 는 호환 쌍. C 먼저 머지
+3. **E → H**: ai-adapter 재배포 안정 (30분 관찰) 후 shadow read
+4. **D → G**: V-13e UX 회귀 없음 확인 후 Istio DR 조정
+5. **F → H**: FORFEIT 경로는 rooms 테이블 업데이트 경로에 연결
+6. **P2_ADR → NA_START**: ADR 승인 이후에만 이주 실구현 착수
+
+### 5.3 K8s smoke 게이트
+
+- **12:00 smoke**: 오전 머지 후
+- **17:30 smoke**: 오후 머지 후
+- **19:45 smoke**: 저녁 H + NA_START 착수 후 **필수**
+
+---
+
+## 6. 성공 기준 + 실패 기준 + 오류 0 반복 절차
+
+### 6.1 성공 기준 (Production 기준, 단일)
+
+- [ ] 문서/인프라 6건 (A, C, I, G, J, P2_ADR) 전부 머지 또는 Day 4 오전 완료 예약
+- [ ] 프로그램 4건 (B, D, E, F) 중 **B, D, F 는 Day 3 완료**. E 는 Day 3 완료 **또는 명확한 재시도 일정 (Day 5 오전)**
+- [ ] H (Phase 2a) 관찰 시작 또는 Day 4 재시도 확정
+- [ ] NA_START ADR 머지 + 이주 실구현 첫 커밋 완료 또는 Day 4 재시도 확정
+- [ ] Playwright 전수 PASS (기존 flaky 허용, 신규 FAIL 0)
+- [ ] Jest 599 → 599 유지 (또는 신규 추가분 포함 증가)
+- [ ] K8s smoke 19:45 PASS
+- [ ] 번다운 차트 업데이트
+
+### 6.2 실패 기준 (즉시 revert, **이관 금지**)
+
+| 트리거 | 대응 | 재시도 일정 |
+|---|---|---|
+| Jest 599 → 598 이하 | E 단독 revert | **Day 5 오전 재시도** (Sprint 7 내 오류 0) |
+| Playwright 신규 FAIL ≥ 2 | 원인 PR 식별 → revert | 같은 날 저녁 또는 익일 오전 재시도 |
+| K8s Pod CrashLoopBackoff | 최근 1h PR 순차 revert (LIFO) | 원인 분리 후 당일 재시도 |
+| Phase 2a drift > 5% | shadow read 비활성 | Day 4 원인 분석 + 재시도 |
+| next-auth v5 이주 회귀 | NA_START revert | Day 4~5 재설계 후 재시도 |
+| **번아웃 조짐** (집중도 60% 이하, 30분+ 정체) | 즉시 마감 | Day 4 이후 재시도 (프로그램 외는 Day 4 오전 마감) |
+
+### 6.3 오류 0 반복 절차 (프로그램 항목)
+
+1. `gh pr revert <NUMBER>` 로 revert PR 생성
+2. 즉시 머지 (LIFO)
+3. K8s 재배포: `kubectl rollout undo deployment/<svc> -n rummikub`
+4. `work_logs/incidents/2026-04-24-revert-<PR>.md` 생성
+5. 원인 분석 → 재시도 일정 sprint7-decisions.md §3 에 반영
+6. **Sprint 7 Week 2 마감 (2026-05-02) 까지 재시도 지속**
+7. 마감 당일에도 미해소 시 **Sprint 7 연장** 판단 (Sprint 밖 이월 금지)
+
+---
+
+## 7. 번아웃 리스크 완화 설계 (Production 기준에서도 유지)
+
+### 7.1 왜 이게 최우선 리스크인가
+
+- Day 2 속도 (5.7 SP/h) 는 architect 사전 준비 효과. Day 3 는 신규 설계·조사 비중 큼
+- Production 재편으로 총 Scope 가 77.5 SP 로 확대 → **속도 착시 위험 증가**
+- 사용자 Preference: "딸깍 프로젝트 아님, 천천히 확실하게"
+- 1인 개발 11h 집중 한계. 중단 지점 설계 필수
+
+### 7.2 완화 설계
+
+1. **점심 60분 필수**. 30분으로 단축 금지
+2. **오후 휴식 15분 × 2** 고정. 스킵 금지
+3. **저녁 H 는 최대 1.25h 박스**. 넘으면 중단 → Day 4 재시도
+4. **집중도 셀프 체크 3시점**: 12:00, 16:00, 19:00
+5. **실패 기준 6.2 번아웃 조건 엄수**
+6. **내일 밤 야근 금지**. 20:00 이후 작업 시 Day 4 휴식 반영
+7. **Production 기준 유지의 의미**: "오늘 못 끝내면 내일 재시도" 는 허용. "Sprint 밖 이관" 은 금지. 이 차이를 명확히 구분
+
+---
+
+## 8. 번다운 차트 (Production 재편)
+
+### 8.1 Sprint 7 전체 번다운
+
+```
+SP 잔여 (총 77.5 SP: Day 12 3 + Day 2 P1 8.5 + 내일까지 17 + 오류0 49)
+  ^
+77 |█ Sprint 7 시작 (Day 1 아침)
+  |
+70 |████ Day 12 마감 (rooms Phase 1)
+  |
+66 |██████ Day 2 마감 (P1 8.5 소화, 66 잔여)
+  |
+50 |██████████ Day 3 목표 (13~15 SP 소화, ~50 잔여)
+  |
+40 |████████████ Day 4 목표 (문서/인프라 완전 소화, 프로그램 반복)
+  |
+20 |██████████████████ Day 5~6 목표 (프로그램 오류 0 집중)
+  |
+ 0 |_____________________________________ Week 2 마감 (2026-05-02)
+     D1  D2  D3  D4  D5  D6  D7  W2종료
+                ↑ 이 계획서 목표 지점
+```
+
+**Day 3 성공 시**: Sprint 7 전체의 약 36% 소화 (누적). 내일까지 (Day 4 오전) 약 48% 목표.
+
+**Sprint 7 예상 종료**: Week 2 마감 (2026-05-02) 또는 **오류 0 까지 연장**.
+
+### 8.2 일자별 목표 (Production 재편)
+
+| 일자 | 목표 SP | 누적 % | 비고 |
+|---|---|---|---|
+| Day 2 (완료) | 8.5 | 15% | P1 전량 |
+| **Day 3** | 13~15 | 33% | 내일까지 (문서/인프라) + 프로그램 일부 |
+| **Day 4** | 15~18 | 52% | 내일까지 완결 목표 (문서/인프라 100%) |
+| Day 5 | 10~12 | 67% | 프로그램 오류 0 반복 |
+| Day 6 | 8~10 | 80% | 프로그램 오류 0 반복 |
+| Day 7 | 5~8 | 90% | H2, P3, M1, M2 |
+| Week 2 마감 | 7~10 | 100% | MODEL, PRB 마지막 |
+
+---
+
+## 9. 다음날 (Day 4, 2026-04-25) 준비도
+
+### 9.1 Day 3 성공 시 Day 4 예정
+
+1. **문서/인프라 100% 완결 마감** (Day 3 잔여 + 회귀 보고서)
+2. **Phase 2a drift 리뷰** → Phase 2b 착수 판단
+3. **next-auth v5 이주 실구현 계속** (NA_START 연장)
+4. **E @nestjs/core v11 회귀 발생 시 재시도**
+5. **Playwright flaky 재분류** (J 결과 기반)
+
+### 9.2 Day 3 미달 시 Day 4 예정
+
+1. **내일까지 기한 문서/인프라** 잔여 완주 (A/C/I/G/J/P2_ADR 누락분)
+2. 프로그램 B/D/F 잔여 완주
+3. Phase 2a 는 Day 5 로 재배치
+4. 번아웃 회복 우선
+5. **Sprint 7 밖 이관은 여전히 금지**
+
+### 9.3 Sprint 7 연장 판단 기준
+
+- Week 2 마감 (2026-05-02) 에 H/H2/NA/P3 중 **1건 이상 오류 잔존** 시 Sprint 7 연장
+- 연장 범위: 오류 0 까지. 최대 1주 추가 검토 (Sprint 8 시작 지연 감수)
+
+---
+
+## 10. 체크리스트 (Day 3 아침 09:00 직전)
+
+### 10.1 사전 점검 (08:30~09:00)
+
+- [ ] architect 가 사전 작성 중인 문서 5건 (79, 80, 49, 50, 51) 완료 확인
+- [ ] main 최신 pull (Day 2 머지분 반영)
+- [ ] K8s 전체 서비스 Running 확인 (`kubectl get pods -n rummikub`)
+- [ ] Jest/Go 베이스라인 테스트 수 재확인 (회귀 기준점 599 / 530 / 201)
+- [ ] next-auth v5 ADR 준비 자료 — `docs/04-testing/78` §5.1 검토 완료
+- [ ] 번아웃 셀프 진단 (어제 수면 6h 이상?)
+
+### 10.2 작업 중 (시간별)
+
+- [ ] 12:00 오전 머지 확인 + 점심 + smoke
+- [ ] 16:00 오후 휴식
+- [ ] 17:00 오후 머지 확인
+- [ ] 17:30 smoke
+- [ ] 19:45 저녁 smoke + 마감
+
+### 10.3 마감 (20:00)
+
+- [ ] 데일리 로그 작성 (`/daily-close`)
+- [ ] 바이브 로그 작성 (에세이 톤)
+- [ ] `docs/01-planning/sprint7-decisions.md` Day 3 섹션 추가
+- [ ] 번다운 차트 업데이트
+- [ ] Day 4 TODO 갱신
+- [ ] Sprint 7 내 이관 여부 재확인 (0 건이어야 함)
+
+---
+
+## 11. 요약 (Production 기준, 300자)
+
+Day 3 에 문서/인프라 6건 (A, C, I, G, J, P2_ADR, 17 SP) 을 **내일까지 전량 완료** 하고, 프로그램 7건 (B, D, E, F, H, NA_START, 31 SP) 은 **오류 0 까지 반복** 한다. UI 변경 (D) 은 architect + frontend-dev **페어 의무**. next-auth v5 이주는 ADR 부터 시작하여 Sprint 7 내 종료. Scope 밖 이관 금지. 실패 시 단독 revert 후 Sprint 7 Week 2 마감 (2026-05-02) 까지 반복. 점심 60분 + 오후 휴식 30분 필수. 번아웃 조짐 시 즉시 마감, 다음 날 재시도. Production 기준이지만 번아웃 방지선은 유지.

--- a/docs/02-design/49-v13a-v13e-refactor.md
+++ b/docs/02-design/49-v13a-v13e-refactor.md
@@ -1,0 +1,828 @@
+# 49. V-13a / V-13e 리팩터·UX 개선 설계
+
+작성일: 2026-04-23 (Sprint 7 Day 2, Day 3 사전 분석)
+작성자: architect
+대상 작업일: 2026-04-24 (Day 3)
+관련 규칙: 06-game-rules.md §6 재배치, 31-game-rule-traceability.md §1.1 V-13 4유형
+연관 이슈/PR: PR #39 (I-4 핫픽스), PR #51 (FINDING-01 롤백), I-19 데드락 수정
+
+---
+
+## 0. Executive Summary
+
+Sprint 7 백로그의 게임 UX 마무리 2건. Day 2 시점 기준 두 건 모두 **기능은 이미 동작**하지만 정합성·체감 품질에 결함이 있다. 각 건의 핵심 의사결정과 권장안을 먼저 요약한다.
+
+| 항목 | 현재 상태 | 권장 옵션 | 근거 | SP | 담당 |
+|------|---------|---------|------|----|------|
+| **V-13a** `ErrNoRearrangePerm` orphan | 상수·메시지만 존재, 호출 경로 0건. `ErrInitialMeldSource` 가 대체 차단 | **옵션 A (유지 + 호출 추가)** | 31-game-rule-traceability.md §1.1 에 "V-05 간접 차단, `ErrNoRearrangePerm` 미사용 (정확도 gap)" 이 공식 부채로 등록돼 있음. 에러 코드가 "의미 있는 구분" 을 제공하므로 삭제보다 정합화가 적절 | 2 | go-dev |
+| **V-13e** 조커 재드래그 UX | 데드락은 PR #39 로 해소. 하지만 `pendingRecoveredJokers` 배너가 재배치 후에도 사라지지 않음. `removeRecoveredJoker` 함수는 정의돼 있으나 **호출되지 않음** | **state machine 정리 + dnd-kit sensor 튜닝 + 배너 동기화** | 핵심 결함은 "회수 → 재배치" 상태 전이가 완료 시그널 없음. Store helper 는 갖춰져 있어 호출 지점만 추가하면 해결 | 3 | frontend-dev |
+
+**병렬성**: 두 작업은 backend(V-13a) ↔ frontend(V-13e) 로 완전히 독립. worktree 두 개 분리 실행 가능. 예상 소요 병렬 기준 **~3시간** (각 작업 1.5~2h + 검증).
+
+**위험 예산**: V-13a 는 백엔드 검증 강화 — 회귀 가능성 낮음 (기존 통과 경로는 그대로). V-13e 는 게임 중 핵심 상호작용 — PR #51 FINDING-01 같은 회귀 방지를 위해 Playwright 시나리오 신규 2건 필수.
+
+---
+
+## 1. V-13a — `ErrNoRearrangePerm` orphan 리팩터
+
+### 1.1 Current state
+
+**코드 현황**:
+
+```
+src/game-server/internal/engine/errors.go
+  L52:  ErrNoRearrangePerm = "ERR_NO_REARRANGE_PERM"   // 재배치 권한 없음 (V-13)
+  L79:  ErrNoRearrangePerm: "최초 등록 전에는 테이블 재배치가 불가합니다."
+```
+
+전수 grep 결과:
+- **상수 정의**: 1건 (`errors.go:52`)
+- **메시지 매핑**: 1건 (`errors.go:79`)
+- **실제 발생 지점**: **0건** — 어디에서도 `newValidationError(ErrNoRearrangePerm, ...)` 를 호출하지 않음
+- **테스트**: 0건 — `ErrNoRearrangePerm` 문자열로 기대값을 검증하는 테스트 없음
+
+대신 V-13a 시나리오 (최초 등록 전 재배치 시도) 는 현재 `validator.go:100-131` 의 `validateInitialMeld` 가 **`ErrInitialMeldSource` (랙 외 타일 사용)** 로 차단한다.
+
+```go
+// validator.go L100~104
+if !req.HasInitialMeld {
+    if err := validateInitialMeld(req); err != nil {
+        return err
+    }
+}
+
+// validateInitialMeld 내부 L124~131
+// "테이블 before 타일이 after 에서 감소했다면 → ErrInitialMeldSource"
+for code := range beforeCodes {
+    if afterCodes[code] < beforeCodes[code] {
+        return newValidationError(ErrInitialMeldSource, ...)
+    }
+}
+```
+
+**의미론적 간극**:
+
+| 시나리오 | 현재 반환 에러 | 의미상 정확한 에러 |
+|---------|-------------|-----------------|
+| 최초 등록 전, 테이블 기존 타일을 이동 (재배치 시도) | `ErrInitialMeldSource` ("랙 외 타일 사용") | `ErrNoRearrangePerm` ("재배치 권한 없음") |
+| 최초 등록 전, 기존 세트에 자기 타일을 추가 (append) | `ErrInitialMeldSource` | `ErrInitialMeldSource` (이것이 맞음) |
+
+즉 현재는 두 개의 서로 다른 위반 상황이 단일 에러 코드로 뭉뚱그려져, **클라이언트 UX 메시지가 부정확**하다. 사용자는 "내 타일이 왜 랙 외 타일이라는 건가?" 하고 혼란한다. V-13a 는 "재배치 권한이 없다" 를 명시적으로 말해야 한다.
+
+**traceability 공식 부채**:
+
+31-game-rule-traceability.md §1.1 L75, §3 L244 가 이 정확도 gap 을 이미 명시하고 있다. 내부 감사 문서 기준으로 기술 부채로 등록된 상태.
+
+### 1.2 3 옵션 비교
+
+**옵션 A — 유지 + 호출 경로 추가 (권장)**
+
+`validateInitialMeld` 를 분기해 "테이블 before 감소 = 재배치 시도" 를 먼저 판정하고 `ErrNoRearrangePerm` 반환. "랙 타일 부족 = 랙 외 타일 사용" 은 기존 `ErrInitialMeldSource` 유지.
+
+```go
+// validator.go validateInitialMeld 수정안
+func validateInitialMeld(req TurnConfirmRequest) error {
+    // V-13a: 테이블 before 타일이 after 에서 감소 → 재배치 시도
+    beforeCodes := collectTileCodes(req.TableBefore)
+    afterCodes := collectTileCodes(req.TableAfter)
+    for code := range beforeCodes {
+        if afterCodes[code] < beforeCodes[code] {
+            // 이 타일이 요청 플레이어의 랙에서 왔는지 검사 → 왔으면 재배치 권한 없음
+            return newValidationError(ErrNoRearrangePerm, ErrorMessages[ErrNoRearrangePerm])
+        }
+    }
+    // V-05: (기존 유지) 제출된 타일 중 랙에 없는 타일 존재
+    // ... 기존 로직
+}
+```
+
+- 장점: 에러 코드 의미 명확화, UX 메시지 정확, traceability gap 해소, 삭제하지 않아 호환성 유지
+- 단점: 분기 추가 (코드 ~10 LOC), 테스트 신규 2건 필요
+- 리스크: LOW — 기존 통과 경로 변화 없음
+
+**옵션 B — 삭제 (YAGNI)**
+
+상수·메시지 맵핑 삭제. V-13a 는 `ErrInitialMeldSource` 로 계속 처리. traceability 에서 "의도적 통합" 로 재분류.
+
+- 장점: 코드 최소화 (~3 LOC 제거)
+- 단점: traceability §1.1 의 공식 부채 해소 불가. "V-13 재배치 권한" 이라는 규칙이 독립 에러 코드를 갖지 않아 에러 코드 레지스트리(29-error-code-registry.md)와 game-rules.md §9 의 "V-13" 체계가 뒤틀림
+- 리스크: MEDIUM — 문서-코드 정합성 부채 확대
+
+**옵션 C — 병합 (`ErrInvalidMove` 하위 code)**
+
+`ErrInvalidMove` 라는 상위 개념 신설 + `detail` 필드로 세분화.
+
+- 장점: 에러 코드 계층 구조 명확화
+- 단점: 현재 `ValidationError` 구조체는 flat code 만 사용. 병합은 전체 에러 체계 리팩터를 유발. 이 건에만 하기에는 과함 (YAGNI violation 역방향)
+- 리스크: HIGH — 범위 폭발
+
+### 1.3 권장 결정
+
+**옵션 A 채택**.
+
+근거:
+1. traceability §1.1 에 기술부채로 등록된 gap 해소
+2. 에러 코드 의미 명확화로 UX 메시지 정확도 향상
+3. 삭제(B) 는 문서-코드 정합성을 악화시키고, 병합(C) 은 범위 폭발
+4. simplify SKILL 관점에서도 "이미 정의된 코드 + 메시지를 살리는 것" 이 가장 단순함
+
+### 1.4 구현 계획
+
+**파일**:
+- `src/game-server/internal/engine/validator.go` — `validateInitialMeld` 분기 추가
+- `src/game-server/internal/engine/validator_test.go` — 테스트 신규 2건
+- `docs/02-design/31-game-rule-traceability.md` — V-13a 행 ⚠️ → ✅ 갱신
+
+**validator.go 수정 (~10 LOC)**:
+
+```go
+// validateInitialMeld enforces V-04, V-05, V-13a.
+func validateInitialMeld(req TurnConfirmRequest) error {
+    beforeCodes := collectTileCodes(req.TableBefore)
+    afterCodes := collectTileCodes(req.TableAfter)
+
+    // V-13a: 최초 등록 전에는 기존 테이블 타일을 재배치할 수 없다.
+    // table before 타일이 after 에서 감소했다면 재배치 시도로 간주한다.
+    for code := range beforeCodes {
+        if afterCodes[code] < beforeCodes[code] {
+            return newValidationError(ErrNoRearrangePerm, ErrorMessages[ErrNoRearrangePerm])
+        }
+    }
+
+    // V-04: 최초 등록 30점 이상 조건 (기존 로직)
+    addedCodes := newlyAddedTiles(req.RackBefore, req.RackAfter)
+    if len(addedCodes) == 0 {
+        return newValidationError(ErrInitialMeldScore, ErrorMessages[ErrInitialMeldScore])
+    }
+    // ... 기존 점수 계산 로직
+}
+```
+
+주의: `ErrInitialMeldSource` 의 "랙 외 타일 사용" 경로는 현재 `validateTileConservation` 이 code-level 로 다시 검증하므로 중복 로직이 아니다. 기존 "table before 타일 빈도 감소 → ErrInitialMeldSource" 분기는 V-13a 로 역할 이전되며, 삭제한다.
+
+**테스트 신규 (validator_test.go)**:
+
+1. `TestValidateTurnConfirm_V13a_NoRearrangePerm` — 최초 등록 전 테이블 타일 재배치 시도 → `ErrNoRearrangePerm` 반환 확인
+2. `TestValidateTurnConfirm_V13a_AfterMeld_Allowed` — 최초 등록 후 재배치는 통과 (회귀 가드)
+
+기존 `TestValidateTurnConfirm_V05_RearrangeBeforeMeld` (validator_test.go L211) 는 단순 `assert.Error` 만 호출하므로 에러 코드를 `ErrNoRearrangePerm` 으로 기대값 변경. (테스트 1건 수정)
+
+**영향도**:
+- 다른 호출자: `turn_service_test.go:553` 이 `engine.ErrInitialMeldSource` 를 기대 — 이 시나리오가 "최초 등록 전, 테이블 기존 세트 타일 제거" 인지 "랙 외 타일 사용" 인지 확인 필요. 구현 시점에 go-dev 가 판단.
+
+### 1.5 검증 계획
+
+- `go test ./internal/engine/...` 전체 통과 (기존 530개 + 신규 2개 = 532개)
+- `go test ./internal/service/...` 회귀 없음 (기존 `turn_service_test.go:553` 기대값 갱신 가능성 검토)
+- 엔진 단에서 끝나므로 Playwright E2E 회귀 불필요 (UI 는 에러 메시지만 표시)
+
+---
+
+## 2. V-13e — 조커 재드래그 UX
+
+### 2.1 Current state
+
+**데드락 해소 경위**:
+- Day 11 실측 I-4 — 조커가 포함된 서버 세트에 랙 타일 드롭 시 조커가 `pendingRecoveredJokers` 배열에만 추가되고 **랙(`pendingMyTiles`) 에 append 되지 않아** 드래그 불가. 턴 타임아웃 트랩.
+- PR #39 (`a58316e`) — `removeFirstOccurrence` + 회수 조커를 `pendingMyTiles` 에 즉시 추가하는 핫픽스. **데드락 해소**.
+- I-19 추가 수정 (handleConfirm) — "`pendingRecoveredJokers.length > 0` 이면 확정 차단" 이라는 과잉 차단을 "pendingMyTiles 에 남아있는 회수 조커가 있으면 차단" 으로 완화.
+
+**현 결함 (I-4 핫픽스 이후에도 남는 UX 누수)**:
+
+핵심: **`removeRecoveredJoker` 가 store 에 정의돼 있으나 어디에서도 호출되지 않음**.
+
+```
+src/frontend/src/store/gameStore.ts
+  L67:  removeRecoveredJoker: (code: TileCode) => void;
+  L172: removeRecoveredJoker: (code) => set((state) => { ... })
+
+src/frontend/src/app/game/[roomId]/GameClient.tsx
+  grep "removeRecoveredJoker" → 0 hits (store import 외)
+```
+
+사용자 시나리오:
+1. 서버 세트 [R5, JK1, R7] 에 랙 R6 을 드롭 → JK1 회수
+2. JokerSwapIndicator 배너 표시: "회수한 조커 1장: JK1"
+3. 사용자가 회수된 JK1 을 다른 pending 그룹에 재드래그 → 그룹에 추가됨 (data 반영 OK)
+4. **배너는 여전히 "회수한 조커 1장: JK1" 표시** ← 결함. 실제로는 이미 재배치됨
+5. 사용자가 "턴 확정" 클릭 → `unplacedRecoveredJokers.filter(...)` 가 JK1 이 pendingMyTiles 에 없음을 확인하고 통과. 정상 확정됨
+
+즉 **기능은 동작하지만 배너가 stale**. 사용자는 "조커를 썼는데 왜 경고가 계속 떠 있지?" 하고 불안. 또한 turn 이 RESET 되면 `clearRecoveredJokers` 가 호출되므로 다음 턴엔 깨끗하지만, 같은 턴 내 feedback 이 없다.
+
+**부수적 이슈 (심층 조사 중)**:
+
+- dnd-kit 드래그 시작 sensor: 현재 `pointerWithin` 사용, activation constraint 8px. 조커처럼 시각적으로 구분되는 타일은 빠른 더블 탭 시 drag 가 두 번 발생하는 경우가 실측에서 간헐적. activation distance 를 10px + delay 50ms 로 조정 검토.
+- Practice 모드와 실전 모드의 조커 회수 경로가 동일 — 분리 필요 없음.
+- FINDING-01 롤백 이후 `hasInitialMeld=false` 상태에서 서버 그룹 드롭은 line 869 의 명시 분기로 처리되므로 조커 swap 경로 (line 763~) 에 간섭하지 않음. 확인됨.
+
+### 2.2 State machine 설계
+
+조커 생애주기 상태를 명시적으로 모델링한다.
+
+```mermaid
+stateDiagram-v2
+    [*] --> OnTable : 턴 시작, 서버 세트에 조커 존재
+    OnTable --> Recovered : 랙 타일 드롭 (tryJokerSwap 성공)
+    Recovered --> Replaced : 회수된 조커를 다른 pending 그룹에 드롭
+    Recovered --> Recovered : 아직 배치 안 함 (idle)
+    Replaced --> [*] : 턴 확정 (CONFIRM_TURN)
+    Recovered --> OnTable : 턴 취소 (RESET_TURN)
+    Replaced --> OnTable : 턴 취소 (RESET_TURN)
+
+    note right of Recovered
+      배너 표시: "회수한 조커 N장"
+      랙에 append 되어 드래그 가능
+      확정 차단 (V-07)
+    end note
+
+    note right of Replaced
+      배너 비표시
+      pending 그룹 안에 재배치됨
+      확정 가능
+    end note
+```
+
+**state 구분 조건**:
+- `OnTable` — `gameState.tableGroups` 안의 특정 세트에 JK1/JK2 포함
+- `Recovered` — `pendingRecoveredJokers` 배열에 코드 있음 AND `pendingMyTiles` 에도 존재 (랙에 남아 아직 드래그 안 됨)
+- `Replaced` — `pendingRecoveredJokers` 배열에 코드 있음 AND `pendingMyTiles` 에는 없음 AND `pendingTableGroups` 어딘가에 존재
+
+현재 구현은 `Recovered` 와 `Replaced` 를 `pendingRecoveredJokers` 배열 하나로 표현하려 해서, 배너의 비표시 타이밍이 이상해짐. **해결**: `Replaced` 로 전이 시 `removeRecoveredJoker(code)` 를 호출해 배열에서 제거한다.
+
+### 2.3 UX flow 설계
+
+```mermaid
+flowchart TB
+    Start["사용자: 랙 R6 → [R5,JK1,R7]"]
+    Start --> Try["tryJokerSwap 호출"]
+    Try -->|성공| Swap["세트 = [R5,R6,R7]<br/>조커 JK1 회수"]
+    Swap --> Store["store.addRecoveredJoker(JK1)<br/>pendingMyTiles += JK1"]
+    Store --> Banner["JokerSwapIndicator 표시:<br/>회수한 조커 1장 (JK1)"]
+    Banner --> UserDrag["사용자: 랙 JK1 → pending 그룹"]
+    UserDrag --> Drop["handleDragEnd:<br/>랙 → pending 그룹 append"]
+    Drop --> Remove["✨ 신규: store.removeRecoveredJoker(JK1)"]
+    Remove --> BannerGone["JokerSwapIndicator 숨김<br/>(recoveredJokers.length === 0)"]
+    BannerGone --> Confirm["사용자: 턴 확정"]
+    Confirm --> Done["CONFIRM_TURN 전송"]
+
+    style Remove fill:#90ee90
+    style BannerGone fill:#90ee90
+```
+
+### 2.4 구현 계획
+
+**파일**:
+- `src/frontend/src/app/game/[roomId]/GameClient.tsx` — `removeRecoveredJoker` 호출 추가
+- `src/frontend/e2e/hotfix-p0-i4-joker-recovery.spec.ts` 또는 별도 `v13e-joker-rebanner.spec.ts` 신규 2 시나리오 추가
+- dnd-kit sensor 튜닝 (선택) — `GameClient.tsx` DndContext sensors prop
+
+**GameClient.tsx 수정 포인트**:
+
+1. "랙 → pending 그룹 append" 분기 (line 801~842 `existingPendingGroup` 블록):
+   - 드롭되는 타일이 `pendingRecoveredJokers` 에 포함되면 → `removeRecoveredJoker(tileCode)` 호출 추가
+   - ~3 LOC 추가
+
+```tsx
+// L840 부근
+setPendingTableGroups(nextTableGroups);
+setPendingMyTiles(nextMyTiles);
+// ✨ 신규: 회수된 조커가 재배치되면 배너에서 제거
+if (pendingRecoveredJokers.includes(tileCode)) {
+  removeRecoveredJoker(tileCode);
+}
+return;
+```
+
+2. "랙 → 새 그룹 생성" 분기 (line 807~821):
+   - 동일 패턴 적용
+
+3. "랙 → 서버 확정 그룹 합병" 분기 (hasInitialMeld=true 경우):
+   - 동일 패턴 적용
+
+4. `handleUndo` (L1259~) — 이미 `clearRecoveredJokers()` 호출 중. 변경 없음.
+
+5. dnd-kit sensor 튜닝 (선택):
+   ```tsx
+   const sensors = useSensors(
+     useSensor(PointerSensor, { activationConstraint: { distance: 10 } })
+   );
+   ```
+   현재 값 확인 후 결정 (구현 시점).
+
+**E2E 시나리오 신규 2건**:
+
+- `v13e-banner-clears.spec.ts` 또는 기존 `hotfix-p0-i4-joker-recovery.spec.ts` SC4/SC5 추가
+  - SC4: 조커 회수 → 재배치 후 JokerSwapIndicator 배너가 `removed` (DOM 에서 삭제됨)
+  - SC5: 조커 회수 → 재배치 → 다시 drag back 하면 배너가 재표시 (state 반전)
+
+### 2.5 위험 요소 및 대응
+
+| 리스크 | 대응 |
+|------|------|
+| FINDING-01 같은 useEffect 의존성 누락 | `removeRecoveredJoker` 는 store action 이므로 useEffect 와 무관. 단순 이벤트 핸들러 내 호출. 안전 |
+| PR #51 롤백 영역 (line 869 `hasInitialMeld=false` 서버 그룹 분기) 간섭 | 조커 swap 은 line 763~794 에서 선행 처리되므로 line 869 에 도달하지 않음. 검증 완료 |
+| `pendingRecoveredJokers` 배열과 `pendingTableGroups` 실제 상태의 sync 깨짐 | derived state 로 전환 고려 가능 (L3 향후 리팩터). 이번 Sprint 는 imperative sync 유지 |
+| dnd-kit sensor 변경 시 기존 드래그 동작 변화 | Playwright 기존 시나리오 전체 회귀. sensor 튜닝은 **optional**. 결함 재현 시에만 적용 |
+
+---
+
+## 3. Verification plan
+
+### 3.1 단위 테스트
+
+**V-13a**:
+- Go: `validator_test.go` 신규 2건 + 기존 `TestValidateTurnConfirm_V05_RearrangeBeforeMeld` 기대값 변경
+- `go test ./internal/engine/...` 통과
+- `go test ./internal/service/...` 통과 (turn_service_test 영향 확인)
+
+**V-13e**:
+- Jest (gameStore 단위테스트 있다면): `removeRecoveredJoker` 호출 후 배열에서 코드 삭제 확인
+- 현재 Jest 201개 통과 유지
+
+### 3.2 통합/E2E
+
+**V-13e**:
+- `hotfix-p0-i4-joker-recovery.spec.ts` 기존 SC1~SC3 통과 유지 (회귀 가드)
+- 신규 SC4/SC5 추가 (배너 클리어 + 재표시)
+- 관련 `sprint7-prep-rearrangement.spec.ts` 영향 확인
+
+**V-13a**:
+- E2E 직접 관련 없음. 에러 메시지만 변경.
+- 선택: 최초 등록 전 재배치 시도 시 "최초 등록 전에는 테이블 재배치가 불가합니다" 메시지 표시를 Playwright 로 1건 검증
+
+### 3.3 회귀 테스트
+
+- go test 전체: 530/530 + 신규 2 = 532/532
+- Jest: 201/201 유지
+- Playwright E2E: 기존 시나리오 전체 통과 유지 + 신규 2건 추가
+
+---
+
+## 4. 병렬 실행 매트릭스 + worktree 전략
+
+### 4.1 의존성 매트릭스
+
+| | V-13a | V-13e |
+|---|---|---|
+| **V-13a** | — | 독립 |
+| **V-13e** | 독립 | — |
+
+두 작업은 **완전 독립**. 공유 파일 없음. 공유 테스트 suite 없음.
+
+### 4.2 Worktree 전략
+
+```bash
+# V-13a (go-dev)
+git worktree add ../rummiarena-v13a refactor/v13a-err-no-rearrange-perm
+
+# V-13e (frontend-dev)
+git worktree add ../rummiarena-v13e feat/v13e-joker-redrop-ux
+```
+
+### 4.3 예상 타임라인 (병렬)
+
+| Phase | V-13a (go-dev) | V-13e (frontend-dev) |
+|-------|--------------|-------------------|
+| 분석 (이 문서 읽기) | 10min | 10min |
+| 구현 | 60min (validator 분기 + 테스트 2건) | 90min (3개 분기 수정 + Playwright 2건) |
+| 검증 | 20min (go test 전체) | 30min (Jest + Playwright) |
+| PR 작성 | 15min | 15min |
+| **총** | **105min** | **145min** |
+
+병렬 기준 Day 3 오전 완료 가능. **총 소요 ~2.5h** (longest path = V-13e 145min).
+
+### 4.4 머지 순서
+
+독립이므로 순서 무관. PR 각각 리뷰 → merge. qa 에이전트가 합친 main 에서 회귀 스모크 1회.
+
+---
+
+## 5. Risk budget
+
+### 5.1 V-13a 리스크
+
+- **LOW** — 백엔드 검증 경로 1개 분기 추가. 기존 통과 경로 영향 없음.
+- 유일한 주의점: `turn_service_test.go:553` 의 `ErrInitialMeldSource` 기대값이 실제로 V-13a 시나리오인지 구현 시 재판정. 맞으면 `ErrNoRearrangePerm` 로 변경.
+
+### 5.2 V-13e 리스크
+
+- **MEDIUM** — 게임 중 핵심 상호작용. FINDING-01 (PR #51) 사례처럼 회귀 가능성 있음.
+- 방어선:
+  1. Playwright E2E 기존 시나리오 전체 통과 필수
+  2. 신규 2 시나리오로 배너 클리어/재표시 cover
+  3. useEffect 의존성 배열 변경 없음 (store action 호출만 추가)
+  4. dnd-kit sensor 튜닝은 **결함 재현 시에만 적용** (이번 PR 범위 제외 가능)
+
+### 5.3 전체 리스크 레벨
+
+**LOW-MEDIUM**. 작업 범위 작고 독립. 테스트 coverage 충분. Day 3 반나절 완결 가능.
+
+---
+
+## 6. 후속 작업 (이번 Sprint 범위 밖)
+
+- 조커 상태를 `pendingRecoveredJokers` 배열 + `pendingMyTiles` 양쪽 관리 대신 **derived state** 로 전환 (L3 리팩터). 이번 Sprint 에서는 imperative sync 유지
+- `ValidationError` 구조에 `Category` 필드 추가 (V-01~V-15 범주화)
+- Playtest S4 결정론적 시드에 V-13e 시나리오 추가 (현재 "조커 미획득 스킵")
+
+---
+
+## 7. 체크리스트 (구현 킥오프용)
+
+**V-13a (go-dev)**:
+- [ ] `validator.go validateInitialMeld` 에 V-13a 분기 추가
+- [ ] `validator_test.go` 신규 테스트 2건 (`V13a_NoRearrangePerm`, `V13a_AfterMeld_Allowed`)
+- [ ] `validator_test.go:211 TestValidateTurnConfirm_V05_RearrangeBeforeMeld` 기대값 `ErrNoRearrangePerm` 로 수정
+- [ ] `turn_service_test.go:553` 기대값 재판정
+- [ ] `go test ./internal/engine/... ./internal/service/...` 통과
+- [ ] `docs/02-design/31-game-rule-traceability.md` V-13a 행 ⚠️ → ✅ 갱신
+
+**V-13e (frontend-dev)**:
+- [ ] `handleDragEnd` 3개 분기에 `removeRecoveredJoker` 호출 추가 (랙→pending, 랙→새 그룹, 랙→서버 그룹 합병)
+- [ ] `useCallback` 의존성 배열에 `removeRecoveredJoker`, `pendingRecoveredJokers` 포함
+- [ ] E2E 신규 2 시나리오 (SC4 배너 clear, SC5 재표시)
+- [ ] 기존 `hotfix-p0-i4-joker-recovery.spec.ts` 통과
+- [ ] Jest 201/201, Playwright 기존 시나리오 통과
+- [ ] `docs/02-design/31-game-rule-traceability.md` V-13e 행 UI 칸 ⚠️ → ✅ 갱신 (배너 동기화 추가 근거)
+- [ ] dnd-kit sensor 튜닝 — 결함 재현 시에만
+
+---
+
+## 8. V-13e Pair Coding Spec (architect ↔ frontend-dev)
+
+- 작성일: 2026-04-23 (Sprint 7 Day 2 저녁)
+- 작성자: architect (Opus 4.7 xhigh)
+- 상태: **Proposed** — frontend-dev 가 본 섹션만 보고 구현 가능한 수준을 목표로 함
+- 배경: 사용자 지시 — "UI 수정은 개발자 혼자 하지 말고 아키텍트와 함께 코딩하도록. 상태가 너무 심각합니다" (2026-04-23)
+- 원칙: **단위 단계 하나 구현 → Jest + Playwright SC6/SC7 확인 → 다음 단계**. 병렬 금지
+
+### 8.1 현재 코드 좌표 확인 (2026-04-23 기준)
+
+이 섹션의 라인 번호는 **현 main HEAD (PR #51 머지 후)** 기준. 구현 시 `git log -p src/frontend/src/app/game/\[roomId\]/GameClient.tsx` 로 라인 시프트 확인 후 보정할 것.
+
+| 파일 | 라인 | 현재 상태 |
+|------|------|----------|
+| `src/frontend/src/store/gameStore.ts:67` | interface 선언 | `removeRecoveredJoker: (code: TileCode) => void;` |
+| `src/frontend/src/store/gameStore.ts:172-179` | action 구현 | `indexOf` + `splice` 로 첫 occurrence 제거. WARN-03 guard 에 의해 `pendingRecoveredJokers` 는 중복 없음 (addRecoveredJoker 가 push 전에 includes 체크) |
+| `src/frontend/src/app/game/[roomId]/GameClient.tsx:455` | destructure | `pendingRecoveredJokers,` 현재 존재 |
+| `src/frontend/src/app/game/[roomId]/GameClient.tsx:462-463` | destructure | `addRecoveredJoker, clearRecoveredJokers,` **현재 `removeRecoveredJoker` 누락** |
+| `src/frontend/src/app/game/[roomId]/GameClient.tsx:664` | `handleDragEnd = useCallback(` 시작 | — |
+| `src/frontend/src/app/game/[roomId]/GameClient.tsx:1105-1120` | useCallback 의존성 배열 | 현재 14개. `removeRecoveredJoker` 미포함 |
+| `src/frontend/src/app/game/[roomId]/GameClient.tsx:1508` | JokerSwapIndicator 렌더 | `<JokerSwapIndicator recoveredJokers={pendingRecoveredJokers} />` (단순 props pass-through) |
+
+### 8.2 `removeRecoveredJoker` 시그니처·동작 재확인 (gameStore.ts)
+
+```ts
+// src/frontend/src/store/gameStore.ts:172-179 (현재 그대로 유지 — 변경 없음)
+removeRecoveredJoker: (code) =>
+  set((state) => {
+    const idx = state.pendingRecoveredJokers.indexOf(code);
+    if (idx < 0) return {};                     // 해당 code 없으면 no-op
+    const next = [...state.pendingRecoveredJokers];
+    next.splice(idx, 1);                        // 첫 occurrence 만 제거
+    return { pendingRecoveredJokers: next };
+  }),
+```
+
+**불변식** (frontend-dev 가 구현 전 반드시 이해):
+
+1. `pendingRecoveredJokers` 에는 중복이 없다 — `addRecoveredJoker` 의 WARN-03 guard 가 보장.
+2. 따라서 `removeRecoveredJoker(code)` 는 **최대 1건** 만 제거.
+3. 존재하지 않는 code 를 넘기면 no-op. **방어적 check 불필요**.
+4. 제거 후 배열 length 가 0 이면 `<JokerSwapIndicator />` 는 현행 렌더 로직상 자동 비표시 (컴포넌트 내부에서 `recoveredJokers.length === 0 ? null : ...`).
+
+→ store 변경은 **필요 없음**. GameClient 에서 `removeRecoveredJoker(tileCode)` 를 정확한 위치에서 호출만 하면 됨.
+
+### 8.3 handleDragEnd 3 분기별 수정 지점 (라인 단위)
+
+#### 분기 A — 랙 → 기존 pending 그룹 append (line 801~842)
+
+**목적**: 랙 타일을 이미 존재하는 pending 그룹에 드롭.
+
+**두 sub-case**:
+
+- (A-1) 호환 불가 → 새 그룹 생성 경로 (line 806~821, 819 `addPendingGroupId` 후 early return)
+- (A-2) 호환 가능 → 기존 그룹에 append (line 822~841, 840 `setPendingMyTiles` 후 return)
+
+**수정 삽입 위치**:
+
+```tsx
+// 분기 A-1: line 819 "addPendingGroupId(newGroupId);" 바로 다음 줄
+// before return 문
+if (pendingRecoveredJokers.includes(tileCode)) {
+  removeRecoveredJoker(tileCode);
+}
+return;
+```
+
+```tsx
+// 분기 A-2: line 840 "setPendingMyTiles(nextMyTiles);" 바로 다음 줄
+// before "return;"
+if (pendingRecoveredJokers.includes(tileCode)) {
+  removeRecoveredJoker(tileCode);
+}
+return;
+```
+
+> **왜 setPendingMyTiles 직후인가**: 배너 업데이트는 React state 반영 순서와 상관없이 자동으로 next render 에 반영된다. `setPendingTableGroups` 이전에 호출해도 동작상 차이는 없지만, **데이터 배치 완료 → 부수효과 (배너 정리)** 순서로 읽히도록 마지막에 배치.
+
+#### 분기 B — 랙 → 서버 확정 그룹 merge (line 885~925)
+
+**두 sub-case**:
+
+- (B-1) 호환 불가 → 새 그룹 생성 (line 886~902, 900 `addPendingGroupId` 후 return)
+- (B-2) 호환 가능 → 서버 그룹에 append (line 903~925, 923 `addPendingGroupId` 후 return)
+
+> **주의**: 이 분기는 `hasInitialMeld=true` 에서만 도달. FINDING-01 롤백(line 869 `!hasInitialMeld`)는 그 이전에 early return 하므로 조커 경로와 무관. 단 line 869 경로에도 **조커가 도달할 수 있는지** 는 §8.3.4 에서 별도 판정.
+
+**수정 삽입 위치**:
+
+```tsx
+// 분기 B-1: line 900 "addPendingGroupId(newGroupId);" 다음 줄, before return
+if (pendingRecoveredJokers.includes(tileCode)) {
+  removeRecoveredJoker(tileCode);
+}
+return;
+```
+
+```tsx
+// 분기 B-2: line 923 "addPendingGroupId(targetServerGroup.id);" 다음 줄, before return
+if (pendingRecoveredJokers.includes(tileCode)) {
+  removeRecoveredJoker(tileCode);
+}
+return;
+```
+
+#### 분기 C — 랙 → 보드 빈 공간 (game-board) (line 933~1056)
+
+**목적**: `treatAsBoardDrop === true` 일 때 실행. 두 sub-case:
+
+- (C-1) lastPendingGroup 에 append (line 1019~1029)
+- (C-2) 새 그룹 생성 (line 1030~1056)
+
+**수정 삽입 위치**:
+
+```tsx
+// 분기 C-1: line 1029 "setPendingMyTiles(nextMyTiles);" 다음 줄
+// (이 sub-case 는 명시적 return 문이 없음 — if/else 블록 끝에서 자연 탈출)
+if (pendingRecoveredJokers.includes(tileCode)) {
+  removeRecoveredJoker(tileCode);
+}
+```
+
+```tsx
+// 분기 C-2: line 1055 "if (forceNewGroup) setForceNewGroup(false);" 다음 줄
+// else 블록 끝, 마찬가지로 명시적 return 없음
+if (pendingRecoveredJokers.includes(tileCode)) {
+  removeRecoveredJoker(tileCode);
+}
+```
+
+> **주의**: 분기 C 는 line 933 `if (treatAsBoardDrop)` 블록 내부. `setForceNewGroup(false)` 뒤에 `}` 닫히고 `} else if (over.id === "game-board-new-group") {` 이어짐 (line 1057). `removeRecoveredJoker` 호출은 **C-2 블록 내부에서만** — `else if` 로 넘어가기 전에.
+
+#### 분기 D — `game-board-new-group` 드롭존 (line 1057~) [추가 검토]
+
+현 디자인 §2.4 에서는 "3 분기" 로 분류했으나 실제 코드엔 `over.id === "game-board-new-group"` 별도 경로 (line 1057) 가 존재. 조커도 이 경로로 드롭될 수 있음.
+
+**판정**: **분기 D 도 동일한 수정 적용**. line 1057 이후 블록 탐색해 최종 setPendingMyTiles 뒤에 동일 삽입.
+
+> **frontend-dev 액션 아이템**: 구현 시 line 1057~의 `else if` 블록 안쪽을 Read 로 확인 후 마지막 `setPendingMyTiles` 직후에 동일 패턴 추가.
+
+### 8.4 destructure 추가 (line 462-463)
+
+```diff
+    addPendingGroupId,
+    clearPendingGroupIds,
+-   addRecoveredJoker,
++   addRecoveredJoker,
++   removeRecoveredJoker,
+    clearRecoveredJokers,
+```
+
+### 8.5 useCallback 의존성 배열 설계 — FINDING-01 재발 방지
+
+#### 8.5.1 현재 배열 (line 1105~1120)
+
+```tsx
+[
+  isMyTurn, currentTableGroups, currentMyTiles,
+  setPendingTableGroups, setPendingMyTiles,
+  addPendingGroupId, clearPendingGroupIds,
+  addRecoveredJoker,
+  pendingTableGroups, pendingMyTiles, pendingGroupIds, myTiles,
+  forceNewGroup, hasInitialMeld,
+]
+```
+
+#### 8.5.2 추가 대상 및 판정
+
+| 추가 후보 | 추가 여부 | 판정 근거 |
+|----------|----------|----------|
+| `removeRecoveredJoker` | ✅ **추가** | zustand store action 은 참조 안정이지만, ESLint `react-hooks/exhaustive-deps` 가 호출을 감지. 일관성 + 린트 PASS |
+| `pendingRecoveredJokers` | ✅ **추가** | handler 내부 `includes` 로 읽음. stale closure 발생 시 이미 비워진 배열을 체크해 remove 를 생략할 수 있음. 실전 시나리오 — 같은 턴 내 drag-drop-drag-drop 반복 시 |
+
+#### 8.5.3 최종 배열
+
+```tsx
+[
+  isMyTurn, currentTableGroups, currentMyTiles,
+  setPendingTableGroups, setPendingMyTiles,
+  addPendingGroupId, clearPendingGroupIds,
+  addRecoveredJoker,
+  removeRecoveredJoker,          // ✨ 신규
+  pendingTableGroups, pendingMyTiles, pendingGroupIds, myTiles,
+  pendingRecoveredJokers,        // ✨ 신규
+  forceNewGroup, hasInitialMeld,
+]
+```
+
+#### 8.5.4 "하지 말 것" 체크리스트 (PR #51 FINDING-01 재발 방지)
+
+1. **✗ `pendingRecoveredJokers` 배열 전체를 ref 로 우회하지 말 것**
+   - 근거: FINDING-01 은 "의존성 배열 누락을 알고도 ref 우회로 '성능 최적화' 시도" 가 원인. handler 가 최신 상태를 본다는 보장 없음.
+   - 예외 없음. zustand store 는 이미 snapshot 제공.
+
+2. **✗ useCallback 을 제거해 inline 함수로 바꾸지 말 것**
+   - 근거: DndContext 의 `onDragEnd` prop 이 매 렌더 재생성되면 sensor/overlay 에 잠재적 리렌더 trigger. 현재 `useCallback` 을 유지하고 deps 만 정확히 맞춘다.
+
+3. **✗ `pendingRecoveredJokers.length` 를 primitive 으로 추출해 deps 에 넣는 trick 쓰지 말 것**
+   - 근거: `.includes(tileCode)` 는 배열 원소 자체에 의존. length 만으로는 "어떤 코드가 들었는지" 판정 불가.
+
+4. **✗ `if (pendingRecoveredJokers.includes(tileCode))` 체크 없이 `removeRecoveredJoker(tileCode)` 를 무조건 호출하지 말 것**
+   - 근거: store action 자체가 no-op 이지만, **데드 코드** 로 의도 모호. 리뷰어가 "왜 모든 드롭마다 호출?" 의문 품음. 방어적 의도 명시적으로 표현.
+
+5. **✗ 분기 A/B/C/D 중 일부만 수정하고 나머지를 "다음 PR" 로 미루지 말 것**
+   - 근거: 조커 재드래그 경로가 3~4 분기로 갈라져 있는데 한두 곳만 수정하면 사용자 시나리오에 따라 **간헐 버그** 발생. FINDING-01 도 "일부 경로만 수정" 에서 재발.
+
+6. **✗ Playwright SC6/SC7 skip 옵션으로 건너뛰지 말 것**
+   - 근거: SC2 가 이미 "dnd-kit hydration race" 로 skip 돼 있음. SC6/SC7 도 skip 하면 regression guard 부재. race 해소가 먼저.
+
+### 8.6 Playwright 신규 시나리오 — SC6 + SC7
+
+기존 `hotfix-p0-i4-joker-recovery.spec.ts` 에 **SC6, SC7 을 append** (SC4/SC5 는 이미 I-19 데이터 주입 테스트로 점유 중이므로 SC 번호 중복 금지).
+
+#### 8.6.1 SC6 — 조커 재배치 후 배너 소멸
+
+```ts
+// 위치: src/frontend/e2e/hotfix-p0-i4-joker-recovery.spec.ts 파일 끝에 append
+test.describe("TC-I4-SC6: 조커 재배치 시 JokerSwapIndicator 배너 소멸 (V-13e)", () => {
+  test.setTimeout(180_000);
+
+  test.afterEach(async ({ page }) => {
+    await cleanupViaPage(page).catch(() => {});
+  });
+
+  test("TC-I4-SC6: 회수된 JK1 을 다른 pending 그룹에 드래그하면 joker-swap-indicator 가 DOM 에서 사라진다", async ({
+    page,
+  }) => {
+    await createRoomAndStart(page, {
+      playerCount: 2,
+      aiCount: 1,
+      turnTimeout: 60,
+    });
+    await waitForGameReady(page);
+    await setupJokerSwapScenario(page);
+
+    // Step 1: 조커 회수 트리거 — 서버 [R5, JK1, R7] 에 R6a 드롭
+    const r6 = page.locator('[aria-label="R6a 타일 (드래그 가능)"]').first();
+    const r5 = page.locator('[aria-label*="R5a 타일"]').first();
+    await expect(r6).toBeVisible({ timeout: 5000 });
+    await dndDrag(page, r6, r5);
+    await page.waitForTimeout(500);
+
+    // Step 2: JokerSwapIndicator 배너가 먼저 표시됐는지 확인
+    const indicator = page.locator('[data-testid="joker-swap-indicator"]');
+    await expect(indicator).toBeVisible({ timeout: 3000 });
+
+    // Step 3: 랙에 나타난 JK1 을 다른 pending 그룹 (예: board 빈 공간) 으로 드롭
+    //   → 분기 C-2 (새 그룹 생성) 을 태움
+    const jk1 = page.locator('[aria-label="JK1 타일 (드래그 가능)"]').first();
+    await expect(jk1).toBeVisible({ timeout: 5000 });
+    const board = page.locator('[data-testid="game-board"]').first();
+    await dndDrag(page, jk1, board);
+    await page.waitForTimeout(500);
+
+    // Then: JokerSwapIndicator 가 DOM 에서 사라져야 한다
+    //   (컴포넌트 내부에서 recoveredJokers.length === 0 이면 null 렌더)
+    await expect(indicator).toHaveCount(0, { timeout: 2000 });
+  });
+});
+```
+
+#### 8.6.2 SC7 — 재배치 후 랙으로 되돌리면 배너 재표시
+
+```ts
+test.describe("TC-I4-SC7: 조커 재배치 후 랙 복귀 시 배너 재표시 (V-13e 역전)", () => {
+  test.setTimeout(180_000);
+
+  test.afterEach(async ({ page }) => {
+    await cleanupViaPage(page).catch(() => {});
+  });
+
+  test("TC-I4-SC7: 재배치한 JK1 을 다시 랙으로 드래그하면 joker-swap-indicator 가 재표시", async ({
+    page,
+  }) => {
+    /**
+     * 이 테스트는 **필수는 아니지만**, V-13e 설계상 state 가 대칭으로 동작하는지 가드.
+     * removeRecoveredJoker 를 호출했다가 사용자가 다시 랙으로 드래그하면
+     * 조커는 다시 pendingRecoveredJokers 에 add 돼야 한다.
+     *
+     * 주의: "랙 → pending → 랙" 경로에서 addRecoveredJoker 가 다시 호출되는 경로는
+     * 현재 코드에 **없다** (pending → 랙 분기는 line 1079~1102 의 "pending 그룹 → 랙" 경로).
+     * 따라서 이 SC7 은 **실패가 예상되는** 테스트로 작성해 기능 gap 을 표면화한다.
+     * frontend-dev 가 SC7 을 처리하려면 pending → 랙 복귀 경로에 addRecoveredJoker 추가 구현
+     * 필요. Sprint 7 범위: SC7 은 `test.fixme` 로 marked 하고 별건 이슈로 추적.
+     */
+    test.fixme(true, "V-13e 역방향 대칭은 별건 이슈 (IS-V13E-SC7). 현재는 SC6 만 가드");
+  });
+});
+```
+
+> **SC7 에 대한 판정**: 현 구현은 "pending → 랙" 복귀 시 조커가 다시 recoveredJokers 에 추가되는 경로가 없음. 즉 `removeRecoveredJoker` 가 한 번 호출되고 나면 같은 턴 내 재회수 불가. 이것은 V-13e 에서 해결하지 말고 **별건 IS-V13E-SC7** 으로 추적. Sprint 7 V-13e 범위는 SC6 PASS 확보까지.
+
+#### 8.6.3 셀렉터 · 타임아웃 표
+
+| 용도 | 셀렉터 | 타임아웃 |
+|------|--------|----------|
+| JokerSwapIndicator 배너 가시성 | `[data-testid="joker-swap-indicator"]` | 3s |
+| 배너 소멸 확인 (`toHaveCount(0)`) | 동일 | 2s |
+| R6a 랙 타일 | `[aria-label="R6a 타일 (드래그 가능)"]` | 5s |
+| R5a 드롭 타겟 | `[aria-label*="R5a 타일"]` | 5s |
+| JK1 재드래그 | `[aria-label="JK1 타일 (드래그 가능)"]` | 5s |
+| 게임 보드 빈 공간 | `[data-testid="game-board"]` | 5s |
+| `page.waitForTimeout` (드래그 후 state reflect) | — | 500ms |
+
+> **주의**: `page.waitForTimeout(500)` 은 안티패턴이지만 `dndDrag` 이후 zustand state → DOM 반영까지의 비동기 체인이 Playwright auto-wait 로 잡히지 않는 경우가 간헐. 기존 SC1/SC3 도 동일 패턴 사용 중이므로 관례 유지.
+
+### 8.7 테스트 데이터 (조커 회수 가능 설정)
+
+`setupJokerSwapScenario(page)` (line 43) 가 이미 정의돼 있음. 이 헬퍼가 수행하는 것:
+
+- 랙에 **R6a** 를 강제 배치 (`__rummikub_devtools` 브릿지 사용)
+- 서버 테이블에 **[R5, JK1, R7]** 런 배치
+- 이로써 R6a 를 R5/R7 사이에 드롭하면 `tryJokerSwap` 성공 조건 성립
+
+SC6 는 이 헬퍼를 그대로 재사용. **추가 fixture 작성 불필요**.
+
+### 8.8 구현 순서 (체크리스트)
+
+frontend-dev 는 아래 순서를 **엄격히** 지킨다. 각 단계 완료 시 commit 분리 권장 (리뷰 가능성).
+
+- [ ] **Step 0** — 현재 main pull & 본 섹션 전체 읽기. 라인 번호 시프트 확인 (`grep -n "handleDragEnd" GameClient.tsx`)
+- [ ] **Step 1** — destructure 에 `removeRecoveredJoker` 추가 (line 463 근처). 빌드 통과 확인 (`pnpm build` 가능 여부만)
+- [ ] **Step 2** — 분기 A-1, A-2 에 `removeRecoveredJoker` 호출 추가 (§8.3 분기 A)
+- [ ] **Step 3** — 분기 B-1, B-2 에 동일 호출 추가 (§8.3 분기 B)
+- [ ] **Step 4** — 분기 C-1, C-2 에 동일 호출 추가 (§8.3 분기 C)
+- [ ] **Step 5** — 분기 D 존재 여부 확인 후 적용 (§8.3.4)
+- [ ] **Step 6** — useCallback deps 배열 업데이트 (`removeRecoveredJoker`, `pendingRecoveredJokers` 추가, §8.5.3)
+- [ ] **Step 7** — `pnpm lint` ESLint `react-hooks/exhaustive-deps` 경고 0 건 확인
+- [ ] **Step 8** — SC6 테스트 파일에 append
+- [ ] **Step 9** — SC7 `test.fixme` 로 marked
+- [ ] **Step 10** — Playwright 로컬 실행: `pnpm test:e2e --grep "TC-I4"` — SC1/SC3 통과 + SC6 PASS 확인
+- [ ] **Step 11** — 기존 Playwright 전체 회귀 `pnpm test:e2e` (Known fail 4 제외 PASS 유지)
+- [ ] **Step 12** — Jest 전체 `pnpm test` 201/201 유지 확인
+- [ ] **Step 13** — `docs/02-design/31-game-rule-traceability.md` V-13e UI 칸 ⚠️ → ✅ 갱신
+- [ ] **Step 14** — PR 생성 (base: main, title: "fix(frontend): V-13e — 조커 재배치 시 배너 동기화 (SC6)")
+
+**각 단계 완료 후 Step 실패 시 architect 에게 SendMessage 로 질의**. 다음 Step 진행 금지.
+
+### 8.9 SKILL 적용 지점
+
+| SKILL | 적용 단계 | 역할 |
+|-------|---------|------|
+| `code-modification` | Step 0~6 구현 전반 | 분석→계획→구현→검증 4단계 템플릿 |
+| `ui-regression` | Step 10~11 Playwright | FINDING-01 의 회귀 가드 패턴 (snapshot + E2E 연동) |
+| `pre-deploy-playbook` | Step 14 PR 직전 | Jest/Playwright/Lint/Build 전수 PASS 체크리스트 |
+| `simplify` | Step 5 분기 D 탐색 시 | "분기가 4개 이상이면 동일 헬퍼 함수로 추출 고려" 가이드 |
+
+### 8.10 예상 변경 규모
+
+| 파일 | +LOC | -LOC | 순변화 |
+|------|------|------|-------|
+| `src/frontend/src/app/game/[roomId]/GameClient.tsx` | +14 (4~5 분기 × 3 줄) + 2 (deps) + 1 (destructure) | -0 | +17 |
+| `src/frontend/e2e/hotfix-p0-i4-joker-recovery.spec.ts` | +95 (SC6 + SC7 fixme) | -0 | +95 |
+| `docs/02-design/31-game-rule-traceability.md` | +1 (status ✅) | -1 | 0 |
+| **합계** | **+110** | **-1** | **+109** |
+
+### 8.11 Risk (V-13e 재평가)
+
+| Risk | 확률 | 영향 | 완화 |
+|------|------|------|------|
+| FINDING-01 같은 useEffect 누락 재발 | 낮 | 고 | §8.5.4 하지 말 것 6건 + Step 7 린트 + Step 10~11 E2E |
+| 분기 C/D 에서 조커가 실제로 도달 못 하는 dead code 작성 | 중 | 낮 | 분기 C/D 는 board 빈 공간 드롭. 조커 재드래그 시 사용자가 board 로 던질 가능성 있으므로 dead 아님 |
+| SC6 이 dnd-kit hydration race 로 flaky | 중 | 중 | SC1/SC3 가 동일 헬퍼로 이미 stable. SC6 은 동일 패턴 재사용. flaky 발생 시 `test.retries(2)` 로 대응 |
+| removeRecoveredJoker 를 4 분기 모두에 복붙 → 코드 중복 | 중 | 낮 | 리뷰에서 헬퍼 함수 추출 제안 (ex. `maybeRemoveRecoveredJoker(tileCode)`). Sprint 7 범위엔 복붙 수용 (simplify SKILL 판단) |
+
+### 8.12 완료 정의 (Definition of Done)
+
+- [ ] Step 0~14 전부 체크됨
+- [ ] Playwright SC6 PASS + 기존 SC1/SC3 PASS 유지 + SC2 skip 유지 + SC4/SC5 PASS 유지
+- [ ] Jest 201/201
+- [ ] ESLint 경고 0 (deps 누락 없음)
+- [ ] `docs/02-design/31-game-rule-traceability.md` V-13e 행 UI 칸 ✅
+- [ ] PR 설명에 본 섹션 §8.3 분기별 수정 표 복붙 (리뷰어가 4~5 곳 수정을 한 번에 확인)
+- [ ] architect 리뷰 approval (FINDING-01 재발 방지 #1~#6 체크리스트 승인)
+
+---
+
+**문서 끝.**

--- a/docs/02-design/50-d03-phase2-cutover-plan.md
+++ b/docs/02-design/50-d03-phase2-cutover-plan.md
@@ -1,0 +1,825 @@
+# 50. D-03 Phase 2 — rooms Read-Path Full Cutover 설계 (Phase 2a/2b/2c)
+
+- 작성일: 2026-04-23 (Sprint 7 Day 2)
+- 작성자: architect (Opus 4.7 xhigh)
+- 상태: **Proposed — Sprint 7 내 전 Phase 완주**
+- 연관 PR: #40 (ADR D-03), #42 (Phase 1 Dual-Write 구현), #50 (ADR-025 게스트 방)
+- 연관 ADR: ADR D-03 (`work_logs/decisions/2026-04-22-rooms-postgres-phase1.md`), ADR-025 (`docs/02-design/48-adr-025-guest-room-persistence.md`)
+- 분류: Persistence · Data Integrity · Read-Path Migration · **HIGH Risk**
+
+---
+
+## 1. Executive Summary
+
+> **이 문서는 D-03 Phase 2 전체(2a/2b/2c) 의 Sprint 7 내 완주 설계**이다. 2026-04-23 사용자 지시로 "Week 2 후반 또는 Sprint 8" 이관 경로는 삭제됐다. Phase 2a Shadow Read 는 **자동화 검증 기반으로 48h 관찰을 축약** 하여, Day 4 오전에 2a 시작 → 자동 게이트 통과 시 Day 4 오후 2b → Day 5 2c 로 진행한다.
+
+### 1.1 왜 HIGH Risk 인가
+
+rooms 조회는 **실시간 게임 진행 경로 그 자체**다. 현재 메모리 정본에서 PostgreSQL 로 **primary read** 를 옮기는 순간:
+
+1. 게임 시작 (`StartGame`), WebSocket 재연결 인증 (`ws_handler.go:296`), LeaveRoom 호스트 인계, FinishRoom 게임 종료 기록(`ws_handler.go:1961`) 이 전부 DB 가용성에 묶인다.
+2. PostgreSQL p99 latency 가 Redis + memory repo 대비 **10~100배** 느리다 (측정값 없음, 설치 prepareForPhase2a 단계에서 실측 필수).
+3. Phase 1 Dual-Write 는 **best-effort 3초 타임아웃** 이라서 **1주일 누적 드리프트 가능성** 이 실제로 존재한다. Shadow Read 없이 바로 cutover 하면 드리프트된 row 를 primary 로 믿고 잘못된 상태를 브로드캐스트할 수 있다.
+
+### 1.2 Sprint 7 Day 3~5 실행 범위 (전 Phase 완주)
+
+| 항목 | 실행 슬롯 | 담당 |
+|---|---|---|
+| **선행**: IS-PH2A-01 DeleteRoom dual-write 수정 | Day 3 오전 | go-dev |
+| **선행**: IS-PH2A-02 `checkDuplicateRoom` 서비스 경유 리팩터 | Day 3 오전 | go-dev |
+| Phase 2a — Shadow Read 구현 + 메트릭 | Day 3 오후 | go-dev + devops |
+| Phase 2a Flag on + **자동 검증 스크립트** 실행 | Day 4 오전 (~2h 축약) | devops |
+| **Phase 2b — Primary 역전** (read-through cache) | Day 4 오후 | go-dev + devops |
+| Phase 2b 안정 게이트 (auto-rollback 준비) | Day 4 저녁 ~ Day 5 오전 (~12h) | devops + qa |
+| **Phase 2c — memory rooms 제거** | Day 5 오후 | go-dev |
+| ADR-025 개정 (게스트 방 DB 전환 또는 Redis cache 경로) | Day 5 오후 | architect + go-dev |
+
+### 1.3 핵심 원칙
+
+- **Feature flag `D03_PHASE2_SHADOW_READ` 기본값 `false`** — 배포 후 관리자가 명시적으로 on 으로 전환. 기본값 on 금지.
+- **Shadow Read 는 관찰 전용** — 반환값은 여전히 memory repo 가 결정한다.
+- **Drift 감지 시 로그 + 메트릭만 증가**, 반환값을 바꾸지 않는다.
+- **Rollback 은 env 한 줄** — `D03_PHASE2_SHADOW_READ=false` 로 즉시 원복 가능.
+
+---
+
+## 2. Phase 1 현황 및 정합성 점검
+
+### 2.1 Phase 1 실제 상태 (2026-04-23 기준)
+
+| 항목 | 상태 | 근거 |
+|------|------|------|
+| `pgGameRepo` DI 연결 | ✅ | `main.go:103` `service.NewRoomService(roomRepo, gameStateRepo, pgGameRepo)` |
+| CreateRoom dual-write | ✅ | `room_service.go:213` `pgBestEffortCreateRoom` |
+| JoinRoom dual-write | ✅ | `room_service.go:294` `pgBestEffortUpdateRoom` |
+| LeaveRoom dual-write | ✅ | `room_service.go:357` |
+| StartGame dual-write | ✅ | `room_service.go:407` |
+| FinishRoom dual-write | ✅ | `room_service.go:451` |
+| **DeleteRoom dual-write** | ❌ | **누락** — `room_service.go:413-424` |
+| 게스트 방 스킵 (ADR-025) | ✅ | `room_converter.go:16-18` |
+| PostgreSQL rooms row 실측 | 2 rows (FINISHED) | `SELECT count(*) FROM rooms` |
+
+> **Gap 발견**: `DeleteRoom` 이 dual-write 누락. 현재는 memory repo 만 삭제하고 PG 는 그대로 남는다. Phase 2a 에서 drift 감지 시 `delete` 된 room 이 PG 에 남아 false-positive 드리프트를 유발한다. **Day 3 구현 전 수정 필요** (별건 Issue 권장).
+
+### 2.2 Dual-Write 정합성 점검 방법
+
+Day 3 구현 **직전** 에 반드시 실행. Phase 2a 시작점의 baseline 을 확보한다.
+
+```sql
+-- PG 상태
+SELECT status, count(*) FROM rooms GROUP BY status;
+SELECT id, room_code, status, updated_at FROM rooms
+  WHERE updated_at > NOW() - INTERVAL '48 hours'
+  ORDER BY updated_at DESC;
+```
+
+```bash
+# Memory repo 상태 (개수만 비교 가능 — 내부 구조 덤프 없음)
+# game-server Pod 로그에서 최근 24h 내 CreateRoom / UpdateRoom / FinishRoom 호출 횟수 집계
+kubectl logs -n rummikub deploy/game-server --since=24h \
+  | grep -E "room_service: postgres (create|update) room" \
+  | wc -l
+```
+
+**허용 기준** (Day 3 GO 조건):
+- PG `rooms.count` ≥ 최근 24h 로그의 `CreateRoom` 횟수 (게스트 방 제외)
+- best-effort 실패 로그 0 건 또는 < 전체의 1%
+- PG updated_at 이 memory 기준 updated_at 대비 ±5 초 이내 (Phase 2a 관찰 시작 시점 기준)
+
+---
+
+## 3. Read Path 매핑
+
+현재 모든 `GetRoom`/`ListRooms` 호출은 memory repo 를 경유한다. Phase 2 대상이 되는 호출 지점은 **6 개**다.
+
+```mermaid
+flowchart TB
+    subgraph FE["Frontend / External"]
+      LB["/api/rooms<br/>(로비 목록)"]
+      DET["/api/rooms/:id<br/>(방 상세)"]
+      JOIN["/api/rooms/:id/join"]
+      WS_AUTH["WS auth<br/>ws_handler.go:296"]
+      WS_END["GameFinished<br/>ws_handler.go:1961"]
+    end
+
+    subgraph RS["RoomService (service 계층)"]
+      GR["GetRoom"]
+      LR["ListRooms"]
+    end
+
+    subgraph RP["Repository"]
+      MEM["memoryRoomRepo<br/>(현재 primary)"]
+      PG["postgresGameRepo<br/>(Phase 1 best-effort)"]
+    end
+
+    LB --> LR
+    DET --> GR
+    JOIN --> GR
+    WS_AUTH --> GR
+    WS_END --> GR
+
+    GR -->|현재| MEM
+    LR -->|현재| MEM
+    GR -.->|Phase 2a shadow| PG
+    LR -.->|Phase 2a shadow| PG
+```
+
+### 3.1 호출 사이트 인벤토리 (6 지점)
+
+| # | 위치 | 호출 | 위험도 | Phase 2a 영향 |
+|---|------|------|-------|---------------|
+| 1 | `room_handler.go:108` `ListRooms` | `h.roomSvc.ListRooms()` | 중 | shadow 로 latency 관찰 |
+| 2 | `room_handler.go:148` `GetRoom` | `h.roomSvc.GetRoom(id)` | 중 | shadow 로 drift 관찰 |
+| 3 | `room_handler.go:181` `JoinRoom` (응답용) | `h.roomSvc.GetRoom(roomID)` | 중 | shadow |
+| 4 | `ws_handler.go:296` WS auth | `h.roomSvc.GetRoom(conn.roomID)` | **고** | shadow only, **primary 전환 절대 금지** — WS 연결 실패 시 게임 자체 중단 |
+| 5 | `ws_handler.go:1961` 게임 종료 기록 | `h.roomSvc.GetRoom(roomID)` | 중 | shadow |
+| 6 | `room_service.go:475` `checkDuplicateRoom` (내부) | `s.roomRepo.GetRoom(existingRoomID)` | 중 | Phase 2a 범위 밖 — memory 직접 호출 (서비스 메서드 경유 안 함) |
+
+> **중요**: #6 은 `roomRepo.GetRoom` 직접 호출이라 `RoomService.GetRoom` shadow 로직을 우회한다. Phase 2a 에서는 그대로 두고, Phase 2b 전에 리팩터하여 단일 진입점으로 모은다.
+
+### 3.2 Shadow Read 시퀀스
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as "Caller<br/>(handler/ws)"
+    participant S as "RoomService.GetRoom"
+    participant M as "memoryRoomRepo"
+    participant P as "postgresGameRepo"
+    participant L as "Log + Metrics"
+
+    C->>S: GetRoom(id)
+    S->>M: GetRoom(id)
+    M-->>S: roomMem (primary)
+
+    alt D03_PHASE2_SHADOW_READ=true
+      S->>P: GetRoom(ctx 500ms, id) [goroutine]
+      P-->>S: roomPg / err
+      S->>S: compareRoomDrift(roomMem, roomPg)
+      S->>L: metrics + drift log if any
+    end
+
+    S-->>C: roomMem (항상 memory 기반)
+```
+
+### 3.3 Drift 비교 대상 필드
+
+`compareRoomDrift` 가 체크할 필드 (Phase 1 에서 PG 에 쓰는 것만):
+
+- `ID`, `RoomCode`, `Name`, `HostID`, `MaxPlayers`, `TurnTimeoutSec`, `Status`, `GameID`
+
+**제외 필드**:
+- `Players` — Phase 1 미매핑 (ADR D-03 §"Phase 1 미매핑")
+- `CreatedAt`, `UpdatedAt` — 쓰기 시점 차이로 false-positive 대량 발생. drift 전용 gauge (`rooms_drift_updated_at_delta_seconds`) 로 별도 관찰
+- `SeatStatus` — Phase 2b 에서 JSONB 컬럼 추가 검토
+
+---
+
+## 4. Phase 2 단계 정의
+
+### 4.1 Phase 2a — Shadow Read (Day 3 구현 · Day 4 오전 flag on)
+
+| 목적 | 증거 수집. PG 실제 응답 시간과 드리프트 빈도를 **staging+production 트래픽** 에서 측정 |
+|------|---|
+| Primary | memory repo (변경 없음) |
+| Shadow | PostgreSQL (500ms timeout, goroutine 병렬 조회) |
+| Feature flag | `D03_PHASE2_SHADOW_READ` (default false) |
+| 기간 | **최소 2시간** (자동 검증 스크립트 §13 통과 시 조기 종료). 48h 관찰은 **자동화로 축약** |
+| 성공 기준 | drift rate < 1%, PG p99 GetRoom < 200ms, shadow read 실패율 < 5% (자동 스크립트가 검증) |
+
+### 4.2 Phase 2b — Primary 역전 (Sprint 7 Day 4 오후)
+
+| 목적 | PostgreSQL 를 primary 로, memory 를 hot cache 로 |
+|------|---|
+| Primary | PostgreSQL (미스 또는 stale 시) + memory read-through cache |
+| Cache TTL | PLAYING 방 24h, WAITING 방 1h |
+| Feature flag | `D03_PHASE2_PRIMARY_PG` (default false, 2a 자동 게이트 통과 시 ArgoCD 에서 on) |
+| 롤백 | env false → 메모리 primary 즉시 복구 (memory 는 dual-write 유지) + **auto-rollback 트리거** (§14) |
+| 선행 조건 | Phase 2a 자동 검증 통과 + DeleteRoom dual-write 수정 (IS-PH2A-01) + `checkDuplicateRoom` 리팩터 (IS-PH2A-02) |
+
+### 4.3 Phase 2c — Redis/memory rooms 제거 (Sprint 7 Day 5 오후)
+
+| 목적 | memory rooms map 완전 제거. cache 는 Redis 로 통합 |
+|------|---|
+| 선행 조건 | Phase 2b 12h 이상 안정 (auto-rollback 0회) + ADR-025 개정 PR 병행 (§15) |
+| 주의 | ADR-025 는 Phase 2c 실행 직전 반드시 개정 머지. memory 제거 시 게스트 방 `ListRooms` 대응 경로 확정 필요 |
+
+### 4.4 단계 간 의존관계 (Sprint 7 Day 3~5 압축 경로)
+
+```mermaid
+flowchart LR
+    P1["Phase 1<br/>Dual-Write (완료)"] --> Gap["Day 3 오전<br/>IS-PH2A-01 + -02"]
+    Gap --> P2A["Day 3 오후<br/>Phase 2a 구현<br/>+ 자동 검증 스크립트"]
+    P2A --> A2H["Day 4 오전<br/>flag on +<br/>자동 검증 2h"]
+    A2H -->|"drift<1%<br/>p99<200ms<br/>auto-pass"| P2B["Day 4 오후<br/>Phase 2b<br/>PG Primary"]
+    P2B -->|"12h 안정<br/>auto-rollback 0"| ADR25["Day 5 오전<br/>ADR-025 개정"]
+    ADR25 --> P2C["Day 5 오후<br/>Phase 2c<br/>memory 제거"]
+
+    A2H -.->|"gate fail"| RB1["env false<br/>auto-rollback"]
+    P2B -.->|"drift/latency<br/>breach"| RB2["env false<br/>auto-rollback<br/>(§14)"]
+```
+
+---
+
+## 5. Feature Flag & Config 설계
+
+### 5.1 제안 변수
+
+| 변수 | Phase | 기본값 | 역할 |
+|------|-------|-------|------|
+| `D03_PHASE2_SHADOW_READ` | 2a | `false` | Shadow read on/off |
+| `D03_PHASE2_SHADOW_TIMEOUT_MS` | 2a | `500` | PG shadow GetRoom timeout |
+| `D03_PHASE2_SHADOW_SAMPLE_RATE` | 2a | `1.0` | 0.0~1.0, 부하 조절용 (기본 전수) |
+| `D03_PHASE2_PRIMARY_PG` | 2b | `false` | Day 4 오후 ArgoCD 에서 on 으로 전환 |
+| `D03_PHASE2_CACHE_TTL_PLAYING_SEC` | 2b | `86400` | PLAYING 방 memory/Redis cache TTL |
+| `D03_PHASE2_CACHE_TTL_WAITING_SEC` | 2b | `3600` | WAITING 방 cache TTL |
+| `D03_PHASE2_AUTO_ROLLBACK_DRIFT_PCT` | 2b | `5` | drift 비율 ≥5% 10분 지속 시 auto-rollback |
+| `D03_PHASE2_AUTO_ROLLBACK_P99_MS` | 2b | `500` | `GetRoom` p99 ≥500ms 5분 지속 시 auto-rollback |
+| `D03_PHASE2_MEMORY_OFF` | 2c | `false` | memory rooms map 완전 제거. 켜진 후에는 Phase 2b 롤백 불가 |
+
+### 5.2 ConfigMap 패치 (Day 3 ~ Day 5)
+
+```yaml
+# helm/charts/game-server/values.yaml (Day 3 배포, Day 4~5 단계별 patch)
+config:
+  # Day 3 배포 시 추가 (모두 false)
+  D03_PHASE2_SHADOW_READ: "false"
+  D03_PHASE2_SHADOW_TIMEOUT_MS: "500"
+  D03_PHASE2_SHADOW_SAMPLE_RATE: "1.0"
+  # Day 4 오후 PR 에 추가 (default false)
+  D03_PHASE2_PRIMARY_PG: "false"
+  D03_PHASE2_CACHE_TTL_PLAYING_SEC: "86400"
+  D03_PHASE2_CACHE_TTL_WAITING_SEC: "3600"
+  D03_PHASE2_AUTO_ROLLBACK_DRIFT_PCT: "5"
+  D03_PHASE2_AUTO_ROLLBACK_P99_MS: "500"
+  # Day 5 PR 에 추가 (default false)
+  D03_PHASE2_MEMORY_OFF: "false"
+```
+
+> 배포 직후 flag 는 모두 `false` 상태. 실제 활성화 시점:
+>
+> | 시점 | 전환 | 명령 |
+> |------|------|------|
+> | Day 4 오전 | `D03_PHASE2_SHADOW_READ=true` | `kubectl patch configmap game-server-config -n rummikub --type merge -p '{"data":{"D03_PHASE2_SHADOW_READ":"true"}}'` + rollout restart |
+> | Day 4 오후 (자동 검증 PASS 후) | `D03_PHASE2_PRIMARY_PG=true` | 동일 패턴 |
+> | Day 5 오후 (12h 안정 + ADR-025 개정 머지 후) | `D03_PHASE2_MEMORY_OFF=true` | 동일 패턴. **이 전환 이후 Phase 2b 롤백 경로 소실됨** → §14.4 no-return gate 체크리스트 필수 |
+
+### 5.3 main.go 주입 패턴 (제안 — 구현은 go-dev)
+
+```go
+// cmd/server/main.go (pseudocode)
+phase2Cfg := service.Phase2ShadowConfig{
+    Enabled:      os.Getenv("D03_PHASE2_SHADOW_READ") == "true",
+    TimeoutMs:    envInt("D03_PHASE2_SHADOW_TIMEOUT_MS", 500),
+    SampleRate:   envFloat("D03_PHASE2_SHADOW_SAMPLE_RATE", 1.0),
+}
+roomSvc := service.NewRoomService(roomRepo, gameStateRepo, pgGameRepo,
+    service.WithShadowRead(phase2Cfg))
+```
+
+**주의**: 기존 `NewRoomService` 3-arg 시그니처를 깨지 않도록 `WithShadowRead` 는 **functional option** 으로 설계. 기존 테스트 17 건이 nil 패턴을 그대로 사용 가능.
+
+---
+
+## 6. 메트릭 & 로그 설계
+
+### 6.1 Prometheus 메트릭 (신규)
+
+| 메트릭 | 타입 | 라벨 | 용도 |
+|--------|------|------|------|
+| `rooms_shadow_read_total` | counter | `op` (get/list), `result` (match/drift/error/miss) | shadow read 횟수 |
+| `rooms_shadow_read_drift_total` | counter | `field` (status/game_id/...) | 필드별 drift 빈도 |
+| `rooms_shadow_read_latency_seconds` | histogram | `op` | PG p50/p95/p99 실측 |
+| `rooms_shadow_read_timeout_total` | counter | `op` | 500ms 타임아웃 초과 횟수 |
+| `rooms_shadow_updated_at_delta_seconds` | histogram | — | memory vs PG updated_at 차이 분포 |
+
+### 6.2 로그 패턴
+
+```
+[WARN] rooms_phase2a: drift detected roomID=<id> field=status mem=PLAYING pg=WAITING
+[INFO] rooms_phase2a: shadow read ok roomID=<id> op=get latency_ms=42
+[ERROR] rooms_phase2a: shadow read timeout roomID=<id> op=get timeout_ms=500
+```
+
+`WARN` 은 SampleRate=1.0 에서 초당 수 건을 넘으면 로그 폭주. **drift 감지 시 roomID 별 1분 dedupe** 권장 (sync.Map + 1min TTL).
+
+### 6.3 대시보드 (Grafana 제안 — Sprint 7 Week 2 추가)
+
+- Panel 1: `rate(rooms_shadow_read_drift_total[5m])` — 드리프트 시간당 추이
+- Panel 2: `histogram_quantile(0.99, rooms_shadow_read_latency_seconds)` — PG p99
+- Panel 3: `rate(rooms_shadow_read_timeout_total[5m])` — 타임아웃 추이
+- Alert: drift rate > 5/min 지속 10분 시 Slack 알림
+
+---
+
+## 7. Rollback 절차
+
+### 7.1 Shadow Read 전면 해제 (즉시)
+
+```bash
+kubectl patch configmap game-server-config -n rummikub \
+  --type merge -p '{"data":{"D03_PHASE2_SHADOW_READ":"false"}}'
+kubectl rollout restart deploy/game-server -n rummikub
+```
+
+소요: ~30 초 (rollout 포함). Shadow 는 primary 결과에 영향 주지 않으므로 사용자 영향 **없음**.
+
+### 7.2 PG 이상 탐지 시
+
+- PG latency 급증 / timeout 폭증 시 flag 전환 전 `D03_PHASE2_SHADOW_READ=false` 로 관찰 중단
+- Phase 2b 진입 전까지는 primary 에 영향 없으므로 **hot-fix 필요 없음**
+
+### 7.3 Phase 2b (장래) 롤백
+
+- `D03_PHASE2_PRIMARY_PG=false` 로 env 변경 → memory primary 복구
+- memory 는 여전히 dual-write 로 최신 유지되므로 cutover 직전 상태로 복귀
+- **전제**: Phase 2b 도입 시 memory 가 dual-write 로 계속 유지돼야 함. 이것이 Phase 2b 설계의 안전장치.
+
+---
+
+## 8. Day 3 (2026-04-24) 실행 범위 & 검증 게이트
+
+### 8.1 범위 (Phase 2a 한정)
+
+| 항목 | 담당 | 예상 LOC | 예상 시간 |
+|------|------|---------|----------|
+| `Phase2ShadowConfig` 구조체 + functional option | go-dev | +40 | 0.5h |
+| `RoomService.GetRoom` shadow 로직 (+ goroutine + timeout) | go-dev | +60 | 1.0h |
+| `RoomService.ListRooms` shadow (ID 집합 교차 비교) | go-dev | +70 | 1.0h |
+| `compareRoomDrift` 헬퍼 + drift dedupe | go-dev | +50 | 1.0h |
+| Prometheus 메트릭 정의 + 등록 | go-dev | +30 | 0.5h |
+| Unit test (drift/timeout/sample rate 5~7 건) | go-dev | +120 | 1.5h |
+| `main.go` env 주입 | go-dev | +15 | 0.25h |
+| Helm values + ConfigMap patch | devops | +10 | 0.25h |
+| K8s smoke: rollout + flag off 확인 | devops | — | 0.5h |
+| `DeleteRoom` dual-write 갭 수정 (선행) | go-dev | +20 | 0.5h |
+| 회귀 테스트 (Go 530 + Playwright 핵심) | qa | — | 0.5h |
+| **합계** | **go-dev + devops + qa** | **~415 LOC** | **~7.5h (병렬 시 ~4h)** |
+
+### 8.2 병렬성
+
+```mermaid
+gantt
+    title Day 3 Phase 2a 작업 병렬화
+    dateFormat HH:mm
+    axisFormat %H:%M
+    section go-dev
+    DeleteRoom gap 수정      :a1, 09:00, 30m
+    Shadow 로직 + option     :a2, after a1, 2h
+    Drift + metrics         :a3, after a2, 1.5h
+    Unit tests              :a4, after a3, 1.5h
+    section devops
+    Helm values              :b1, 09:00, 15m
+    ConfigMap patch 준비     :b2, after b1, 15m
+    Build + rollout 대기     :b3, after a4, 30m
+    K8s smoke                :b4, after b3, 30m
+    section qa
+    회귀 스윕 검증 준비      :c1, 09:00, 30m
+    rollout 후 회귀 실행     :c2, after b3, 30m
+```
+
+### 8.3 검증 게이트 (Day 3 GO/NO-GO)
+
+**GO 조건** (모두 충족):
+1. Go unit test: `go test ./... -count=1 -timeout 90s` 기존 530 + 신규 5~7 전부 PASS
+2. Phase 1 정합성 baseline 확보: §2.2 쿼리 결과가 허용 기준 안
+3. K8s rollout 후 `D03_PHASE2_SHADOW_READ=false` 상태에서 **기존 동작 100% 유지** (회귀 0건)
+4. flag `true` 로 토글 후 10분 내 drift WARN 로그 0 건 또는 기대 수준
+5. PG shadow read p99 latency < 500ms (timeout 내)
+
+**NO-GO 조건** (하나라도 해당):
+- Phase 1 drift baseline 이 5% 초과 → Phase 2a 전 Phase 1 수리 필요
+- `DeleteRoom` gap 수정 후 회귀 테스트에서 LeaveRoom 등 연관 기능 깨짐
+- PG shadow read 평균 latency > 300ms (인프라 상 Phase 2b 무리)
+
+---
+
+## 9. Phase 2b / 2c 전제 조건 (Sprint 7 Day 4~5)
+
+### 9.1 Phase 2b 전제 조건 체크리스트 (Day 4 오후 진입 직전)
+
+- [ ] Phase 2a **자동 검증 스크립트** (§13) 통과 (drift<1%, p99<200ms, 실패율<5%)
+- [ ] PG p99 GetRoom < 200ms, p99 ListRooms < 400ms (staging 측정)
+- [ ] IS-PH2A-01 DeleteRoom dual-write 머지 완료 (Day 3 오전)
+- [ ] IS-PH2A-02 `checkDuplicateRoom` 리팩터 머지 완료 (Day 3 오전)
+- [ ] **auto-rollback 트리거** (§14) 구현 + dry-run 검증 1회 (Day 4 점심 전)
+- [ ] memory 는 dual-write 유지 (cutover 후에도 폴백 경로로 남김)
+
+### 9.2 Phase 2c 전제 조건 (Day 5 오후 진입 직전)
+
+- [ ] Phase 2b **12시간 이상** 안정 (auto-rollback 0회)
+- [ ] Phase 2b 기간 내 drift 평균 < 0.5%, p99 GetRoom < 300ms
+- [ ] **ADR-025 개정 PR** 머지 완료 (§15) — 게스트 방 경로 명확화
+- [ ] 게스트 방 `ListRooms` 회귀 테스트 실패 0건 (Playwright + Go unit)
+- [ ] memory off 이후 **롤백 경로 소실** 에 대한 사용자 명시 승인
+
+### 9.3 파생 이슈 (Day 3~5 순차)
+
+| ID | 제목 | 우선순위 | 실행 슬롯 |
+|-----|------|----------|----------|
+| IS-PH2A-01 | DeleteRoom dual-write 누락 수정 | P1 | Day 3 오전 (Phase 2a 착수 전 선행) |
+| IS-PH2A-02 | `checkDuplicateRoom` → 서비스 메서드 경유 리팩터 | P1 | Day 3 오전 (Phase 2b 선행 필수) |
+| IS-PH2A-03 | Grafana 대시보드 `rooms_shadow_*` + `rooms_primary_*` 패널 | P2 | Day 4 오전 |
+| IS-PH2A-04 | memory repo `UpdatedAt` 갱신 정책 정렬 | P2 | Day 4 오전 |
+| IS-PH2A-05 | auto-rollback 트리거 스크립트 (§14) | P1 | Day 4 점심 전 |
+| IS-PH2A-06 | ADR-025 개정 (게스트 방 Phase 2c 경로) | P1 | Day 5 오전 (Phase 2c 선행 필수) |
+
+---
+
+## 10. Risk Budget
+
+| Risk | 확률 | 영향 | 완화 전략 | 잔여 위험 |
+|------|------|------|----------|----------|
+| R1. PG shadow query 가 primary 성능 영향 | 중 | 중 | `goroutine + 500ms timeout + sample rate`. flag off 시 영향 제로 | 낮음 |
+| R2. drift 로그 폭주 → Pod OOM | 중 | 중 | roomID 별 1분 dedupe, SampleRate 하향 가능 (1.0 → 0.1) | 낮음 |
+| R3. Phase 1 drift baseline 높음 → Phase 2a 자체 오염 | 낮~중 | 고 | §2.2 baseline 쿼리로 Day 3 전 확인, 5% 초과 시 **NO-GO** | 중 (데이터 의존) |
+| R4. DeleteRoom gap 이 Phase 2a 드리프트 false-positive 유발 | 높 | 중 | Day 3 첫 작업으로 gap 수정 (IS-PH2A-01) | 낮음 |
+| R5. WS auth 경로(ws_handler.go:296) 가 shadow 부하로 간헐 slowdown | 낮 | 고 | WS auth 경로는 shadow SampleRate 0.1 적용 (별도 호출 지점 추적) | 낮음 |
+| R6. Phase 2b 로 조급히 넘어가서 primary 전환 → 장애 | 중 | **치명** | **Day 3 에는 2a 만**. 2b 진입은 Week 2 후반 별도 PR + tabletop | 낮음 |
+| R7. ADR-025 게스트 방 경로가 shadow 에서 drift 로 오탐 | 높 | 낮 | `compareRoomDrift` 가 `HostID UUID 유효성` 선검사, 게스트 방은 drift 판정 제외 | 낮음 |
+| R8. Phase 2c memory 제거 시 게스트 방 ListRooms 회귀 | 중 | 고 | **본 문서 §9.2** Phase 2c 전 ADR-025 개정 필수 | 낮음 (Sprint 8 이슈) |
+
+### 10.1 종합 위험도: **MEDIUM-HIGH** → Phase 2a 에 한정하면 **MEDIUM-LOW**
+
+Phase 2a 만 실행하면 primary 가 바뀌지 않으므로 최악의 경우에도 flag off 로 30초 내 원복. **Day 3 실행 범위를 Phase 2a 로 제한하는 조건 하에 GO** 권장.
+
+---
+
+## 11. Sprint 7 Day 3~5 최종 권고
+
+| 항목 | 권고 |
+|------|------|
+| Day 3 오전 선행 수정 (IS-PH2A-01/-02) | **GO** |
+| Day 3 오후 Phase 2a 구현 + 자동 검증 스크립트 (§13) | **GO** |
+| Day 4 오전 Phase 2a flag on + 자동 검증 2h | **GO** (PASS 시 Day 4 오후 진행) |
+| Day 4 오후 Phase 2b Primary 역전 | **GO** (auto-rollback §14 선제 배치 필수) |
+| Day 5 오전 ADR-025 개정 (IS-PH2A-06) | **GO** |
+| Day 5 오후 Phase 2c memory 제거 | **GO** (2b 12h 안정 게이트 통과 조건) |
+| Feature flag 기본값 | 모든 Phase flag `false` 배포 → 단계별 수동/자동 patch |
+| 자동 검증 축약 | **48h → 2h Phase 2a, 12h Phase 2b** (자동 스크립트 통과 시 조기 전진) |
+| No-return gate | `D03_PHASE2_MEMORY_OFF=true` 전환 전 §14.4 체크리스트 필수 |
+
+---
+
+## 12. 참조
+
+- `docs/02-design/48-adr-025-guest-room-persistence.md` — 게스트 방 영속 배제 (Phase 2a compareRoomDrift 에서 선검사)
+- `work_logs/decisions/2026-04-22-rooms-postgres-phase1.md` — Phase 1 원본 ADR
+- `src/game-server/internal/service/room_service.go` — Phase 2a 구현 진입점 (532행, GetRoom 224행, ListRooms 233행)
+- `src/game-server/internal/service/room_converter.go` — 정합성 비교에서 재사용
+- `src/game-server/internal/repository/postgres_repo.go` — `GetRoom`/`ListRooms` 이미 구현 완료 (80/95 행)
+- PR #40 (ADR), PR #42 (Phase 1 구현)
+
+---
+
+## 13. 자동 검증 스크립트 설계 (48h → 2h/12h 축약 근거)
+
+### 13.1 목적
+
+"48h 관찰 → 사람 판단" 패턴을 **자동화된 수치 게이트** 로 대체. Sprint 7 내 전 Phase 완주를 위한 시간 축약 도구. 사람은 **스크립트 PASS/FAIL** 만 확인.
+
+### 13.2 실행 주체
+
+| 스크립트 | 위치 (제안) | 실행 슬롯 | 실행자 |
+|---------|-------------|----------|-------|
+| `scripts/d03-phase2a-gate.sh` | 신규 | Day 4 오전, Phase 2a flag on 후 2h | devops |
+| `scripts/d03-phase2b-gate.sh` | 신규 | Day 4 저녁 + Day 5 오전 (12h 중 4회) | devops |
+| `scripts/d03-phase2c-precheck.sh` | 신규 | Day 5 오후 Phase 2c 직전 | devops + architect |
+
+### 13.3 Phase 2a gate 스크립트 동작
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant DO as devops
+    participant GS as "game-server Pod"
+    participant PR as Prometheus
+    participant PG as PostgreSQL
+    participant S as gate-script
+
+    DO->>GS: kubectl patch D03_PHASE2_SHADOW_READ=true
+    DO->>GS: rollout restart (30s)
+    loop every 5 min, total 2h (24회)
+      S->>PR: sum(rate(rooms_shadow_read_drift_total[5m])) / sum(rate(rooms_shadow_read_total[5m]))
+      S->>PR: histogram_quantile(0.99, rooms_shadow_read_latency_seconds)
+      S->>PR: sum(rate(rooms_shadow_read_timeout_total[5m])) / sum(rate(rooms_shadow_read_total[5m]))
+      S->>PG: SELECT count(*) FROM rooms WHERE updated_at > NOW() - INTERVAL '5 min'
+      alt drift<1% AND p99<200ms AND timeout<5% (24회 중 22회 이상)
+        S-->>DO: PASS
+      else 3회 이상 gate breach
+        S->>GS: auto-rollback D03_PHASE2_SHADOW_READ=false
+        S-->>DO: FAIL + 근거 로그
+      end
+    end
+```
+
+### 13.4 수치 게이트 (Production 기준 강화)
+
+| 메트릭 | Phase 2a 기준 | Phase 2b 기준 | 측정 창 | breach 정의 |
+|--------|--------------|--------------|--------|------------|
+| drift rate | < 1% | < 0.5% | 5분 이동평균 | 연속 3 window 초과 |
+| PG p99 GetRoom | < 200ms | < 300ms | 5분 이동평균 | 연속 3 window 초과 |
+| shadow/primary 실패율 | < 5% | < 1% | 5분 이동평균 | 연속 2 window 초과 |
+| WS auth 경로 실패 증가율 | < 0.1% 증가 | < 0.1% 증가 | 10분 이동평균 | 1 window 초과 즉시 breach |
+| Redis 가용성 | 변경 없음 | 변경 없음 | - | Pod `rummikub-redis` Ready=1 |
+
+> 기존 1.0 버전의 `drift rate < 1%` 는 Phase 2a 기준으로만 적용. Phase 2b 는 **primary 가 PG** 이므로 drift 가 곧 **데이터 일관성 파괴** 이기 때문에 0.5% 로 하향.
+
+### 13.5 스크립트 pseudocode (Phase 2a)
+
+```bash
+#!/bin/bash
+# scripts/d03-phase2a-gate.sh
+set -euo pipefail
+NAMESPACE=rummikub
+PROM_URL=http://prometheus.monitoring:9090
+DURATION_MIN=120
+WINDOW_MIN=5
+BREACH_MAX=3
+breaches=0
+
+for ((i=0; i<DURATION_MIN/WINDOW_MIN; i++)); do
+  drift=$(curl -sG "$PROM_URL/api/v1/query" \
+    --data-urlencode 'query=sum(rate(rooms_shadow_read_drift_total[5m])) / sum(rate(rooms_shadow_read_total[5m]))' \
+    | jq -r '.data.result[0].value[1] // "0"')
+  p99=$(curl -sG "$PROM_URL/api/v1/query" \
+    --data-urlencode 'query=histogram_quantile(0.99, sum(rate(rooms_shadow_read_latency_seconds_bucket[5m])) by (le))' \
+    | jq -r '.data.result[0].value[1] // "0"')
+  fail=$(curl -sG "$PROM_URL/api/v1/query" \
+    --data-urlencode 'query=sum(rate(rooms_shadow_read_timeout_total[5m])) / sum(rate(rooms_shadow_read_total[5m]))' \
+    | jq -r '.data.result[0].value[1] // "0"')
+
+  if awk "BEGIN{exit !($drift >= 0.01 || $p99 >= 0.200 || $fail >= 0.05)}"; then
+    breaches=$((breaches+1))
+    echo "[WINDOW $i] BREACH drift=$drift p99=$p99 fail=$fail (breaches=$breaches)"
+    if [ "$breaches" -ge "$BREACH_MAX" ]; then
+      echo "FAIL — auto-rollback"
+      kubectl patch configmap game-server-config -n "$NAMESPACE" \
+        --type merge -p '{"data":{"D03_PHASE2_SHADOW_READ":"false"}}'
+      kubectl rollout restart deploy/game-server -n "$NAMESPACE"
+      exit 1
+    fi
+  else
+    breaches=0
+  fi
+  sleep $((WINDOW_MIN*60))
+done
+echo "PASS"
+```
+
+### 13.6 Phase 2b gate 스크립트 차이점
+
+| 항목 | 2a | 2b |
+|------|----|----|
+| 측정 대상 | `rooms_shadow_*` | `rooms_primary_*` (신규 메트릭) + `cache_hit_ratio` |
+| 기준 강화 | drift<1%, p99<200ms | drift<0.5%, p99<300ms, cache hit>80% |
+| 기간 | 2h | 12h |
+| breach 시 | `D03_PHASE2_SHADOW_READ=false` | `D03_PHASE2_PRIMARY_PG=false` (§14 auto-rollback) |
+
+---
+
+## 14. Auto-rollback 트리거 설계 (Phase 2b 전용)
+
+### 14.1 왜 Phase 2b 에만 auto-rollback?
+
+- Phase 2a: primary 가 memory 이므로 shadow read 이상은 사용자 영향 없음. 사람 판단으로 충분.
+- **Phase 2b**: primary 가 PG. PG 장애/지연이 곧 **게임 중단**. 사람이 수동 대응 전까지 수분~수십분 게임 불가 가능성 → 자동화 필수.
+- Phase 2c: primary 가 PG + cache. 구조는 2b 와 동일하되 memory 폴백이 사라져 위험 증가. `memory_off=true` 이전 단계(`2b`)에서 **auto-rollback 이 실증** 돼야 진입.
+
+### 14.2 Auto-rollback 컴포넌트
+
+```mermaid
+flowchart TB
+    PROM["Prometheus<br/>rooms_primary_*<br/>rooms_cache_*"] --> ALM["Prometheus Alertmanager"]
+    ALM -->|"webhook"| OPS["scripts/d03-auto-rollback.sh<br/>(K8s Job, 상시 대기)"]
+    OPS -->|"kubectl patch"| CFG["ConfigMap<br/>D03_PHASE2_PRIMARY_PG=false"]
+    OPS -->|"rollout restart"| GS["game-server Pod"]
+    OPS -->|"Slack webhook"| TM["팀 알림<br/>(카카오톡 봇)"]
+```
+
+### 14.3 트리거 조건 (AND 로 묶지 말고 OR)
+
+| 조건 | 임계값 | 창 | 액션 |
+|------|-------|----|------|
+| drift rate ≥ 5% | PromQL `rate(rooms_primary_drift_total[5m]) / rate(rooms_primary_read_total[5m])` | 10분 지속 | auto-rollback |
+| PG `GetRoom` p99 ≥ 500ms | `histogram_quantile(0.99, rooms_primary_latency_seconds_bucket)` | 5분 지속 | auto-rollback |
+| PG connection error rate ≥ 1% | `rate(rooms_primary_db_error_total[1m])` | 3분 지속 | auto-rollback |
+| WS auth 실패 증가율 ≥ 1%p | `rate(ws_auth_fail_total[5m])` - baseline | 5분 지속 | auto-rollback |
+| 관리자 수동 트리거 | `kubectl annotate deploy/game-server rollback=true` | 즉시 | auto-rollback |
+
+### 14.4 No-return gate 체크리스트 (`D03_PHASE2_MEMORY_OFF=true` 전)
+
+memory 제거는 **Phase 2b 롤백 경로를 영구히 차단** 한다. 전환 직전 반드시 확인:
+
+- [ ] Phase 2b 가 **12시간 이상** 안정 (auto-rollback 0회)
+- [ ] Phase 2b 기간 중 auto-rollback 트리거 1회 이상 **dry-run** (test drift 주입으로 정상 발동 확인)
+- [ ] PG backup 최신 (24h 이내)
+- [ ] PG HA (읽기 레플리카 최소 1대) Ready
+- [ ] ADR-025 개정 PR 머지 (§15)
+- [ ] 게스트 방 `ListRooms` 응답이 memory 없이도 정상 (Go unit + Playwright PASS)
+- [ ] 사용자 (애벌레) 명시적 승인 — No-return 임을 공유
+
+### 14.5 Auto-rollback script pseudocode
+
+```bash
+#!/bin/bash
+# scripts/d03-auto-rollback.sh (alertmanager webhook 대응)
+set -euo pipefail
+REASON="$1"  # drift / latency / db_error / ws_auth / manual
+NAMESPACE=rummikub
+echo "[$(date -Is)] AUTO-ROLLBACK triggered reason=$REASON"
+kubectl patch configmap game-server-config -n "$NAMESPACE" \
+  --type merge -p '{"data":{"D03_PHASE2_PRIMARY_PG":"false"}}'
+kubectl rollout restart deploy/game-server -n "$NAMESPACE"
+kubectl rollout status deploy/game-server -n "$NAMESPACE" --timeout=120s
+# Slack/카카오톡 알림 (KAKAO_WEBHOOK 환경변수)
+curl -sS -X POST "$KAKAO_WEBHOOK" \
+  -H 'Content-Type: application/json' \
+  -d "{\"text\":\"D-03 Phase 2b auto-rollback: reason=$REASON\"}"
+```
+
+### 14.6 검증 방법 (dry-run)
+
+Day 4 오후 Phase 2b 진입 **직후 1시간 이내** 에 auto-rollback 을 1회 dry-run 실행 (테스트용 drift 수동 주입):
+
+```bash
+# staging 환경에서
+kubectl exec -n rummikub deploy/game-server -- \
+  curl -X POST localhost:8080/internal/test/inject-drift
+# 5분 대기 → Prometheus 알림 발생 → auto-rollback 실행 확인
+# 완료 후 primary_pg=true 복원
+```
+
+> 이 endpoint (`/internal/test/inject-drift`) 는 production 빌드에서 `INTERNAL_TEST_ENDPOINTS=false` 로 기본 차단. staging 에서만 활성.
+
+---
+
+## 15. IS-PH2A-01 DeleteRoom dual-write 선수정 상세 diff 초안
+
+### 15.1 현재 코드 (`src/game-server/internal/service/room_service.go:412-424`)
+
+```go
+// DeleteRoom 방을 삭제한다. 호스트만 삭제 가능하다.
+func (s *roomService) DeleteRoom(roomID, hostUserID string) error {
+    room, err := s.roomRepo.GetRoom(roomID)
+    if err != nil {
+        return &ServiceError{Code: "NOT_FOUND", Message: errMsgRoomNotFound, Status: 404}
+    }
+
+    if room.HostID != hostUserID {
+        return &ServiceError{Code: "FORBIDDEN", Message: "방장만 방을 삭제할 수 있습니다.", Status: 403}
+    }
+
+    return s.roomRepo.DeleteRoom(roomID)
+}
+```
+
+### 15.2 수정 후 (예상 diff — go-dev 구현 참조)
+
+```go
+// DeleteRoom 방을 삭제한다. 호스트만 삭제 가능하다.
+// Phase 1 Dual-Write: PostgreSQL 에도 CANCELLED 상태로 기록한 뒤 memory 에서 삭제.
+// 게스트 방은 PG 미기록이므로 roomStateToModel nil 반환 경로에서 조용히 건너뛴다.
+func (s *roomService) DeleteRoom(roomID, hostUserID string) error {
+    room, err := s.roomRepo.GetRoom(roomID)
+    if err != nil {
+        return &ServiceError{Code: "NOT_FOUND", Message: errMsgRoomNotFound, Status: 404}
+    }
+
+    if room.HostID != hostUserID {
+        return &ServiceError{Code: "FORBIDDEN", Message: "방장만 방을 삭제할 수 있습니다.", Status: 403}
+    }
+
+    // Phase 1 Dual-Write: 삭제 전에 PG 상태를 CANCELLED 로 마킹 (soft-delete)
+    // hard DELETE 는 별건. Phase 2b 이후 game_results FK 관계를 별도 ADR 에서 재검토
+    room.Status = model.RoomStatusCancelled
+    room.UpdatedAt = time.Now().UTC()
+    s.pgBestEffortUpdateRoom(room)
+
+    return s.roomRepo.DeleteRoom(roomID)
+}
+```
+
+### 15.3 왜 soft-delete (CANCELLED) 인가
+
+| 옵션 | 장단 | 선택 |
+|------|------|------|
+| A. PG 에서 hard DELETE | game_results 와 FK 깨질 위험. Phase 1 은 best-effort 라서 FK 관계 아직 확정 아님 | ❌ |
+| B. PG 를 CANCELLED 로 soft-delete | 감사 추적 가능. Phase 2a drift 감지 시 false-positive 제거 | ✅ |
+| C. PG 건드리지 않음 | 현재 상태 유지. Phase 2a shadow read drift 폭주 | ❌ |
+
+### 15.4 회귀 테스트 (기존 테스트 영향)
+
+| 테스트 | 영향 | 조치 |
+|--------|------|------|
+| `room_service_test.go` DeleteRoom 케이스 | PG mock 호출 추가 검증 | mock expectation +1 |
+| `room_service_test.go` 호스트 아님 케이스 | 변화 없음 | - |
+| `e2e/rooms_persistence_test.go` | soft-delete 관찰 가능성 추가 | CANCELLED row 1건 assertion 추가 |
+| `handler_test.go` | 영향 없음 | - |
+
+예상 테스트 증감: +5~7 assertions, 신규 테스트 0건.
+
+### 15.5 Day 3 오전 실행 순서
+
+1. go-dev: 위 diff 적용 (+ `roomStateToModel` 에서 CANCELLED 가 정상 처리되는지 확인)
+2. go-dev: Go unit test (`go test ./internal/service/... -count=1`)
+3. go-dev: e2e persistence test (`go test ./e2e/... -count=1 -timeout 90s`)
+4. devops: staging 배포 smoke
+5. qa: LeaveRoom → DeleteRoom (호스트 인계 포함) 시나리오 smoke
+
+---
+
+## 16. ADR-025 개정 경로 (Phase 2c 선행 필수)
+
+### 16.1 기존 ADR-025 입장
+
+`docs/02-design/48-adr-025-guest-room-persistence.md` 요약:
+- 게스트 방 = PG 영속 배제, memory only
+- admin rooms UI 는 "DB + memory 머지" 로 표시
+
+### 16.2 Phase 2c 에서의 충돌
+
+memory 가 완전히 제거되면 게스트 방은 **어디에도 없다**. `ListRooms` 호출 시:
+- 게스트 인증자 본인의 방만 확인 가능해야 하는 요구 사항 존재 (admin 은 전체)
+- Redis cache 도 Phase 2c 에서는 PG 의 cache 이므로 PG 에 없는 게스트 방은 표현 불가
+
+### 16.3 개정안 3 옵션
+
+| 옵션 | 설명 | 장 | 단 | 권장 |
+|------|------|----|----|------|
+| A. 게스트 방도 PG 영속 (ADR-025 뒤집기) | 게스트 UUID + partial profile row 생성 | 구조 단순 | ADR-025 초기 결정 번복, 게스트 테이블 스키마 추가 | ⭐ |
+| B. Redis 에 게스트 방 전용 namespace | 게스트 방만 Redis, 인증자는 PG | 기존 ADR-025 유지 | cache/primary 구분 복잡, 조회 로직 분기 | - |
+| C. 게스트 방 자체 지원 중단 | 모든 방은 인증자 전용 | 가장 단순 | UX 후퇴, 게스트 스모크 플로우 깨짐 | - |
+
+### 16.4 권장 — 옵션 A
+
+- ADR-025 는 "게스트 방 PG 배제" → "**게스트 방은 PG 에 `is_guest=true` 플래그 컬럼과 함께 영속**" 으로 개정
+- `users` 테이블에 게스트용 partial row (email NULL 허용) 허용 또는 `guest_users` 별도 테이블 설계
+- Phase 2c 진입 직전 (Day 5 오전) 마이그레이션 + ADR 동시 머지
+
+### 16.5 Day 5 오전 실행 순서
+
+1. architect: ADR-025 개정 PR (options 재검토 + 옵션 A 확정)
+2. go-dev: PG 마이그레이션 `add_is_guest_column.sql` 작성
+3. go-dev: `roomStateToModel` 가 게스트 방을 **nil 반환 대신** `is_guest=true` 로 기록하도록 수정
+4. devops: staging 적용 → Playwright 게스트 플로우 PASS 확인
+5. architect + go-dev: Phase 2c flag on
+
+---
+
+## 17. Sprint 7 Day 3~5 실행 타임라인 (압축)
+
+```mermaid
+gantt
+    title D-03 Phase 2 Sprint 7 압축 실행
+    dateFormat HH:mm
+    axisFormat %H:%M
+    section Day 3 (2026-04-24)
+    IS-PH2A-01 DeleteRoom     :a1, 09:00, 30m
+    IS-PH2A-02 checkDup 리팩터 :a2, after a1, 30m
+    Phase 2a 구현             :a3, after a2, 4h
+    Phase 2a 단위테스트       :a4, after a3, 1.5h
+    Day 3 마감 PR             :a5, after a4, 1h
+    section Day 4 (2026-04-25)
+    Phase 2a flag on          :b1, 09:00, 15m
+    자동검증 스크립트 2h      :b2, after b1, 2h
+    auto-rollback dry-run     :b3, after b2, 30m
+    Phase 2b 구현             :b4, after b3, 3h
+    Phase 2b flag on          :b5, after b4, 15m
+    Day 4 저녁 안정 관찰      :b6, after b5, 4h
+    section Day 5 (2026-04-26)
+    Phase 2b 안정 게이트       :c1, 08:00, 2h
+    ADR-025 개정 + 마이그      :c2, after c1, 2h
+    Phase 2c 구현              :c3, after c2, 2h
+    Phase 2c flag on           :c4, after c3, 15m
+    Sprint 7 마감              :c5, after c4, 1h
+```
+
+---
+
+## 18. 종합 Risk (업데이트)
+
+기존 §10 R1~R8 에 추가:
+
+| Risk | 확률 | 영향 | 완화 | 잔여 |
+|------|------|------|------|------|
+| R9. 48h → 2h/12h 축약으로 증거 부족 | 중 | 고 | 자동 검증 게이트가 **기존 48h 사람 판단보다 엄격한 수치 기준** (§13.4). 실측 트래픽이 부족하면 gate 가 자동으로 PASS 보류 | 중 |
+| R10. auto-rollback 오탐 → 불필요 재시작 | 중 | 중 | 5분/3분 지속 창으로 순간 스파이크 제외. dry-run 으로 오탐율 선검증 | 낮 |
+| R11. ADR-025 개정이 Day 5 오전에 미완 | 중 | 고 | Day 5 오전 2h 블록. 실패 시 Phase 2c **HOLD** → Phase 2b 유지로 Sprint 7 마감 | 낮 |
+| R12. `MEMORY_OFF=true` 이후 PG 장애 | 낮 | **치명** | Phase 2c 진입 no-return gate (§14.4) + PG HA 레플리카 Ready 필수 | 중 |
+| R13. 게스트 방 PG 영속 전환 (ADR-025 옵션 A) 가 users 테이블 FK 깨짐 | 중 | 고 | `guest_users` 별도 테이블 또는 `users.email` nullable 마이그레이션. Day 5 오전 DB review | 낮 |
+
+### 18.1 종합 위험도 재평가
+
+Phase 2a 만: **MEDIUM-LOW** (1.0 버전과 동일)
+Phase 2b 포함: **MEDIUM** (auto-rollback 으로 완화)
+Phase 2c 포함 (전 Phase 완주): **MEDIUM-HIGH** — `MEMORY_OFF` no-return 특성 때문. 단 §14.4 게이트 + §15/§16 선행 조건으로 완화하면 **MEDIUM**.
+
+---
+
+> **문서 이력**
+>
+> | 버전 | 날짜 | 작성자 | 내용 |
+> |------|------|--------|------|
+> | 1.0 | 2026-04-23 | architect (Opus 4.7 xhigh) | 초안 — Phase 2a Shadow Read 한정 설계, Day 3 실행 범위 + Phase 2b/2c 로드맵 |
+> | 2.0 | 2026-04-23 | architect (Opus 4.7 xhigh) | **Sprint 7 내 전 Phase 완주 확장**. 48h 관찰 → 자동 검증 게이트 축약 (§13). Phase 2b auto-rollback 트리거 (§14). IS-PH2A-01 diff 초안 (§15). ADR-025 개정 경로 (§16). Day 3~5 압축 타임라인 (§17) |

--- a/docs/02-design/51-nestjs-v11-migration.md
+++ b/docs/02-design/51-nestjs-v11-migration.md
@@ -1,0 +1,427 @@
+# 51. @nestjs/core v10 → v11 메이저 Bump 영향도 분석
+
+**작성자**: architect
+**작성일**: 2026-04-23 (Day 2 저녁, Day 3 사전 분석)
+**대상 Sprint**: Sprint 7 Week 1 Day 3 (2026-04-24)
+**종속 보고서**: `docs/04-testing/78-sec-a-b-c-audit-delta.md`
+**판정**: **PROCEED with gates** (조건부 Go) — 검증 2.5h 이내 수렴 예상
+
+---
+
+## 0. 배경
+
+security 보고서 78(SEC-A/B/C audit delta) 에서 `@nestjs/core` v10 계열 moderate injection 취약점은
+**v11 메이저 bump 로만 해소** 된다고 결론. Day 2 Sprint 7 의 SEC-A(Go/go-redis) + SEC-B(Next) +
+SEC-C(admin) 마일스톤에 이어 Day 3 에 **ai-adapter Nest 생태계 v11 동반 bump** 를 수행한다.
+
+ai-adapter 는 LLM 어댑터 런타임 핵심 (Claude/OpenAI/DeepSeek/Ollama) 이며 game-server 의 모든 AI 턴
+요청 경로에 있다. 메이저 버전 bump 는 Pipe/Guard/Filter 동작과 DI 규칙을 바꿀 수 있으므로
+**MED-HIGH risk** 로 분류한다.
+
+---
+
+## 1. Executive Summary
+
+| 항목 | 값 |
+|---|---|
+| 판정 | **PROCEED with gates** |
+| 위험도 | MED-HIGH → 실제 **MED** (rxjs 직사용 0건, websocket 미사용, microservices 미사용으로 재평가) |
+| 코드 수정 예상 LOC | 0 ~ 20 (Guard 시그니처 확인 필요) |
+| 예상 wall-clock | 2.5h (수정 30m + Jest 15m + 재배포 10m + Playwright 25m + 버퍼 60m) |
+| Jest 599/599 유지 확신도 | **85%** (ThrottlerGuard canActivate 시그니처 + TypeScript 5 엄격화 리스크) |
+| Playwright 전수 회귀 예상 | **0건** (ai-adapter 는 game-server HTTP 피호출만, API 형상 유지) |
+| Rollback | 이미지 tag 롤백 (feature flag 없음) |
+
+### 판정 근거 3줄
+
+1. ai-adapter 는 Nest 기능 중 **Module/Controller/Service/Global Guard/Global Filter/Global Pipe**
+   최소 집합만 사용. WebSocket/Microservices/GraphQL/CacheModule/@nestjs/axios 등
+   **breaking 영향 큰 기능은 전무**.
+2. **rxjs 직접 사용 0건** (`grep "from 'rxjs" src = 0 hits`). rxjs 7→8 peer dep 변경도 영향 없음.
+3. 유일한 리스크는 `RateLimitGuard extends ThrottlerGuard` 의 `canActivate` 시그니처 —
+   @nestjs/throttler v6 (현재) 가 **v11 Nest 를 peer dep 로 허용** 하므로 병행 bump 불필요.
+
+---
+
+## 2. 현재 ai-adapter Nest 의존성 목록
+
+### 2.1 package.json (src/ai-adapter/package.json)
+
+```json
+"dependencies": {
+  "@nestjs/common":           "^10.0.0",
+  "@nestjs/config":           "^3.0.0",
+  "@nestjs/core":             "^10.0.0",
+  "@nestjs/platform-express": "^10.0.0",
+  "@nestjs/throttler":        "^6.5.0",
+  "axios":                    "^1.6.0",
+  "class-transformer":        "^0.5.1",
+  "class-validator":          "^0.14.0",
+  "ioredis":                  "^5.10.1",
+  "reflect-metadata":         "^0.1.13",
+  "rxjs":                     "^7.8.1"
+},
+"devDependencies": {
+  "@nestjs/cli":        "^10.0.0",
+  "@nestjs/schematics": "^10.0.0",
+  "@nestjs/testing":    "^10.0.0",
+  "@types/express":     "^4.17.17",
+  "@types/node":        "^20.3.1",
+  "typescript":         "^5.1.3"
+}
+```
+
+### 2.2 import 전수 (grep 결과 요약)
+
+| Nest 모듈 | import 심볼 | 사용처 파일 수 |
+|---|---|---|
+| `@nestjs/common` | Module, Global, Controller, Injectable, Inject, Optional, Logger, Get, Query, ValidationPipe, BadRequestException, HttpException, HttpStatus, ExecutionContext, ExceptionFilter, Catch, ArgumentsHost, OnModuleInit, OnModuleDestroy | 34 |
+| `@nestjs/core` | NestFactory, APP_GUARD | 2 (main + app.module) |
+| `@nestjs/config` | ConfigModule, ConfigService | 8 |
+| `@nestjs/platform-express` | (직접 import 없음; NestFactory가 내부 사용) | 0 |
+| `@nestjs/throttler` | ThrottlerModule, ThrottlerGuard, ThrottlerException, Throttle | 6 |
+| `@nestjs/testing` | Test, TestingModule | 28 (spec files) |
+
+### 2.3 Nest 확장 인터페이스 구현
+
+| 파일 | 인터페이스 | 메서드 시그니처 |
+|---|---|---|
+| `common/filters/http-exception.filter.ts` | `ExceptionFilter` | `catch(exception, host)` |
+| `common/guards/internal-token.guard.ts` | `CanActivate` | `canActivate(context)` |
+| `common/guards/rate-limit.guard.ts` | `extends ThrottlerGuard` | `async canActivate(context): Promise<boolean>` |
+| `cost/cost-limit.guard.ts` | `CanActivate` | `canActivate(context)` |
+| `prompt/registry/prompt-registry.service.ts` | `OnModuleInit` | `onModuleInit()` |
+| `redis/redis.module.ts` | `OnModuleDestroy` (provider) | `onModuleDestroy()` |
+
+### 2.4 사용하지 **않는** Nest 기능 (리스크 배제)
+
+- `@nestjs/axios` — 0 import. 어댑터는 axios 직접 사용
+- `@nestjs/websockets` — 0 import. game-server 가 WS 소유
+- `@nestjs/microservices` — 0 import
+- `@nestjs/graphql` — 0 import
+- `@nestjs/cache-manager` — 0 import (Redis 직접 사용)
+- `@nestjs/schedule` — 0 import
+- `@nestjs/event-emitter` — 0 import
+- `rxjs` 직접 import — **0 hits** (`grep "from 'rxjs" src`)
+
+---
+
+## 3. Nest v11 Breaking Change 매핑 (ai-adapter 사용 기능 중심)
+
+Nest v11 공식 마이그레이션 가이드 (https://docs.nestjs.com/migration-guide) 를 기준으로
+**우리가 실제 사용하는 기능에 한해** 영향을 매핑한다.
+
+### 3.1 영향 **있음** (검증 필수)
+
+#### (a) `@nestjs/throttler` ↔ `@nestjs/common` v11 peer dep
+
+- **변경점**: ThrottlerGuard v6 의 `canActivate` 내부가 `ExecutionContext` 외에 `@Throttle()`
+  metadata 를 reflector 로 읽는 로직. v11 에서 reflector API 는 안정(유지).
+- **우리 코드**: `rate-limit.guard.ts:28` `async canActivate(context: ExecutionContext): Promise<boolean>`
+  — `super.canActivate(context)` 호출. 시그니처 호환.
+- **리스크**: `@nestjs/throttler@^6.5.0` 가 v11 peer dep 허용해야 함. 공식 매트릭스 확인 필요 —
+  **v6 는 Nest v10/v11 both 허용** (throttler v6 changelog 확인).
+- **액션**: throttler v6 유지. 만약 peer 충돌 시 **v6 최신 patch** 또는 v7 병행 bump.
+- **검증**: `rate-limit.guard.spec.ts`, `rate-limit-config.spec.ts` 통과 확인.
+
+#### (b) `ValidationPipe` 동작 (main.ts:13-22)
+
+- **변경점**: v11 에서 `class-validator` / `class-transformer` peer 정합성 유지. v10 과 동작 동일.
+- **우리 코드**: `whitelist: true, forbidNonWhitelisted: true, transform: true,
+  transformOptions: { enableImplicitConversion: true }` — 모두 v11 유지 옵션.
+- **리스크**: `class-validator@^0.14.0` (현재) — v11 Nest 가 최소 `0.14.x` 를 peer 로 요구.
+  우리는 이미 `0.14.0`. **영향 없음**.
+- **검증**: `move.controller.spec.ts` 의 DTO 검증 경로 통과.
+
+#### (c) `ExceptionFilter` 글로벌 필터 (http-exception.filter.ts)
+
+- **변경점**: `@Catch()` 빈 괄호 전역 catch 는 v11 에서도 유효. `ArgumentsHost.switchToHttp()` API
+  변경 없음.
+- **리스크**: 없음.
+
+#### (d) `Logger` 인스턴스 생성
+
+- **변경점**: v11 에서 `Logger` 는 기본 `context` 파라미터를 우선. `new Logger(ClassName.name)`
+  패턴 우리 전부 사용 — v11 에서도 권장 패턴.
+- **리스크**: 없음.
+
+#### (e) `@nestjs/testing` Test API
+
+- **변경점**: v11 에서 `Test.createTestingModule()` 시그니처는 v10 과 동일. `overrideProvider`,
+  `compile()` 모두 유지.
+- **우리 코드**: 28 개 spec 파일에서 사용.
+- **리스크**: 없음. 단 ts-jest 가 TypeScript 5.x 유지하면 무풍.
+
+#### (f) `OnModuleInit` / `OnModuleDestroy` 라이프사이클
+
+- **변경점**: v11 에서 동일. provider 단위 destroy 훅 호출 순서 유지.
+- **리스크**: 없음.
+
+### 3.2 영향 **없음** (비사용 기능)
+
+- rxjs 8 요구 → 우리는 rxjs 직접 사용 0. peer 경고만 발생 가능 (peer 충족 여부).
+- Fastify adapter 변경 → 우리는 express adapter 사용. `@nestjs/platform-express` v11 동반 bump.
+- CacheModule 분리 (`@nestjs/cache-manager` 별도 패키지화) → 우리 미사용.
+- Microservices / GraphQL / WebSocket gateway 변경 → 우리 미사용.
+- `@nestjs/event-emitter` 메이저 변경 → 우리 미사용.
+
+### 3.3 TypeScript 버전 요구
+
+- Nest v11 은 **TypeScript 5.2+** 권장 (5.1 에서 4가지 strict 경고).
+- 우리 현재: `typescript: ^5.1.3` → **5.3+ 병행 bump 권장** (작업 범위 1줄).
+- tsconfig 기존 strict 옵션 유지: `strict: true`, `strictNullChecks: true`.
+
+### 3.4 Node 버전 요구
+
+- Nest v11: **Node 20+** (공식 LTS), Node 18 drop.
+- 우리 K8s 이미지 base: `node:20-alpine` (Dockerfile 확인 전제) — 호환.
+
+---
+
+## 4. 변경 범위 산출
+
+### 4.1 package.json diff 예상 (ai-adapter only)
+
+```diff
+-"@nestjs/common":           "^10.0.0",
++"@nestjs/common":           "^11.1.0",
+-"@nestjs/config":           "^3.0.0",
++"@nestjs/config":           "^4.0.0",
+-"@nestjs/core":             "^10.0.0",
++"@nestjs/core":             "^11.1.0",
+-"@nestjs/platform-express": "^10.0.0",
++"@nestjs/platform-express": "^11.1.0",
+-"@nestjs/throttler":        "^6.5.0",
++"@nestjs/throttler":        "^6.5.0",   // 유지 (v11 peer 허용 확인 후)
+
+ // devDependencies
+-"@nestjs/cli":        "^10.0.0",
++"@nestjs/cli":        "^11.0.0",
+-"@nestjs/schematics": "^10.0.0",
++"@nestjs/schematics": "^11.0.0",
+-"@nestjs/testing":    "^10.0.0",
++"@nestjs/testing":    "^11.1.0",
+-"typescript":         "^5.1.3"
++"typescript":         "^5.3.3"
+```
+
+- **총 8 패키지 bump** (dep 5 + devDep 4 - throttler 유지 + ts bump 1 = 9, 실질 bump 7~8).
+- `@nestjs/config` 는 v10→v11 Nest core 와 함께 v3→v4 동반 bump 필요 (peer dep).
+
+### 4.2 package-lock.json 예상 diff
+
+- Nest 패키지 트리 전체 재생성 → **수천 라인** (~3000~5000 lines).
+- `npm install --package-lock-only` 로 lock 만 재생성 후 review.
+- 의존성 그래프 내 `class-validator`, `class-transformer`, `reflect-metadata` 는 v10 수준 유지.
+
+### 4.3 소스 코드 수정 예상 LOC
+
+| 파일 | 예상 LOC | 이유 |
+|---|---|---|
+| `src/main.ts` | **0** | ValidationPipe/CORS/Filter 모두 v11 호환 |
+| `src/app.module.ts` | **0** | Module decorator, APP_GUARD 유지 |
+| `src/common/guards/rate-limit.guard.ts` | **0~5** | throttler v6 + Nest v11 조합이 OK 면 0. 시그니처 strict 경고 시 5 |
+| `src/common/filters/http-exception.filter.ts` | **0** | ExceptionFilter 인터페이스 유지 |
+| `src/common/guards/internal-token.guard.ts` | **0** | CanActivate 시그니처 유지 |
+| `src/cost/cost-limit.guard.ts` | **0** | CanActivate 시그니처 유지 |
+| spec 파일 28개 | **0** | TestingModule API 유지 |
+| **합계** | **0 ~ 20 LOC** | |
+
+---
+
+## 5. 검증 전략
+
+### 5.1 로컬 Jest 전수 (필수 게이트)
+
+```bash
+cd src/ai-adapter
+npm install          # lockfile 재생성
+npm test             # 현재 599/599 PASS → 599/599 유지 목표
+```
+
+- 실패 시 즉시 stacktrace 분석. 대부분은 class-validator peer 또는 throttler canActivate 시그니처.
+- 수정 범위 초과 (20 LOC 이상) 시 **HOLD** 판정 후 재분석.
+
+### 5.2 로컬 build smoke
+
+```bash
+cd src/ai-adapter
+npm run build        # tsc --project tsconfig.build.json
+node dist/main.js &  # 포트 8081 기동 확인
+curl http://localhost:8081/health        # 200 OK
+curl http://localhost:8081/health/adapters  # openai/claude/deepseek/ollama 상태
+```
+
+### 5.3 K8s 배포 smoke (4 LLM 각 1턴)
+
+```bash
+# Build & push
+docker build -t ai-adapter:day3-nestjs-v11-<sha> src/ai-adapter/
+# Helm upgrade (ai-adapter only, game-server 무변경)
+helm upgrade ai-adapter helm/charts/ai-adapter --set image.tag=day3-nestjs-v11-<sha>
+kubectl -n rummikub rollout status deploy/ai-adapter --timeout=120s
+
+# Smoke: 각 모델 1회 AI_MOVE
+python scripts/ai-battle-3model-r4.py --models openai --max-turns 3
+python scripts/ai-battle-3model-r4.py --models claude --max-turns 3
+python scripts/ai-battle-3model-r4.py --models deepseek --max-turns 3
+python scripts/ai-battle-3model-r4.py --models ollama --max-turns 3
+```
+
+- **기준**: 4 모델 각각 **AI_MOVE 1턴 이상 place 또는 draw 성공**. fallback/timeout 0건.
+- Redis `quota:daily:{YYYY-MM-DD}` hash 증가 확인 (비용 집계 정상).
+
+### 5.4 Playwright 전수 (회귀 확인)
+
+```bash
+cd src/frontend
+npx playwright test --reporter=line
+```
+
+- **기준**: 기존 PASS 유지 (376/390 기준). **신규 FAIL 0건**.
+- ai-adapter 는 game-server HTTP 피호출 경로에서 블랙박스 — API contract 유지 시 회귀 0 기대.
+
+### 5.5 에러 코드 파싱 정상 확인
+
+- `http-exception.filter.ts` 의 `error.code` 응답 포맷 (HttpException 기반) 회귀 확인.
+- Smoke: 400 (ValidationPipe), 429 (RateLimitGuard), 500 (unhandled) 각 1회 유발.
+- `docs/02-design/29-error-code-registry.md` 의 `AI_*` 코드 정합.
+
+---
+
+## 6. Rollback 계획
+
+### 6.1 트리거 조건
+
+- Jest 599/599 유지 실패 (수정 범위 20 LOC 이상 or 원인 불명)
+- K8s smoke 에서 4 모델 중 1개라도 신규 fallback/timeout
+- Playwright 신규 FAIL 발생
+- health/adapters 엔드포인트가 401/403 반환 (Internal-token guard 회귀)
+
+### 6.2 롤백 절차
+
+```bash
+# 1. 이미지 tag 롤백
+helm upgrade ai-adapter helm/charts/ai-adapter \
+  --set image.tag=day2-2026-04-23
+kubectl -n rummikub rollout status deploy/ai-adapter --timeout=60s
+
+# 2. package.json / lockfile 롤백
+cd src/ai-adapter
+git checkout HEAD -- package.json package-lock.json
+npm ci
+
+# 3. 커밋 revert (PR 머지 전이면 drop, 머지 후면 revert commit)
+git revert <nestjs-v11-bump-sha>
+```
+
+### 6.3 롤백 후 대응
+
+- SEC-78 의 Nest core moderate 이슈는 **일시 유지** (Medium, 7일 이내 재시도 목표).
+- 원인 분석 보고서 추가: `docs/04-testing/79-nestjs-v11-rollback-analysis.md`.
+
+---
+
+## 7. Go/No-Go 게이트
+
+Day 3 실행 중 각 게이트에서 **통과 시 다음 단계, 실패 시 Rollback** 결정.
+
+| # | 게이트 | 통과 기준 | 실패 시 |
+|---|---|---|---|
+| G1 | `npm install` 성공 | peer dep 경고만 허용, error 0 | HOLD — peer 매트릭스 재분석 |
+| G2 | `npm run build` 성공 | tsc 0 error | 시그니처 패치 (최대 20 LOC) 후 재시도 |
+| G3 | **Jest 599/599** | PASS 유지 | 원인 분석 ≤ 30m, 초과 시 Rollback |
+| G4 | K8s deploy ready | rollout status OK, readinessProbe PASS | Pod log 확인, 10m 내 미해결 시 Rollback |
+| G5 | **4 LLM smoke** | 각 모델 1턴 이상 정상 turn | 어댑터별 격리 분석, Rollback 판정 |
+| G6 | **Playwright 전수** | 신규 FAIL 0 | 회귀 격리, Rollback |
+| G7 | **에러 코드 파싱** | 400/429/500 각 1회 정상 포맷 | 필터 수정 or Rollback |
+
+---
+
+## 8. Day 3 실행 예산 + 의존성
+
+### 8.1 시간 예산 (wall-clock)
+
+| 단계 | 예산 | 누적 |
+|---|---|---|
+| package.json + lockfile bump | 15m | 0h15m |
+| 코드 수정 (Guard 시그니처 if any) | 15m | 0h30m |
+| 로컬 Jest 전수 | 15m | 0h45m |
+| 로컬 build + smoke | 15m | 1h00m |
+| Docker build + K8s 재배포 | 10m | 1h10m |
+| 4 LLM smoke (3턴씩) | 20m | 1h30m |
+| Playwright 전수 | 25m | 1h55m |
+| 트러블슈팅 여유 | 60m | 2h55m |
+| **합계** | **~2.5h~3h** | |
+
+### 8.2 의존성 / 병렬성
+
+- **독립 가능**: ai-adapter 단일 서비스 변경. game-server / frontend / helm 기타 chart 영향 없음.
+- **Day 3 병렬 가능 작업**:
+  - SEC-A (Go 1.25.9 + go-redis v9.7.3) — go-dev + devops 담당, 충돌 없음
+  - SEC-BC (Next 15.5.15 + admin) — frontend-dev 담당, 충돌 없음
+  - Issue #47 (LeaveRoom PLAYING guard) — go-dev 담당, 충돌 없음
+- **선행 조건**: Day 2 저녁 Playwright baseline 녹음 (최근 PR 머지 직후 상태 기준).
+- **후속 블록**: Day 4 ~ Day 5 의 ai-adapter 관련 E2E 배치 (v4 prompt pilot 등) 는 Day 3 검증
+  통과 후 착수.
+
+### 8.3 담당 / 역할
+
+| 단계 | 담당 |
+|---|---|
+| 본 분석 문서 (이 문서) | architect (Day 2 저녁 완료) |
+| bump + 코드 수정 | node-dev |
+| Jest + build 검증 | node-dev |
+| K8s 재배포 | devops |
+| 4 LLM smoke | qa |
+| Playwright 전수 | qa |
+| 게이트 판정 | architect (최종) |
+
+---
+
+## 9. 의사결정 요약 (ADR-style)
+
+### Status
+**Accepted (조건부)** — 게이트 G1~G7 전수 통과 시 머지.
+
+### Context
+`@nestjs/core@^10.0.0` 는 moderate injection 취약점 존재 (SEC-78). v11 메이저 bump 가 유일한 해소 경로.
+ai-adapter 는 runtime 핵심이지만 Nest 최소 집합만 사용.
+
+### Decision
+Day 3 (2026-04-24) 에 Nest 생태계 8개 패키지 동반 bump 를 수행한다. 세부 게이트 7개 + Rollback 절차 +
+이미지 tag 기반 즉시 복구 계약을 준수한다.
+
+### Consequences
+- **긍정**: SEC-78 moderate 해소, Nest 생태계 lifecycle 유지, Node 20+ 정렬
+- **부정**: 2.5~3h wall-clock, lockfile 수천 줄 diff, throttler v6 peer 매트릭스 상시 모니터
+- **리스크 전가**: `@nestjs/throttler` 가 v11 peer 미지원 시 **v7 병행 bump** 필요 (추가 30m)
+
+### Alternatives Considered
+1. **HOLD** (v10 유지) — SEC-78 moderate 장기 방치, 불수용
+2. **부분 bump** (throttler/config 만) — Nest core peer dep 위반, 불가
+3. **이미지만 scan ignore** — 감사 기록 악화, DevSecOps 원칙 위배
+
+---
+
+## 10. 체크리스트 (Day 3 실행용)
+
+### 사전 (Day 2 저녁, 현재)
+- [x] 본 문서 작성
+- [ ] Playwright baseline 녹음 (`npx playwright test --reporter=json > baseline.json`)
+- [ ] 현재 이미지 tag 기록 (`kubectl -n rummikub get deploy ai-adapter -o=jsonpath='{.spec.template.spec.containers[0].image}'`)
+
+### Day 3 당일
+- [ ] G1: `npm install` 성공
+- [ ] G2: `npm run build` 성공
+- [ ] G3: Jest 599/599
+- [ ] G4: K8s rollout ready
+- [ ] G5: 4 LLM smoke OK
+- [ ] G6: Playwright 신규 FAIL 0
+- [ ] G7: 에러 코드 파싱 정상
+- [ ] 커밋 PR 작성 (`security(ai-adapter): @nestjs/* v10 → v11 bump — SEC-78 moderate 해소`)
+- [ ] 머지 후 Redis quota 증가 확인 (smoke 비용 집계)
+
+### 사후
+- [ ] 데일리 로그에 소요 시간 기록
+- [ ] 실패 게이트 있었다면 `docs/04-testing/79-*.md` 로 별도 보고

--- a/docs/02-design/52-adr-next-auth-v5-migration.md
+++ b/docs/02-design/52-adr-next-auth-v5-migration.md
@@ -1,0 +1,491 @@
+# 52. ADR — next-auth v5 (Auth.js) 이주
+
+- 작성일: 2026-04-23 (Sprint 7 Day 2)
+- 작성자: architect (Opus 4.7 xhigh)
+- 상태: **Proposed** — Sprint 7 내 실행 확정
+- 연관 ADR: ADR D-03 (rooms PostgreSQL Phase 1), ADR-025 (게스트 방 영속 배제)
+- 연관 문서: `docs/02-design/51-nestjs-v11-migration.md` (supply-chain 동기화 bump)
+- 분류: Security · Supply-chain · Frontend Runtime · **MEDIUM Risk**
+
+---
+
+## 1. Context
+
+### 1.1 촉발 이슈
+
+`src/frontend` npm audit 결과 `next-auth@4.24.11` 이 의존하는 **`uuid` 버전 범위** 에서 [`GHSA-w5hq-g745-h8pq`](https://github.com/advisories/GHSA-w5hq-g745-h8pq) (moderate) 가 발견됐다. 해당 advisory 는 `uuid < 14` 범위에 적용되며, `next-auth@4` 의 `dependencies.uuid` semver 범위(`^8.x`)가 상향되지 않았기 때문에 **v4 semver 안에서는 해소 불가**하다.
+
+```
+next-auth 4.24.11
+└─ uuid@8.3.2  ← GHSA-w5hq-g745-h8pq (moderate)
+```
+
+### 1.2 next-auth v4 상태
+
+- 2025-Q4 시점부터 Vercel/Auth.js 팀이 v4 를 **maintenance mode** 로 전환. 신규 기능 없고 보안 패치만 받음.
+- 실제 v4 branch 에 `uuid` 업그레이드 PR 이 올라와있지만 (v4 스펙 호환성 이슈로) merge 지연 상태.
+- `next@15.5.15` (현재 사용) 는 v4 호환은 유지하되 **App Router + React Server Components 환경에서 v5 를 공식 권장**.
+
+### 1.3 기존 사용 패턴
+
+조사 결과 (2026-04-23 기준):
+
+| 파일 | 사용 | 패턴 |
+|------|------|------|
+| `src/frontend/src/app/api/auth/[...nextauth]/route.ts` | handler | `NextAuth(authOptions)` → `GET/POST` export |
+| `src/frontend/src/lib/auth.ts` | config | `NextAuthOptions`, Google + Credentials (dev-login) providers, `jwt/session` 콜백 |
+| `src/frontend/src/components/providers/AuthProvider.tsx` | provider | `SessionProvider` (client boundary) |
+| `src/frontend/src/types/next-auth.d.ts` | 타입 확장 | `declare module "next-auth"` / `"next-auth/jwt"` |
+| `src/frontend/src/hooks/useWebSocket.ts` | client | `useSession` |
+| `src/frontend/src/lib/authToken.ts` | client | session 우선 + localStorage fallback |
+| Server pages (7개) | SSR | `getServerSession(authOptions)` |
+| Client components (5개) | client | `useSession`, `signIn`, `signOut` |
+
+**총 18 파일 영향권** (src/frontend/src 한정, node_modules 제외).
+
+### 1.4 미들웨어 · 외부 의존
+
+- `middleware.ts` 또는 `withAuth` HOC: **미사용 확인** (frontend src 내 grep 0 건).
+- Helm `frontend.values.yaml`: `NEXTAUTH_URL`, `NEXTAUTH_SECRET` env 주입. v5 에서 각각 `AUTH_URL`, `AUTH_SECRET` 으로 rename (호환 alias 유지되지만 권장명 변경).
+- Admin 패널(`helm/charts/admin/values.yaml`) 도 `NEXTAUTH_*` env 사용. **본 ADR 범위 밖** (admin 은 별건).
+
+### 1.5 Game-server JWT 와의 관계
+
+Game-server (`src/game-server/internal/middleware/auth.go`) 는 **자체 HS256 JWT** 를 검증한다. next-auth 는 다음 2 경로로 이 토큰을 획득한다:
+
+1. **Google 로그인**: next-auth `jwt` 콜백에서 `id_token` 을 game-server `POST /api/auth/google/token` 으로 교환 → 응답 `token` 을 `session.accessToken` 으로 저장.
+2. **dev-login (Credentials)**: `authorize` 에서 game-server `POST /api/auth/dev-login` 호출 → 응답 `token` 을 `user.accessToken` 으로 전달.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as Browser
+    participant NA as "next-auth<br/>(frontend)"
+    participant GS as "game-server<br/>/api/auth/*"
+    participant G as Google OAuth
+
+    alt Google 로그인
+      U->>NA: signIn("google")
+      NA->>G: OAuth code 교환
+      G-->>NA: id_token + access_token
+      NA->>GS: POST /api/auth/google/token {idToken}
+      GS-->>NA: {token: HS256 JWT}
+      NA->>NA: jwt 콜백: token.accessToken = HS256
+    else dev-login
+      U->>NA: signIn("dev-login", {userId, displayName})
+      NA->>GS: POST /api/auth/dev-login
+      GS-->>NA: {token: HS256 JWT}
+    end
+    NA-->>U: Set-Cookie: next-auth.session-token
+    U->>GS: WS/REST + Authorization: Bearer HS256
+    GS->>GS: JWTAuth middleware 검증
+```
+
+**결정적 관찰**: game-server 는 next-auth 의 내부 session JWT 를 **전혀 보지 않는다**. game-server 는 자체 발급한 HS256 JWT 만 검증한다. 따라서 next-auth v5 이주는 **game-server 코드 변경 0 건**.
+
+---
+
+## 2. Decision
+
+next-auth v4.24.11 → **Auth.js v5 (`next-auth@5.x`)** 로 이주한다. Sprint 7 내 (Day 3~Day 5 사이) PR 1 건으로 완료.
+
+### 2.1 이주를 선택한 이유
+
+1. **v4 semver 범위 내 uuid patch 불가** — supply-chain 고착.
+2. **v4 maintenance mode** — 추후 moderate+ CVE 반복 발생 시 재이주 부담.
+3. **Auth.js v5 가 App Router 기본 가정** — 현재 App Router 기반 (app/) 이라 v5 가 자연스러움.
+4. **game-server 영향 0** — 파급이 frontend 한정이라 risk budget 이 작음.
+
+### 2.2 대안 검토
+
+| 대안 | 선택 안 한 이유 |
+|------|---------------|
+| A. `overrides` 로 `uuid@11` 강제 | `next-auth@4` 내부 `uuid.v4()` API 가 v11 과 호환은 되지만 Auth.js 팀이 **비공식**. 다음 CVE 재발 가능. 기술 부채 누적 |
+| B. v4 fork 후 uuid bump 패치 유지 | 유지보수 부담 너무 큼 |
+| C. Sprint 8 이관 | 사용자 지시: Sprint 7 내 처리. moderate 가 빌드 안 막아도 audit 잡에서 계속 WARN 생성 |
+| D. next-auth 제거 → 자체 구현 | 게임 엔진이 아닌 영역에서 오버엔지니어링. OAuth 상태 기기 (code→token 교환, PKCE, session cookie rotation) 를 자체 유지 불합리 |
+
+### 2.3 결정 = v5 단행, dev-login(Credentials) 유지
+
+v5 는 Credentials provider 를 계속 지원한다 (JWT 전략 한정). dev-login 경로는 `authorize` 구현 그대로 이식 가능.
+
+---
+
+## 3. 범위
+
+### 3.1 Frontend 파일 단위 변경 matrix
+
+| 파일 | 변경 유형 | v4 → v5 |
+|------|---------|---------|
+| `src/app/api/auth/[...nextauth]/route.ts` | **재작성** | `NextAuth(authOptions)` → `const { handlers } = NextAuth(config); export const { GET, POST } = handlers` |
+| `src/lib/auth.ts` | **재작성** | `NextAuthOptions` → `NextAuthConfig`. `providers` 배열 그대로. `callbacks` 그대로. `authOptions` export → `auth` / `signIn` / `signOut` / `handlers` export |
+| `src/components/providers/AuthProvider.tsx` | **변경 없음** | `SessionProvider` import 경로 v5 에서도 `next-auth/react` 유지 |
+| `src/types/next-auth.d.ts` | **소폭 수정** | `DefaultSession`, `DefaultJWT` 타입 import 경로 동일. 모듈 이름도 유지. 단 `token.sub` 접근 경로 변경 없음 |
+| `src/app/**/page.tsx` (7 파일) | **API 치환** | `getServerSession(authOptions)` → `auth()` (v5 universal helper) |
+| 클라이언트 컴포넌트 5 파일 | **변경 없음** | `useSession`, `signIn`, `signOut` 모두 v5 유지 |
+| `src/hooks/useWebSocket.ts` | **변경 없음** | `useSession` 유지 |
+| `src/lib/authToken.ts` | **변경 없음** | `session.accessToken` 접근 패턴 유지 |
+
+### 3.2 Env 변수
+
+| v4 | v5 | 조치 |
+|----|----|------|
+| `NEXTAUTH_URL` | `AUTH_URL` (선호) or `NEXTAUTH_URL` 그대로 | **호환 유지** — 둘 다 동작. Helm values 변경 **없음** |
+| `NEXTAUTH_SECRET` | `AUTH_SECRET` (선호) or `NEXTAUTH_SECRET` 그대로 | 동일 |
+| `GOOGLE_CLIENT_ID/SECRET` | 동일 | 없음 |
+
+> v5 는 `AUTH_*` prefix 가 권장이지만 `NEXTAUTH_*` 호환 유지. **이주 PR 에서는 env 이름을 건드리지 않는다** (Helm / Secret / CI 순환 폭 최소화). 별건으로 Sprint 8 에서 rename 검토.
+
+### 3.3 세션 전략 — JWT 유지
+
+현재 `session.strategy = "jwt"`, `maxAge = 24h`. v5 에서 JWT 전략은 **그대로 유지** (database adapter 로 전환하면 PostgreSQL schema 추가 필요 → 범위 확장됨).
+
+- JWT secret: `NEXTAUTH_SECRET` 재사용. 기존 발급된 세션 쿠키는 **secret 호환** 이므로 rotation 불필요 (같은 secret → 같은 서명).
+- `jwt()` callback 내부의 game-server 토큰 교환 로직은 **1:1 이식**.
+- `session()` callback 에서 `session.accessToken`, `session.user.id` 노출 로직도 1:1 이식.
+
+### 3.4 서버 컴포넌트 session 접근
+
+v5 의 핵심 변경 = `auth()` helper.
+
+**v4 (현행)**:
+```ts
+// src/app/lobby/page.tsx
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+
+export default async function LobbyPage() {
+  const session = await getServerSession(authOptions);
+  if (!session) redirect("/login");
+  // ...
+}
+```
+
+**v5 (목표)**:
+```ts
+// src/app/lobby/page.tsx
+import { auth } from "@/lib/auth";
+
+export default async function LobbyPage() {
+  const session = await auth();
+  if (!session) redirect("/login");
+  // ...
+}
+```
+
+`authOptions` 이 `auth` / `handlers` / `signIn` / `signOut` 으로 쪼개진다. 즉 `lib/auth.ts` 가 config 파일에서 **runtime helper factory** 로 바뀐다.
+
+### 3.5 Middleware 변경 여부
+
+현재 `src/frontend/middleware.ts` 미존재. v5 가 기본 제공하는 edge middleware (`export { auth as middleware } from "@/lib/auth"`) 도입은 **본 PR 범위 밖**. 도입 시점은 Phase 2 인증 강제 경로(로그인 리디렉션 중앙화) 가 필요할 때 별건 ADR.
+
+---
+
+## 4. 마이그레이션 단계 (파일 단위)
+
+```mermaid
+flowchart TB
+    S0["Step 0: 브랜치 + 백업<br/>현재 auth.ts 스냅샷"] --> S1
+    S1["Step 1: package.json<br/>next-auth@5.x 로 bump"] --> S2
+    S2["Step 2: lib/auth.ts<br/>NextAuth 재구성<br/>handlers/auth/signIn 분리 export"] --> S3
+    S3["Step 3: api/auth/route.ts<br/>handlers 재export"] --> S4
+    S4["Step 4: types/next-auth.d.ts<br/>v5 타입 모듈 이름 검증"] --> S5
+    S5["Step 5: SSR pages 7개<br/>getServerSession → auth()"] --> S6
+    S6["Step 6: 로컬 pnpm build<br/>+ dev 서버 구동"] --> S7
+    S7["Step 7: Playwright auth 플로우<br/>(Google + dev-login)"] --> S8
+    S8["Step 8: Helm 변경 없음 확인<br/>+ PR 생성"]
+```
+
+### Step 1 — package.json bump
+
+```jsonc
+// src/frontend/package.json (diff)
+{
+  "dependencies": {
+-   "next-auth": "^4.24.11",
++   "next-auth": "^5.0.0-beta.25",  // v5 stable 출시 시 ^5.0.0 로 pin
+    // ...
+  }
+}
+```
+
+> **주의**: 2026-01 현재 v5 는 `5.0.0-beta.25` 가 최신. beta 이지만 Vercel 프로덕션 배포 사례가 다수 존재. **stable 출시 전까지 beta 사용** 은 Sprint 7 맥락에서 수용 가능 리스크 (우리도 early adopter 가 아님 — 수개월 beta 기간 경과).
+> 만약 v5 beta 채택이 정책적으로 부담스러우면 Step 1 에서 정지하고 **fallback 플랜 A (overrides uuid@11)** 를 단기 적용 후 v5 stable 출시 시 재이주.
+
+### Step 2 — `lib/auth.ts` 재작성 (핵심)
+
+**v4 → v5 diff 요지**:
+
+```ts
+// BEFORE (v4)
+import type { NextAuthOptions } from "next-auth";
+export const authOptions: NextAuthOptions = { providers, callbacks, pages, session };
+```
+
+```ts
+// AFTER (v5)
+import NextAuth, { type NextAuthConfig } from "next-auth";
+import GoogleProvider from "next-auth/providers/google";
+import CredentialsProvider from "next-auth/providers/credentials";
+
+const config: NextAuthConfig = {
+  providers: [...],   // 동일
+  callbacks: {...},   // 동일 (타입만 next-auth@5 의 JWT/Session 로 맞춤)
+  pages: {...},       // 동일
+  session: { strategy: "jwt", maxAge: 24 * 60 * 60 },
+};
+
+export const { handlers, auth, signIn, signOut } = NextAuth(config);
+```
+
+### Step 3 — `route.ts` 재export
+
+```ts
+// BEFORE (v4)
+import NextAuth from "next-auth";
+import { authOptions } from "@/lib/auth";
+const handler = NextAuth(authOptions);
+export { handler as GET, handler as POST };
+```
+
+```ts
+// AFTER (v5)
+export { GET, POST } from "@/lib/auth"; // handlers 에서 구조분해
+// OR:
+import { handlers } from "@/lib/auth";
+export const { GET, POST } = handlers;
+```
+
+### Step 4 — 타입 확장 (`types/next-auth.d.ts`)
+
+v5 에서도 module augmentation 경로는 `"next-auth"` / `"next-auth/jwt"` 유지. 파일 변경 **최소**.
+
+```ts
+// v5 에서도 동일
+declare module "next-auth" {
+  interface Session {
+    accessToken?: string;
+    user?: { id?: string } & { name?: string | null; email?: string | null; image?: string | null };
+  }
+}
+declare module "next-auth/jwt" {
+  interface JWT {
+    accessToken?: string;
+  }
+}
+```
+
+### Step 5 — SSR pages 7개 치환 (기계적)
+
+```diff
+- import { getServerSession } from "next-auth";
+- import { authOptions } from "@/lib/auth";
++ import { auth } from "@/lib/auth";
+
+- const session = await getServerSession(authOptions);
++ const session = await auth();
+```
+
+대상: `app/page.tsx`, `lobby/page.tsx`, `practice/page.tsx`, `rankings/page.tsx`, `room/create/page.tsx`, `room/[roomId]/page.tsx`, `game/[roomId]/page.tsx`.
+
+### Step 6 — 빌드 + dev 구동
+
+```bash
+cd src/frontend
+pnpm install
+pnpm build    # next build 통과
+pnpm dev      # localhost:3000 로그인 수동 확인
+```
+
+### Step 7 — Playwright 인증 플로우 회귀
+
+```bash
+pnpm test:e2e -- --grep "login|auth"
+# 타겟:
+#  - tests/auth/google-mock.spec.ts (있으면)
+#  - tests/auth/dev-login.spec.ts
+#  - tests/auth/session-persist.spec.ts (재로딩 후 session 유지)
+```
+
+전수 Playwright (390 tests) 는 Step 8 PR CI 에서 실행.
+
+### Step 8 — Helm 변경 없음 확인
+
+`helm/charts/frontend/values.yaml` `NEXTAUTH_SECRET`, `NEXTAUTH_URL` 이 **그대로** 동작하는지 staging 에서 확인. v5 가 `AUTH_*` 를 권장하지만 `NEXTAUTH_*` alias 를 읽는다.
+
+---
+
+## 5. Game-server 연동 영향
+
+### 5.1 JWT 토큰 흐름 — 변경 없음
+
+앞서 §1.5 에서 분석한 대로 game-server 는 `Authorization: Bearer <HS256>` 을 `middleware/auth.go` 에서 검증한다. HS256 secret (`JWT.Secret`) 은 **next-auth 와 무관**. next-auth 는 단지 session cookie 에 HS256 토큰을 wrapping 해 client 로 실어나르는 역할.
+
+```mermaid
+flowchart LR
+    NA5["next-auth v5<br/>session-cookie<br/>(next-auth 내부 JWT)"] -->|WS open| WS["WebSocket handshake<br/>Sec-WebSocket-Protocol 또는<br/>Query param: token=HS256"]
+    NA5 -->|REST fetch| API["fetch() + Authorization:<br/>Bearer HS256"]
+    WS --> GS["game-server<br/>middleware.JWTAuth(HS256)"]
+    API --> GS
+```
+
+Game-server 입장에서 **"누가 토큰을 발급했는지"** 는 상관없다. 서명 검증이 통과하면 유효. 따라서 **game-server 코드 변경 0**.
+
+### 5.2 dev-login POST 계약
+
+`POST /api/auth/dev-login` 의 request/response body contract 은 v5 이주와 무관하게 유지. (`{userId, displayName}` → `{token, userId, displayName}`)
+
+### 5.3 Google ID Token 교환 경로
+
+`POST /api/auth/google/token` contract 도 유지. next-auth v5 의 `jwt` 콜백에서도 동일하게 `account.id_token` 을 사용 가능.
+
+**예외 1건 검증 필요**: v5 의 `account` 객체 스키마가 `id_token` 필드를 노출하는지 Step 2 구현 중 로컬 로그로 확인. Auth.js v5 docs 기준 노출 유지.
+
+---
+
+## 6. Rollback 전략
+
+### 6.1 PR 머지 전 로컬 롤백
+
+Git revert 1 커밋. `pnpm install` 로 v4 복구.
+
+### 6.2 프로덕션 배포 후 장애 시
+
+| 상황 | 대응 | 예상 시간 |
+|------|------|----------|
+| 빌드 실패 | 이미 CI 에서 차단 → 프로덕션 영향 없음 | - |
+| 로그인 100% 실패 | ArgoCD 에서 이전 리비전으로 rollback | 5분 |
+| 세션 쿠키 호환성 문제 | 사용자에게 **재로그인 요청** 공지 (모든 세션 무효화) | 즉시 |
+| Google OAuth 리디렉션 URL mismatch | Google Cloud Console 리디렉션 URI 가 동일 (`/api/auth/callback/google`) 확인. v5 도 **같은 path** 사용 | N/A |
+
+### 6.3 세션 쿠키 이름
+
+- v4: `next-auth.session-token`, Secure 환경 `__Secure-next-auth.session-token`
+- v5: **동일 이름 유지**. 단 `AUTH_URL` 이 `https` 면 prefix 자동 Secure.
+
+→ 기존 로그인 세션은 이주 후에도 **원칙적으로 유지**. (단 signature 알고리즘 변경이 없다는 전제. v5 기본 JWT 알고리즘 HS256 로 v4 와 동일.)
+
+→ **안전 조치**: 배포 시점에 `NEXTAUTH_SECRET` 을 굳이 rotate 하지 않는다. 만약 호환성 예외 발생 시 secret rotate + 전면 재로그인을 **최후** 옵션으로 유지.
+
+---
+
+## 7. 검증 — Playwright auth 플로우 재실행
+
+### 7.1 필수 테스트 케이스
+
+| 시나리오 | 테스트 파일 (추정) | PASS 기준 |
+|---------|-------------------|-----------|
+| dev-login 성공 | `e2e/auth/dev-login.spec.ts` | session 쿠키 set + `/lobby` 리다이렉트 |
+| dev-login 실패 (잘못된 userId) | 동일 | 400 + `/login` 잔류 |
+| Google OAuth 모킹 | `e2e/auth/google-mock.spec.ts` | `authorize` callback 통과 + HS256 교환 |
+| 세션 지속 (새로고침) | `e2e/auth/session-persist.spec.ts` | `useSession` 이 client 에서 로드 |
+| signOut | `e2e/auth/signout.spec.ts` | 쿠키 제거 + `/login` 리다이렉트 |
+| WS 재연결 with accessToken | `e2e/game/ws-reconnect.spec.ts` | WS handshake 성공 |
+| SSR session 접근 | `e2e/lobby/room-list.spec.ts` | 비로그인 시 `/login` 리다이렉트, 로그인 시 /lobby |
+
+### 7.2 전수 회귀
+
+Playwright **390 tests** 전부 CI 에서 실행. 기존 Ollama Known Fail 4건 / Flaky 10건 을 제외한 **376+ tests PASS** 유지가 GO 조건.
+
+### 7.3 수동 smoke (staging)
+
+| 체크리스트 | 예상 시간 |
+|-----------|-----------|
+| Google 로그인 → `/lobby` 진입 | 2분 |
+| dev-login → `/lobby` 진입 | 1분 |
+| 로비 → 방 생성 → WS 연결 | 2분 |
+| 새로고침 → 세션 유지 | 1분 |
+| signOut → `/login` | 1분 |
+| 관리자 로그인 (admin role) | 2분 |
+
+---
+
+## 8. 예상 LOC + 소요 시간
+
+### 8.1 LOC 예측
+
+| 파일 | 예상 변화 |
+|------|---------|
+| `package.json` | +1/-1 |
+| `src/lib/auth.ts` | +15/-10 (구조 변경 위주) |
+| `src/app/api/auth/[...nextauth]/route.ts` | +2/-4 |
+| `src/types/next-auth.d.ts` | +0/-0 |
+| SSR pages 7 파일 | 각 +2/-2 (기계적) = +14/-14 |
+| **합계 (src)** | **+32/-29 ≈ 60 LOC 순수 변경** |
+
+단, `pnpm-lock.yaml` 은 next-auth v5 의 전이 의존성 (node-forge, jose 등) 이 달라지므로 **수백 줄 auto-generated diff** 발생.
+
+### 8.2 시간 예측 (병렬 없음 가정)
+
+| 작업 | 시간 |
+|------|------|
+| 브랜치 + 의존성 bump | 0.25h |
+| `lib/auth.ts` 재작성 | 1.5h (callback 타입 검증 포함) |
+| SSR pages 치환 | 0.5h |
+| 로컬 build + dev 수동 smoke | 0.5h |
+| Playwright auth spec 재실행 | 0.5h |
+| CI 전수 Playwright 대기 | 0.5h |
+| PR 작성 + 코드리뷰 대응 | 1h |
+| **합계** | **~4.75h** |
+
+Sprint 7 Day 3 오후 또는 Day 4 오전 슬롯에 적합. frontend-dev 단독 가능.
+
+---
+
+## 9. Risk Budget
+
+| Risk | 확률 | 영향 | 완화 | 잔여 |
+|------|------|------|------|------|
+| R1. v5 beta 사용으로 향후 breaking change | 중 | 중 | `5.0.0-beta.X` pin + Auth.js release notes 모니터 | 낮 |
+| R2. 세션 쿠키 호환성 깨져 전면 재로그인 | 낮 | 중 | `NEXTAUTH_SECRET` 유지 + staging 에서 기존 쿠키 테스트 | 낮 |
+| R3. Google OAuth 리다이렉트 URI mismatch | 낮 | 고 | path 동일 (`/api/auth/callback/google`) 확인. Google Console 변경 불필요 | 낮 |
+| R4. SSR `auth()` helper 가 server component 에서 성능 저하 | 낮 | 낮 | v5 에서 `auth()` 는 기존 `getServerSession` 대비 오히려 경량 (Auth.js blog 벤치). p95 latency 회귀 모니터 | 낮 |
+| R5. dev-login Credentials provider 가 v5 에서 JWT 전략 외 미지원 | 낮 | 중 | 우리 코드가 이미 JWT 전략 고정. 영향 없음 | 없 |
+| R6. 타입 모듈 이름 (`declare module "next-auth"`) 이 v5 에서 변경 | 낮 | 낮 | v5 docs 확인 완료. 모듈명 동일 | 없 |
+| R7. pnpm lockfile 대량 변경으로 SEC 감사 잡에서 alert 폭주 | 중 | 낮 | 별건 SEC 감사 잡이 차단이 아닌 WARN 이므로 통과 허용 (PR 설명에 명시) | 낮 |
+| R8. useSession client-side 호환성 | 낮 | 중 | v5 에서도 `useSession` 유지. `SessionProvider` 동일 | 없 |
+
+**종합 위험도: MEDIUM-LOW**. game-server 코드 변경 0, Helm 변경 0, 세션 시그니처 동일 유지 → 롤백 시 데이터 손실 없음.
+
+---
+
+## 10. Production 기준 실행 결정
+
+- [x] Sprint 7 Day 3~5 슬롯 중 선택 (frontend-dev 단독, 4.75h)
+- [x] beta 채택 수용 (Vercel 다수 프로덕션 레퍼런스)
+- [x] Env 변수 이름 유지 (별건 rename PR 은 Sprint 8)
+- [x] Middleware 도입 보류 (별건)
+- [x] Admin 패널 next-auth v5 이주 **본 PR 범위 밖** (admin 은 15.x, 별건 Sprint 7 Day 4 SEC-BC 에 묶어 처리)
+- [x] Supply-chain 동기화: 본 이주 이후 npm audit 에서 `GHSA-w5hq-g745-h8pq` 소멸 확인
+
+---
+
+## 11. 연관 변경 (체크리스트)
+
+- [ ] `src/frontend/package.json` bump (+ pnpm-lock 재생성)
+- [ ] `src/frontend/src/lib/auth.ts` 재작성
+- [ ] `src/frontend/src/app/api/auth/[...nextauth]/route.ts` 재export
+- [ ] `src/frontend/src/types/next-auth.d.ts` 모듈 타입 재검증
+- [ ] SSR pages 7 파일 기계적 치환
+- [ ] Playwright auth spec 수동 재실행
+- [ ] PR 설명에 npm audit 전/후 요약 첨부
+- [ ] `docs/04-testing/` 에 이주 회귀 보고서 1건 추가
+- [ ] CLAUDE.md "Auth" 섹션 업데이트 검토 (필요 시)
+
+---
+
+## 12. 참조
+
+- Auth.js v5 migration guide: `https://authjs.dev/getting-started/migrating-to-v5`
+- GHSA-w5hq-g745-h8pq (uuid moderate advisory)
+- `src/frontend/src/lib/auth.ts` — 현 config 원본
+- `src/game-server/internal/middleware/auth.go` — HS256 검증 (변경 없음 근거)
+- `helm/charts/frontend/values.yaml` — env 이름 유지 근거
+
+---
+
+> **문서 이력**
+>
+> | 버전 | 날짜 | 작성자 | 내용 |
+> |------|------|--------|------|
+> | 1.0 | 2026-04-23 | architect (Opus 4.7 xhigh) | 초안 — v5 이주 단행, Sprint 7 내 실행, game-server 영향 0 |

--- a/docs/03-development/19-next-auth-guide.md
+++ b/docs/03-development/19-next-auth-guide.md
@@ -1,0 +1,210 @@
+# 19. next-auth / Auth.js 기술 가이드 — 현 프로젝트(v4) 와 v5 이주 배경
+
+- **작성일**: 2026-04-23 (Sprint 7 Day 2 저녁)
+- **작성자**: Claude main (Opus 4.7 xhigh)
+- **목적**: 프로젝트 구성원이 next-auth 가 무엇이고, 왜 v5 로 이주해야 하는지 공통 이해를 확보하기 위한 기술 개요 문서. 실제 이주 결정 사항은 별도 ADR `docs/02-design/52-adr-next-auth-v5-migration.md` 참조.
+- **독자**: 애벌레 + 개발 에이전트 (frontend-dev, go-dev, architect, security)
+- **비고**: ADR 과 역할이 다르다. ADR = 결정·절차, 본 문서 = 개념·배경·용어 해설
+
+---
+
+## 1. next-auth 란 무엇인가
+
+**Next.js 용 인증(authentication) 라이브러리**. 오픈소스이며 NPM 패키지 `next-auth` 로 배포된다. 사용자가 웹사이트에 로그인하고, 세션을 유지하고, 권한을 확인하는 기능을 몇 줄 코드로 붙일 수 있게 해준다.
+
+### 핵심 기능
+
+| 기능 | 설명 | 예시 |
+|------|------|------|
+| OAuth 제공자 연동 | Google, GitHub, Facebook, Kakao 등 수십 곳과 통합 | 현 프로젝트: Google OAuth 2.0 |
+| 세션 관리 | JWT 토큰 또는 DB 기반 세션 | 로그인 유지, 만료 처리 |
+| 콜백 훅 | 로그인 성공 시 사용자 프로필 DB 저장 등 커스텀 로직 | `signIn`, `jwt`, `session` 콜백 |
+| CSRF 방어 | 자동으로 CSRF 토큰 발급·검증 | 공격 방어 |
+| 프론트엔드 helper | `useSession()` 훅, `getServerSession()` 함수 | UI 에서 로그인 상태 읽기 |
+| 이메일·credentials | 이메일 매직 링크, 아이디·비밀번호 로그인 | (현 프로젝트 미사용) |
+
+### 동작 흐름 — 현 프로젝트 기준
+
+```mermaid
+sequenceDiagram
+    participant User as 사용자(애벌레)
+    participant Browser as 브라우저
+    participant NextAuth as next-auth v4<br/>(Next.js API route)
+    participant Google as Google OAuth
+    participant GameServer as game-server<br/>(Go + JWT 검증)
+
+    User->>Browser: "Google 로그인" 클릭
+    Browser->>NextAuth: /api/auth/signin/google
+    NextAuth->>Google: 인가 요청 (리다이렉트)
+    Google->>User: 동의 화면
+    User->>Google: 동의
+    Google->>NextAuth: authorization code
+    NextAuth->>Google: code → access_token 교환
+    NextAuth->>NextAuth: 사용자 프로필 획득 + JWT 발급
+    NextAuth->>Browser: JWT 쿠키 set
+    Browser->>GameServer: API 호출 (쿠키 자동 포함)
+    GameServer->>GameServer: JWT 서명 검증 (JWKS)
+    GameServer->>Browser: 인증된 응답
+```
+
+---
+
+## 2. 현 프로젝트에서의 사용 현황 (v4)
+
+### 2.1 파일 경로
+
+| 파일 | 역할 |
+|------|------|
+| `src/frontend/src/app/api/auth/[...nextauth]/route.ts` | NextAuth 설정·핸들러 (Google provider, 콜백) |
+| `src/frontend/src/hooks/*` (추정) | `useSession()` 호출부 |
+| `src/frontend/src/components/**` | 로그인 상태 분기 UI |
+| `src/frontend/middleware.ts` 또는 없음 | 미사용으로 확인됨 (SEC-B 감사 §2.4) |
+| `src/game-server/internal/middleware/jwt.go` (추정) | NextAuth 가 발급한 JWT 를 game-server 측에서 검증 |
+
+### 2.2 의존성 버전
+
+- `next-auth`: v4.x (현재, `src/frontend/package.json`)
+- peer 의존: `uuid<14` (취약점 경로, §4 참조)
+
+### 2.3 설정 포인트
+
+- `NEXTAUTH_SECRET` — JWT 서명 키 (K8s secret 주입)
+- `NEXTAUTH_URL` — 자기 URL (helm values)
+- `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` — Google Cloud Console 발급 (MEMORY.md "Google OAuth K8s 관리" 섹션 참조)
+
+### 2.4 중요 원칙 (CLAUDE.md §6)
+
+> **인증/인가 ↔ 사용자 프로필 완전 분리**: OAuth 핸들러에서 DisplayName, AvatarURL 등 프로필 정보를 절대 덮어쓰지 않는다. OAuth 는 identity 확인만, 프로필은 별도 API 에서 관리.
+
+이 원칙은 v5 이주 후에도 유지.
+
+---
+
+## 3. v5 (Auth.js) 와의 차이
+
+2024년 next-auth 가 **Auth.js** 로 리브랜딩되며 v5 가 나왔다. 이름은 바뀌었지만 NPM 패키지 이름은 여전히 `next-auth` (v5.x).
+
+### 3.1 API 변화
+
+| 영역 | v4 | v5 |
+|------|-----|-----|
+| 초기화 | `NextAuth(authOptions)` | `NextAuth(config)` — 공통 `auth()` helper 자동 export |
+| 서버 컴포넌트 세션 | `getServerSession(authOptions)` | `auth()` (인자 없음) |
+| 클라이언트 세션 | `useSession()` | `useSession()` (동일) |
+| 로그인 트리거 | `signIn()` from `next-auth/react` | `signIn()` — 서버 액션 지원 추가 |
+| 타입 확장 | `declare module "next-auth"` | 동일하지만 경로 일부 변경 |
+
+### 3.2 Runtime 개선
+
+- **Edge runtime 지원**: middleware, API route 를 Edge 에서 실행 가능 (더 빠른 콜드 스타트)
+- **App Router 최적화**: Next.js 15 App Router 와 동작 매끄러움
+- **TypeScript strict 모드** 공식 지원
+
+### 3.3 Breaking changes (주요)
+
+- `pages/api/auth/[...nextauth].ts` → `app/api/auth/[...nextauth]/route.ts` (이미 현 프로젝트는 App Router)
+- `authOptions` export 이름·구조 변경
+- Adapter API 변경 (DB 기반 세션 쓰는 경우. 현 프로젝트는 JWT 라 영향 적음)
+- `NEXTAUTH_SECRET` → `AUTH_SECRET` (환경변수 이름 변경. v5 가 두 이름 모두 인식하지만 새 이름 권장)
+- `NEXTAUTH_URL` → `AUTH_URL` (동일 원칙)
+
+---
+
+## 4. 왜 v5 로 이주해야 하나
+
+### 4.1 보안 이유 (1차 동기)
+
+- `next-auth v4` 의 의존성 체인에 `uuid<14` 가 포함됨
+- `uuid<14` 는 **GHSA-w5hq-g745-h8pq** (Moderate) 취약점이 있음 — 예측 가능한 UUID 생성
+- **v4 semver 범위 안에서는 해소 불가**. next-auth v4 가 uuid v9 를 고정 의존하고, uuid v9 는 v14 로 올리려면 메이저 bump 필요
+- next-auth v5 는 uuid 의존성을 제거하거나 v14+ 로 교체함 → 취약점 자동 해소
+
+### 4.2 미래 호환성 (2차)
+
+- next-auth v4 는 **유지보수 모드**. 신규 기능 추가 없음
+- Next.js 16/17 출시 시 v4 호환성 보장 안 됨
+- Edge runtime, Server Actions 등 최신 Next 기능은 v5 만 지원
+
+### 4.3 취약점 실제 위험도
+
+UUID 예측 가능 문제는:
+- 이론상: 세션 토큰 생성에 사용될 경우 공격자가 다음 세션 ID 추측 가능
+- 현 프로젝트: JWT 서명 기반이라 UUID 가 세션 ID 로 직접 노출되지 않음
+- 실제 공격 경로까지 여러 단계 필요 → Critical 은 아니고 Moderate
+
+그럼에도 Production 기준으로는 "해소 가능한 취약점은 해소" 원칙이라 이주 대상.
+
+---
+
+## 5. 이주 시 주의사항
+
+### 5.1 JWT 서명 키 호환성
+
+`NEXTAUTH_SECRET` 은 v4 와 v5 가 동일한 HMAC-SHA256 알고리즘 사용. 기존 발급된 JWT 는 v5 전환 후에도 검증 가능 (세션 무효화 없음).
+
+### 5.2 game-server 측 JWT 검증 영향
+
+- v4 와 v5 모두 RFC 7519 표준 JWT 를 발급
+- game-server `jwt.go` 의 JWKS 조회 · 서명 검증 로직은 변경 불필요 (추정)
+- 단, JWT payload 필드 이름 변경 시 game-server 측 claim 추출 수정 필요. 이주 시 실제 payload diff 로 확인
+
+### 5.3 사용자 세션 강제 로그아웃 여부
+
+이주 후 첫 배포 직후 사용자 브라우저의 v4 세션 쿠키는:
+- 이름 동일 (`next-auth.session-token`) → 유지됨
+- 서명 키 동일 → 검증 성공
+
+→ **강제 로그아웃 없음**. 사용자 경험 매끄러움.
+
+### 5.4 MEMORY.md 원칙 지속 적용
+
+- OAuth 핸들러에서 DisplayName/AvatarURL 덮어쓰기 절대 금지 (`feedback_auth_profile_separation.md`)
+- `helm/charts/frontend/values.yaml` 에서 `GOOGLE_CLIENT_ID` 키 완전 제거 (2026-03-29 결정)
+- `scripts/inject-secrets.sh` 가 `.env.local` 자동 참조
+
+### 5.5 환경변수 네이밍 전환
+
+- v5 기본값: `AUTH_SECRET`, `AUTH_URL`
+- 하위 호환: `NEXTAUTH_SECRET`, `NEXTAUTH_URL` 도 인식
+- **권장**: 이주 PR 에서 함께 변경. K8s ConfigMap + Helm values + `.env.local.example` 3곳 동기화
+
+---
+
+## 6. 검증 체크리스트 (이주 PR 배포 직후)
+
+1. 기존 로그인 사용자가 재로그인 없이 접근 가능 (세션 유지)
+2. 신규 로그인: Google OAuth 동의 화면 → 성공 → 로비 진입
+3. game-server 측 JWT 검증: 일반 API 호출 성공 (401 Unauthorized 없음)
+4. WebSocket 연결: JWT 서명 검증 경로 정상
+5. 로그아웃: `signOut()` 호출 → 쿠키 제거 + 서버 세션 invalidate
+6. Playwright E2E auth 스위트 전수 PASS
+7. `npm audit --audit-level=high --omit=dev` frontend 0 건
+
+---
+
+## 7. 참고 자료
+
+- Auth.js 공식 v5 마이그레이션: https://authjs.dev/getting-started/migrating-to-v5 (공식)
+- GHSA-w5hq-g745-h8pq uuid 취약점: https://github.com/advisories/GHSA-w5hq-g745-h8pq
+- 현 프로젝트 이주 결정: `docs/02-design/52-adr-next-auth-v5-migration.md` (architect-docs 작성 중)
+- security 감사 근거: `docs/04-testing/78-sec-a-b-c-audit-delta.md` §3
+- OAuth K8s 관리: `docs/03-development/README.md` "Google OAuth K8s" 섹션
+
+---
+
+## 8. 용어 정리 (빠른 참조)
+
+| 용어 | 설명 |
+|------|------|
+| **OAuth** | 사용자가 비밀번호 노출 없이 제3자(Google 등) 에 자기 신원 증명하는 표준 |
+| **OAuth provider** | 신원 증명을 제공하는 곳. Google, GitHub 등 |
+| **JWT (JSON Web Token)** | 서명된 JSON. 쿠키/헤더에 담아 인증 정보 전달 |
+| **Session strategy** | 세션 저장 방식. "jwt" (쿠키 내 JWT) vs "database" (DB 에 세션 row) |
+| **Callback** | 인증 단계별 커스텀 훅 (signIn/jwt/session) |
+| **Adapter** | DB 기반 세션 사용 시 DB 연결 추상화 |
+| **middleware** | Next.js 의 요청 인터셉터. 인증 가드에 자주 사용 |
+| **JWKS** | JSON Web Key Set. 공개 키 세트. JWT 서명 검증에 사용 |
+
+---
+
+**문서 끝.**

--- a/docs/04-testing/78-sec-a-b-c-audit-delta.md
+++ b/docs/04-testing/78-sec-a-b-c-audit-delta.md
@@ -1,0 +1,410 @@
+# 78. SEC-A/B/C 패치 전후 델타 감사 리포트
+
+- **작성일**: 2026-04-23 (Sprint 7 Day 2 착수 직전 ~ 현재진행)
+- **작성자**: Security Engineer (security agent, Opus 4.7 xhigh)
+- **SEC ID**: SEC-REV-013 후속 — Day 2 의존성 bump PR 3건 (SEC-A, SEC-B, SEC-C) 적용 전후 재감사
+- **모드**: Read-only. 코드 수정 / 커밋 / 브랜치 생성 없음.
+- **실행 환경**:
+  - Branch: `chore/sec-a-go-toolchain-bump` (현재 체크아웃 상태)
+  - Go runtime: `go1.25.0 linux/amd64` (주의: **1.25.9 아님**)
+  - govulncheck v1.2.0
+  - npm 10.x / node v22
+- **선행 참조**:
+  - `docs/04-testing/70-sec-rev-013-dependency-audit-report.md` — Sprint 6 마감 감사
+  - `docs/04-testing/75-sec-day12-impact-and-plan.md` — architect 영향 분석 및 실행 계획
+
+---
+
+## 1. Executive Summary
+
+| ID | 항목 | 현황 | 판정 | 핵심 근거 |
+|----|------|------|------|----------|
+| **SEC-A** | Go 1.24→1.25 + go-redis 9.7.0→9.7.3 | **부분 적용** (코드 반영, toolchain 미선언) | **PROCEED (보강 필요)** | `go.mod` line 3 `go 1.25` 만 있고 `toolchain go1.25.9` directive **누락**. 로컬 `go1.25.0` 기준 govulncheck 에서 **stdlib 19건 여전히 code-called**. go-redis 는 완전 해소 (GO-2025-3540 ✅) |
+| **SEC-B** | Next bump — frontend 15.2.9→15.5.15, admin 16.1.6→16.2.4 | **미적용** | **PROCEED** | 현재 lockfile 실측: frontend `next@15.2.9`, admin `next@16.1.6`. runtime 경로 trigger 표면은 매우 좁음 (middleware/Server Actions/next/image/rewrites **모두 미사용**). DoS 공격표면 (Server Components) 은 유효 → 패치 필요 |
+| **SEC-C** | npm audit fix (axios + transitive) | **미적용** | **PROCEED** | axios `1.14.0` (<1.15.0 취약범위) 확인. 모든 LLM adapter 에서 direct import. `npm audit fix` non-breaking 으로 해소 가능 |
+| **신규 발견** | frontend `uuid <14` + `next-auth <=4.24.14` | **미적용** | **권고 (Moderate)** | 선행 감사 §2.2 에 누락된 GHSA-w5hq-g745-h8pq (Missing buffer bounds check). next-auth v4 종속 — 업스트림 없어서 SEC-C 본 PR 에서 해소 불가. Sprint 7 W1~W2 후속 PR 로 분리 권장 |
+| SEC-REV-002 | Rate limit violations decay | **해소 완료** | N/A | `ws_rate_limiter.go:138~146` — `consecutiveAllowed` 누적 기반 decay 구현됨 |
+| SEC-REV-008 | Hub RLock 내 외부 호출 | **해소 완료** | N/A | `ws_hub.go:100~130` — Snapshot-then-iterate 패턴 (snapshotRoom → lock 해제 후 Send) |
+| SEC-REV-009 | panic 전파 방어 | **해소 완료** | N/A | `ws_hub.go:166~180` — `invokeCallback` defer-recover 가드 |
+
+**최종 판정**: SEC-A / SEC-B / SEC-C **3건 모두 PROCEED**. 단, SEC-A 는 머지 전에 `go.mod` 에 `toolchain go1.25.9` 한 줄 추가 **필수**. 현재 상태로 머지하면 CI runner 는 `golang:1.25-alpine` 이 자동 최신 pull 하므로 통과하겠으나, 로컬/재현성 측면에서 govulncheck 게이트가 **매 실행 환경에 따라 결과가 달라지는 재현성 결함** 보유.
+
+---
+
+## 2. SEC-A 상세 — Go toolchain 1.24→1.25 + go-redis v9.7.0→v9.7.3
+
+### 2.1 현재 브랜치 상태
+
+```
+src/game-server/go.mod
+  line 3:  go 1.25          ← 언어 버전만 지정
+           (toolchain directive 없음)
+  line 14: github.com/redis/go-redis/v9 v9.7.3   ← 반영 완료
+src/game-server/Dockerfile
+  line 10: FROM golang:1.25-alpine AS deps        ← 반영 완료
+  line 21: FROM deps AS builder                   (상속)
+.gitlab-ci.yml
+  line 162: image: golang:1.25-alpine             ← 반영 완료 (lint-go)
+```
+
+### 2.2 go.mod `go` directive vs. `toolchain` directive 차이
+
+Go 1.21 이후 `go.mod` 는 두 필드를 분리한다:
+- `go 1.25` — 언어/API **호환성 레벨**. "이 모듈은 1.25 이상에서 빌드 가능"
+- `toolchain go1.25.9` — **실제 컴파일러 버전 강제**. CI/로컬 모두에 일괄 반영
+
+현 브랜치는 `toolchain` directive 가 없어서 **각 개발자 환경의 `GOTOOLCHAIN` 환경변수에 따라 결과가 달라진다**. 필자 환경 (`GOTOOLCHAIN=auto`, 로컬 `go1.25.0`) 에서 govulncheck 는 `go1.25.0` 기준으로 stdlib 를 평가하여 **19건 code-called** 잔존.
+
+### 2.3 govulncheck 재실행 결과 (post-bump, 현재 브랜치)
+
+**Before (Sprint 6 감사 §3.1 70번 리포트, go1.24.1)**: code-called **25건**
+**After (현재, go1.25.0, go-redis v9.7.3)**: code-called **19건**
+
+**제거된 6건**:
+| # | ID | 카테고리 |
+|---|-----|---------|
+| 1 | GO-2025-3540 | **go-redis out-of-order** — v9.7.3 bump 로 완전 해소 ✅ |
+| 2 | GO-2025-3563 | net/http chunked smuggling (1.24.2+) |
+| 3 | GO-2025-3751 | net/http cross-origin header leak (1.24.4+) |
+| 4 | GO-2025-3750 | os/syscall Windows only (1.24.4+) — Linux K8s 무관 |
+| 5 | GO-2025-3849 | database/sql percentile (1.24.6+) |
+| 6 | 기타 toolchain 정리로 매칭 해제 |
+
+**잔여 19건 (모두 stdlib, 로컬 `go1.25.0` 기준)**:
+
+| # | Vuln ID | 모듈 | Fixed in | Severity 추정 | 실제 호출 경로 |
+|---|---------|------|---------|-------------|-------------|
+| 1 | GO-2026-4947 | crypto/x509 | 1.25.9 | moderate | seed-finder (prod 무관) |
+| 2 | GO-2026-4946 | crypto/x509 | 1.25.9 | moderate | seed-finder |
+| 3 | **GO-2026-4870** | crypto/tls | **1.25.9** | **high** (KeyUpdate DoS) | server + AI client + Redis DialWithDialer |
+| 4 | GO-2026-4865 | html/template | 1.25.9 | moderate (XSS) | middleware.init + template.Parse |
+| 5 | GO-2026-4602 | os | 1.25.8 | low | ws_connection.Close |
+| 6 | GO-2026-4601 | net/url | 1.25.8 | moderate | AIClient.HealthCheck + JWKS |
+| 7 | GO-2026-4341 | net/url | 1.25.6 | moderate | ranking handler DefaultQuery |
+| 8 | **GO-2026-4340** | crypto/tls | **1.25.6** | **high** (handshake encryption level) | TLS 전체 경로 |
+| 9 | GO-2026-4337 | crypto/tls | 1.25.7 | moderate | session resumption |
+| 10 | GO-2025-4175 | crypto/x509 | 1.25.5 | low | seed-finder only |
+| 11 | GO-2025-4155 | crypto/x509 | 1.25.5 | low | seed-finder only |
+| 12 | GO-2025-4013 | crypto/x509 | 1.25.2 | low | seed-finder only |
+| 13 | **GO-2025-4012** | net/http | 1.25.2 | moderate (cookie memory) | AIClient.HealthCheck |
+| 14 | GO-2025-4011 | encoding/asn1 | 1.25.2 | moderate | ws_connection |
+| 15 | GO-2025-4010 | net/url | 1.25.2 | moderate | AIClient + JWKS |
+| 16 | GO-2025-4009 | encoding/pem | 1.25.2 | moderate | ws_connection |
+| 17 | GO-2025-4008 | crypto/tls | 1.25.2 | moderate | ALPN |
+| 18 | GO-2025-4007 | crypto/x509 | 1.25.3 | moderate | GORM Postgres 연결 |
+| 19 | GO-2025-4006 | net/mail | 1.25.2 | low | auth GoogleLoginByIDToken |
+
+### 2.4 GO-2026 계열 8건 커버 목록 (선행 요청)
+
+Go 1.25.9 가 커버하는 GO-2026 계열 8건:
+
+| # | Vuln ID | 모듈 | 심각도 | 1.25.X 패치 릴리스 | Runtime 경로 여부 |
+|---|---------|------|-------|------------------|----------------|
+| 1 | GO-2026-4947 | crypto/x509 | moderate | 1.25.9 | ❌ seed-finder only |
+| 2 | GO-2026-4946 | crypto/x509 | moderate | 1.25.9 | ❌ seed-finder only |
+| 3 | **GO-2026-4870** | crypto/tls | **HIGH** | 1.25.9 | ✅ server+AI client+Redis |
+| 4 | GO-2026-4865 | html/template | moderate | 1.25.9 | ✅ middleware.init |
+| 5 | GO-2026-4602 | os | low | 1.25.8 | ✅ ws_connection (탈출 영향) |
+| 6 | GO-2026-4601 | net/url | moderate | 1.25.8 | ✅ AIClient+JWKS |
+| 7 | GO-2026-4341 | net/url | moderate | 1.25.6 | ✅ ranking handler |
+| 8 | **GO-2026-4340** | crypto/tls | **HIGH** | 1.25.6 | ✅ TLS 전체 |
+
+**1.25.9 = 최소 cutover 버전**. 1.25.8 또는 1.25.6 로도 대부분 커버되나 crypto/x509 GO-2026-4946/4947 와 crypto/tls GO-2026-4870 을 고려하면 **최신 1.25.9 로 고정 권장**.
+
+### 2.5 go-redis v9.7.0 → v9.7.3 cross-check
+
+`go.mod:14` + `go.sum:98~99` 모두 `v9.7.3` 확인. govulncheck 출력에서 GO-2025-3540 (out-of-order responses) 완전 소거. Redis 연결 초기화 (`infra.NewRedisClient`) 경로가 안전화됨.
+
+### 2.6 테스트 회귀
+
+`go test ./... -count=1 -timeout 120s` → **모든 패키지 PASS** (e2e / client / config / engine / handler / middleware / service). 빌드 에러·API 호환성 문제 없음.
+
+### 2.7 SEC-A 머지 전 보완 권고
+
+**필수**:
+1. `src/game-server/go.mod` 에 `toolchain go1.25.9` directive 1줄 추가 — line 3 (`go 1.25`) 직후. 예:
+   ```
+   module github.com/k82022603/RummiArena/game-server
+
+   go 1.25
+
+   toolchain go1.25.9
+   ```
+   이 한 줄 추가로 **19건 → 0건** 완전 제거. CI/로컬 재현성 모두 확보.
+2. Dockerfile 의 `golang:1.25-alpine` 은 현재 자동 최신이므로 그대로 두거나 **재현성 위해 `golang:1.25.9-alpine3.20` 로 pin 권장**.
+
+**선택**:
+3. `.gitlab-ci.yml` lint-go 잡에도 동일 tag pin.
+
+### 2.8 SEC-A 최종 판정: **PROCEED (보강 필요)**
+
+- go-redis 측: **완전 해소**
+- stdlib 측: toolchain directive 추가 전까지 code-called 19건 잔존 (로컬 환경 기준)
+- CI 환경 (Docker `golang:1.25-alpine`) 에서는 빌드 시점 최신 1.25.X 가 자동 반영되므로 **runtime 이미지는 안전**
+- 감사 리포트 게이트 통과 조건: `toolchain go1.25.9` directive 필수. 머지 전 보강하면 govulncheck code-called = **0** 달성
+
+---
+
+## 3. SEC-B 상세 — Next.js bump
+
+### 3.1 Runtime Trigger 경로 분석
+
+현 코드베이스의 Next.js 사용 표면을 grep 전수 조사.
+
+| 기능 | 사용 여부 | 근거 | 관련 CVE 악용 가능성 |
+|-----|---------|------|-----------------|
+| `middleware.ts` | ❌ **미사용** | frontend/admin 둘 다 존재 안 함 | GHSA-4342-x723-ch2f (SSRF middleware redirect) **영향 없음** |
+| `"use server"` (Server Actions) | ❌ **미사용** | `grep -rn "use server"` = 0 hits | GHSA-mq59-m269-xvcx (null origin CSRF) **영향 없음** |
+| `<Image>` / `next/image` | ❌ **미사용** | `grep -rn "next/image"` = 0 hits | GHSA-9g9p-9gw9-jx7f, GHSA-3x4c-7xq6-9pq8, GHSA-xv57-4mr9-wg8v, GHSA-g5qg-72qw-gw5v **모두 영향 없음** |
+| `rewrites` (next.config) | ❌ **미사용** | `next.config.ts` 는 보안 헤더만 설정 (frontend + admin 동일) | GHSA-ggv3-7p47-pfv8 (request smuggling) **영향 제한적** |
+| Server Components 렌더링 | ✅ **사용** | Next 15 App Router 기본 | **GHSA-q4gf-8mx6-v5v3 (CVSS 7.5 DoS) 적용** |
+| Dev HMR | ✅ (dev only) | 프로덕션 영향 없음 | GHSA-jcc7-9wpm-mj36 dev-only |
+| Postponed resume | ✅ (PPR 가능) | App Router 기본 behavior | GHSA-h27x-g6w4-24gq (DoS) 적용 가능 (admin 측) |
+
+### 3.2 실제 리스크 (High → 2건만 유효)
+
+**frontend (15.2.9 → 15.5.15)**:
+- **GHSA-q4gf-8mx6-v5v3** — Server Components DoS (CVSS 7.5) — **유효**. 모든 App Router 페이지 (`/`, `/login`, `/game/[roomId]` 등) 에서 악의적 요청으로 서버 CPU/메모리 고갈 가능.
+- 나머지 6건 (cache confusion, content injection, SSRF middleware, image DoS × 2, smuggling) — 사용하지 않는 기능이라 **실질 exploit 어려움**
+
+**admin (16.1.6 → 16.2.4)**:
+- **GHSA-q4gf-8mx6-v5v3** — 동일 Server Components DoS — **유효** (admin 트래픽은 내부이지만 인증 전 경로도 영향)
+- **GHSA-h27x-g6w4-24gq** — postponed resume buffering DoS — 유효 (App Router)
+- 나머지 4건 (smuggling / image DoS / null origin CSRF / dev HMR) — 사용하지 않는 기능
+
+### 3.3 minor 점프 리스크
+
+- frontend **15.2 → 15.5** (3단계 minor 점프)
+  - Next 15.3: `experimental.after`, `turbopack` 개선
+  - Next 15.4: `unstable_allowDynamic` 강화
+  - Next 15.5: React 19.1 + DevTools 개편
+  - **Playwright E2E 전수 재실행 필수** (회귀 가능성 존재)
+- admin **16.1 → 16.2** (1 minor) — 낮은 리스크
+
+### 3.4 호환성 점검 요소
+
+- NextAuth v4.24.11 ↔ Next 15.5: 커뮤니티 보고상 호환 확인. 단 `getServerSession` import 경로 변화 가능성 (참조: `src/frontend/src/app/api/auth/[...nextauth]/route.ts` 존재 여부는 미확인, 빌드 검증 필요).
+- Tailwind v3 (frontend) / v4 (admin) + Next 15.5/16.2 — 프로덕션 빌드 산출물 확인 필요.
+
+### 3.5 SEC-B 최종 판정: **PROCEED**
+
+- 실 runtime exploit 표면은 **Server Components DoS 1건** (양쪽 공통) + admin 측 postponed resume DoS 1건
+- 패치하지 않으면 DoS 공격에 노출 — 승격 권고
+- 머지 후 **Playwright E2E 전수 재실행 필수** (선행 75번 계획서 §2.2 Verification 기준 준수)
+- 추가 리스크 시나리오 (minor 회귀) 대응: qa 가 failing 5건+ 식별 시 frontend-dev 가 Next 15.5 release note 검토 후 부분 롤백 또는 15.3 단계적 upgrade 대안
+
+---
+
+## 4. SEC-C 상세 — npm audit fix
+
+### 4.1 ai-adapter production 경로 6건 재확인
+
+| 패키지 | 현재 버전 | 취약 범위 | Severity | Advisory | import chain | False positive? |
+|-------|---------|---------|---------|---------|-------------|----------------|
+| `axios` | **1.14.0** | 1.0.0~1.14.0 | moderate × 2 | GHSA-3p68-rc4w-qgx5 (NO_PROXY SSRF), GHSA-fvcv-3m26-pcqx (Header Injection → Cloud Metadata Exfil) | **Direct import**: `openai.adapter.ts`, `claude.adapter.ts`, `deepseek.adapter.ts`, `ollama.adapter.ts`, `dashscope.service.ts` | ❌ **진짜 취약**. LLM API 호출 전 경로. `npm audit fix` 로 `>=1.15.0` 자동 bump (semver ^1.6.0 범위 내) |
+| `@nestjs/core` | `<=10.4.22` (현 `^10.0.0`) | `<=11.1.17` | moderate | GHSA-36xv-jgw5-4q75 (Injection) | Direct | ⚠️ **메이저 bump 필요** — `npm audit fix --force` 아니면 해소 불가. SEC-C non-breaking 범위 밖. **P1 별도 PR 로 이관** |
+| `file-type` | transitive via `@nestjs/common` | 13.0.0~21.3.1 | moderate × 2 | GHSA-5v7r-6r5c-r473 (ASF DoS), GHSA-j47w-4g3g-c36v (ZIP bomb) | Transitive. **파일 업로드 엔드포인트 미확인**. 현재 ai-adapter 는 JSON-only API 이므로 **exploitability 매우 낮음** | ⚠️ @nestjs/common bump 에 종속 |
+| `follow-redirects` | transitive via axios | `<=1.15.11` | moderate | GHSA-r4q5-vmmm-2653 (Auth header leak on redirect) | Transitive via axios | ✅ **axios bump 시 자동 해소** |
+
+### 4.2 frontend/admin transitive moderate
+
+| 패키지 | 경로 | Severity | 실제 영향 |
+|-------|------|---------|---------|
+| `brace-expansion` | frontend + admin @typescript-eslint, 기타 | moderate (GHSA-f886-m6hf-6m8v) | **dev-only**. 실 runtime 영향 없음. `npm audit fix` non-breaking |
+
+### 4.3 ai-adapter dev 경로 주요 High (본 PR 제외 범위)
+
+| 패키지 | Severity | 조치 | 본 PR 포함? |
+|-------|---------|------|----------|
+| `@typescript-eslint/*` 6.x → 7.6+ | high × 5 (minimatch ReDoS) | `npm i -D @typescript-eslint/eslint-plugin@latest` | ❌ P1 별도 PR |
+| `@nestjs/cli` 10 → 11.1+ | high | 메이저 bump | ❌ P1 별도 PR |
+| `glob 10.2~10.4.5` | high (command injection) | @nestjs/cli bump 로 해결 | ❌ |
+| `minimatch 9.0.0~9.0.6` | high × 3 | typescript-eslint bump | ❌ |
+| `picomatch <=2.3.1` | high × 2 | schematics bump | ❌ |
+| `webpack buildHttp` | low × 2 | HttpUriPlugin 미사용 — exploitability 0 | ❌ 추적만 |
+
+### 4.4 `--omit=dev` Critical/High=0 유지 검증 방법
+
+```bash
+# 본 PR 머지 후 CI 또는 pre-push 에서 자동 게이트
+cd src/ai-adapter && npm audit --audit-level=high --omit=dev
+# → exit 0 기대
+
+cd src/frontend && npm audit --audit-level=high --omit=dev
+# → 기존 next High 해소 후 + 신규 uuid moderate 1건만 남음 → exit 0 (high=0)
+
+cd src/admin && npm audit --audit-level=high --omit=dev
+# → 기존 next High 해소 후 → exit 0
+```
+
+`package.json` 의 `overrides` 필드 (ai-adapter 는 multer/path-to-regexp/lodash 3개 pin) 는 그대로 유지. SEC-C 는 lockfile 만 update.
+
+### 4.5 SEC-C 최종 판정: **PROCEED**
+
+- ai-adapter axios **진짜 취약** → `npm audit fix` (non-breaking, `^1.6.0` 범위 내 `>=1.15.0` 자동 bump) 필수
+- follow-redirects 는 axios bump 에 종속 자동 해소
+- brace-expansion 은 dev-only transitive
+- @nestjs/core / file-type 는 본 PR 에서 제외 (breaking change) — P1 별도 PR 이관
+
+---
+
+## 5. 신규 발견 (선행 감사 70번 누락 항목)
+
+### 5.1 frontend `uuid <14` + `next-auth <=4.24.14`
+
+선행 70번 §2.2 에서 빠진 **새로 승격된 production 경로 취약점**:
+
+| 패키지 | 버전 | Severity | Advisory | 경로 |
+|-------|------|---------|---------|------|
+| `uuid` | `<14.0.0` | moderate | GHSA-w5hq-g745-h8pq (Missing buffer bounds check in v3/v5/v6 when buf is provided) | next-auth transitive |
+| `next-auth` | `<=4.24.14` | moderate (의존성 경유) | — | **production direct** |
+
+**업스트림 fix**:
+- `npm audit fix --force` 권고는 `next-auth@3.29.10` (downgrade) — **절대 수용 불가**
+- 실제 fix: next-auth v5 (Auth.js) 메이저 이주 필요
+- 완화책: uuid v3/v5/v6 `buf` 파라미터 전달 경로가 next-auth 내부에 있는지 확인 (현재 미확인, 코드 검증 필요)
+
+**권고**: SEC-C 본 PR 에서 처리 불가. **Sprint 7 W1~W2 별도 PR 로 next-auth v5 (Auth.js) 이주 타당성 검토** — 이주 범위 광범위 (session strategy, callbacks, adapter 재설계) 이므로 **ADR 선행 필요**.
+
+**Day 2 영향**: 없음 (SEC-B/C 머지 후에도 잔존하는 moderate 1건으로 `--audit-level=high` 게이트는 통과).
+
+---
+
+## 6. SEC-REV-002/008/009 재점검 결과
+
+### 6.1 SEC-REV-002 — Rate Limit violations 감소 로직 (Medium)
+
+- **상태**: **해소 완료**
+- **구현**: `src/game-server/internal/handler/ws_rate_limiter.go:138~146`
+  ```go
+  // SEC-REV-002: 연속 허용이 임계값(5회) 누적된 경우에만 violations 1 감소.
+  if rl.violations > 0 {
+      rl.consecutiveAllowed++
+      if rl.consecutiveAllowed >= violationsDecayThreshold {
+          rl.violations--
+          rl.consecutiveAllowed = 0
+      }
+  }
+  ```
+- **공격 패턴 "위반-정상-위반-정상" 회피 검증**: `consecutiveAllowed` 필드로 위반 이후 연속 정상 카운트. 정상 5회 연속이어야 violations 1 감소. 악용 불가.
+- **향후 추가 조치**: 없음. Sprint 6 이관 항목 종결 처리 가능.
+
+### 6.2 SEC-REV-008 — Hub RLock 내 외부 호출 (Medium)
+
+- **상태**: **해소 완료**
+- **구현**: `src/game-server/internal/handler/ws_hub.go:100~130`
+  - `snapshotRoom(roomID)` / `snapshotRoomExcept(roomID, excludeUserID)` — RLock 내부에서 conn slice 생성 후 즉시 RUnlock
+  - `BroadcastToRoom` / `BroadcastToRoomExcept` / `SendToUser` — lock 해제 후 `Send()` 호출
+  - 주석 명시 ("SEC-REV-008: Snapshot-then-iterate — lock is released before Send()")
+- **공격 경로 차단**: Hub lock 점유 중 Redis GET / DB query / JSON marshal 수행 가능성 제거. Register/Unregister 의 Write Lock 경합 최소화.
+- **향후 추가 조치**: 없음.
+
+### 6.3 SEC-REV-009 — panic 전파 가능성 (Medium)
+
+- **상태**: **해소 완료**
+- **구현**: `src/game-server/internal/handler/ws_hub.go:166~180`
+  - `invokeCallback(roomID, conn, fn)` — 각 콜백을 defer-recover 가드로 래핑
+  - 주석 명시 ("SEC-REV-009: Each callback invocation is wrapped in a defer-recover")
+- **공격 경로 차단**: 4인 방에서 conn 2 처리 중 panic 발생 → conn 3, 4 는 정상 콜백 실행. 부분 서비스 불능 방지.
+- **향후 추가 조치**: 없음.
+
+### 6.4 SEC-REV 재점검 결론
+
+**3건 모두 이미 해소됨**. Sprint 6 이관 Medium 은 사실상 부재. Sprint 7 TODO 에서 "SEC-REV-002/008/009 미완료" 항목 제거 권장.
+
+---
+
+## 7. 후속 조치 권장
+
+### 7.1 Day 2 즉시 (SEC-A/B/C PR 머지 전)
+
+| # | 조치 | 담당 | 근거 |
+|---|------|------|------|
+| 1 | **SEC-A PR 에 `toolchain go1.25.9` directive 추가** (go.mod line 5) | devops | 본 리포트 §2.2, §2.7. toolchain directive 없으면 CI 환경 의존적 — 재현성 위해 필수 |
+| 2 | (선택) Dockerfile `golang:1.25.9-alpine3.20` 으로 tag pin | devops | §2.7 |
+| 3 | SEC-B 머지 전 `middleware.ts` / `next/image` / `use server` / `rewrites` 4가지 기능 **도입 예정 없음** 확인 | architect 또는 frontend-dev | §3.1 트리거 경로 분석 — 추가 도입 시 재평가 필요 |
+| 4 | SEC-B 머지 후 Playwright E2E **전수 재실행** + **4 FAIL + 신규 0** 게이트 | qa | 선행 75번 §2.2 verification + §4.2 리스크 시나리오 |
+| 5 | SEC-C 머지 후 `npm audit --audit-level=high --omit=dev` → exit 0 3개 프로젝트 모두 확인 | devops | §4.4 |
+
+### 7.2 Sprint 7 Week 1~2 (별도 PR)
+
+| # | 조치 | 담당 | 근거 |
+|---|------|------|------|
+| 6 | `@typescript-eslint/*` 7.6+ bump (ai-adapter dev) | node-dev | §4.3 |
+| 7 | `@nestjs/cli` 10 → 11.1+ bump | node-dev | §4.3 |
+| 8 | `jest-environment-jsdom` 30.x bump (frontend dev) | frontend-dev | 70번 §4.2 |
+| 9 | **next-auth v5 (Auth.js) 이주 ADR 작성** | architect | §5. next-auth v4 의 uuid transitive moderate 해소 유일 경로 |
+| 10 | **`.gitlab-ci.yml` 에 `sca-npm-audit` + `sca-govulncheck` + `weekly-dependency-audit` 잡 추가** | devops | 70번 §6. 새 CVE 드리프트 감지용 (6일 사이 GO-2026 8건 공개 사례 재발 방지) |
+
+### 7.3 Sprint 7 Week 2+ (후순위)
+
+| # | 조치 | 담당 | 근거 |
+|---|------|------|------|
+| 11 | `@nestjs/core` v10 → v11 메이저 bump (Injection moderate 해소) | node-dev | 70번 §5.1 |
+| 12 | gin v1.10 → v1.12, pgx v5.6 → v5.9, gorm v1.25 → v1.31 | go-dev | 70번 §3.2 |
+| 13 | `cloud.google.com/go/*` 사용 여부 점검 후 미사용 시 제거 | go-dev | 70번 §5.1 |
+
+### 7.4 Sprint 7 TODO 정리
+
+- ✅ **SEC-REV-002/008/009 Sprint 6 이관** → **종결 처리** (모두 해소 확인)
+- ✅ Day 12 backend P0-1 (`game_results` persistence) → 종결 (선행 75번 §2.4 확인)
+- ✅ Day 12 backend P0-2 (GAME_OVER broadcast) → 종결 (선행 75번 §2.5 확인)
+
+---
+
+## 8. 최종 결론
+
+| 질문 | 답변 |
+|-----|-----|
+| SEC-A bump 판정 | **PROCEED (go.mod 에 `toolchain go1.25.9` 추가 필수)**. 현 상태 stdlib code-called 19건 잔존 (로컬 환경 기준). toolchain directive 1줄로 0건 달성. go-redis 는 완전 해소 |
+| SEC-B bump 판정 | **PROCEED**. 실제 exploit 표면은 Server Components DoS (CVSS 7.5) + admin postponed resume DoS 2건. 나머지 4건 (middleware/image/actions/rewrites) 은 **미사용 기능**이라 영향 없으나 defense-in-depth 관점 패치 권장. Playwright 전수 재실행 필수 |
+| SEC-C bump 판정 | **PROCEED**. axios SSRF/Header Injection 2건 (direct import, 모든 LLM adapter) → non-breaking bump. @nestjs/core / file-type 는 메이저 bump 필요 → P1 별도 PR |
+| SEC-REV-002/008/009 현황 | **3건 모두 이미 해소됨** (ws_rate_limiter.go + ws_hub.go). Sprint 7 TODO 에서 제거 권장 |
+| 신규 발견 | frontend `uuid <14` (GHSA-w5hq-g745-h8pq) via next-auth v4 — 업스트림 fix 부재로 SEC-C 에서 해소 불가. next-auth v5 이주 ADR 선행 필요 |
+| 게이트 상태 (Day 2 3개 PR 머지 완료 후 예상) | production 경로 Critical/High = **0**. moderate 잔존 (axios→0, next-auth uuid 1건, @nestjs/core 1건, file-type 2건) — **`--audit-level=high` 게이트 통과** |
+
+**감사 판정**: **3건 PROCEED**. SEC-A 에만 `toolchain` directive 1줄 보강 조건 추가.
+
+---
+
+## 부록 A. 재현 명령
+
+```bash
+# Go 감사
+cd src/game-server && govulncheck -mode=source ./...
+grep -E "^go |^toolchain " go.mod   # toolchain directive 확인
+cd src/game-server && go test ./... -count=1 -timeout 120s
+
+# npm 감사 (production)
+cd src/frontend && npm audit --audit-level=low --omit=dev
+cd src/admin && npm audit --audit-level=low --omit=dev
+cd src/ai-adapter && npm audit --audit-level=low --omit=dev
+
+# npm 감사 (전체 포함 dev)
+cd src/frontend && npm audit --audit-level=low
+cd src/admin && npm audit --audit-level=low
+cd src/ai-adapter && npm audit --audit-level=low
+
+# Runtime trigger 경로 검증
+grep -rn "use server" src/frontend/src src/admin/src
+grep -rn "next/image\|<Image" src/frontend/src src/admin/src
+find src/frontend src/admin -name "middleware.ts" -not -path "*/node_modules/*"
+grep -rn "rewrites\|redirects" src/frontend/next.config.ts src/admin/next.config.ts
+```
+
+## 부록 B. 참조
+
+- `docs/04-testing/70-sec-rev-013-dependency-audit-report.md` — Sprint 6 마감 감사
+- `docs/04-testing/75-sec-day12-impact-and-plan.md` — architect 영향 분석 및 실행 계획
+- `docs/02-design/26-sec-rev-medium-impact-analysis.md` — SEC-REV Medium 분석 (002/008/009 원본)
+- `docs/04-testing/36-security-review-phase1.md` — SEC-REV Phase 1 원본
+- GHSA 공식 페이지:
+  - https://github.com/advisories/GHSA-q4gf-8mx6-v5v3 (Next Server Components DoS)
+  - https://github.com/advisories/GHSA-mq59-m269-xvcx (Next null origin CSRF)
+  - https://github.com/advisories/GHSA-ggv3-7p47-pfv8 (Next request smuggling)
+  - https://github.com/advisories/GHSA-3p68-rc4w-qgx5 (axios NO_PROXY SSRF)
+  - https://github.com/advisories/GHSA-fvcv-3m26-pcqx (axios Header Injection)
+  - https://github.com/advisories/GHSA-w5hq-g745-h8pq (uuid buffer bounds)
+  - https://pkg.go.dev/vuln/GO-2025-3540 (go-redis out-of-order)
+  - https://pkg.go.dev/vuln/GO-2026-4870 (Go crypto/tls KeyUpdate DoS)
+  - https://pkg.go.dev/vuln/GO-2026-4340 (Go crypto/tls handshake encryption level)

--- a/docs/04-testing/79-dev-only-deps-impact.md
+++ b/docs/04-testing/79-dev-only-deps-impact.md
@@ -1,0 +1,458 @@
+# 79. Sprint 7 Day 3 — dev-only High/Low 의존성 3건 영향 분석 및 실행 계획서
+
+- **작성일**: 2026-04-23 (Sprint 7 Day 2 마감 직후, Day 3 착수 전)
+- **작성자**: Software Architect (architect agent, Opus 4.7 xhigh)
+- **모드**: Read-only 영향 분석. 본 문서는 계획서이며 코드 수정 / 커밋 / 브랜치 생성 없음.
+- **선행 참조**:
+  - `docs/04-testing/70-sec-rev-013-dependency-audit-report.md` (SEC-REV-013 감사 리포트)
+  - `docs/04-testing/75-sec-day12-impact-and-plan.md` §6.1 (본 계획 항목을 Sprint 7 Week 1 이관으로 명시)
+  - `docs/04-testing/78-sec-a-b-c-audit-delta.md` (Day 2 SEC-A/B/C 실행 후 audit delta)
+- **범위**: 3건 — D3-A (`@typescript-eslint/*` bump), D3-B (`@nestjs/cli` major bump), D3-C (`jest-environment-jsdom` bump)
+- **모두 dev-only**: 세 패키지 모두 `devDependencies` 에만 존재. production runtime 위험 없음
+
+---
+
+## 1. Executive Summary
+
+| ID | 항목 | 현재 설치 | 목표 | 판정 | 근거 요약 |
+|----|------|---------|------|------|---------|
+| **D3-A** | `@typescript-eslint/eslint-plugin` + `/parser` ^6.0.0 → ^7.18.0 | 6.21.0 | 7.18.0 | **PROCEED** | CVE 3건 (minimatch ReDoS High). eslint@8.42 호환 유지, rule config 변경 없음 예상. 리스크 LOW. |
+| **D3-B** | `@nestjs/cli` ^10.0.0 → ^11.0.21 (SemVer major) | 10.4.9 | 11.0.21 | **PROCEED (주의)** | CVE 1건 (glob command injection High) + dev transitive 다수 해소. Node >= 20.11 engine 요구 (현재 22.x 사용 중 OK). nest-cli.json 포맷 변경 없음 확인. 리스크 MEDIUM. |
+| **D3-C** | `jest-environment-jsdom` ^29.7.0 → ^30.3.0 (SemVer major) | 29.7.0 | **HOLD (조건부)** | 30.3.0 | CVE 4건 (@tootallnate/once CWE-705 Low 등). **peer mismatch**: v30 은 `@jest/environment@30.3.0` + `jsdom@^26.1.0` 요구. frontend `jest@29.7.0` 과 비호환 → **jest 30 동반 bump 필수**. 리스크 HIGH. |
+
+**Go/No-Go 결론**:
+- **D3-A / D3-B** 는 Day 3 오전 착수 가능 (총 ~3시간 병렬)
+- **D3-C** 는 **jest@30 동반 bump 필수** — 이를 별건 구현으로 뗄지, Low 4건 WONTFIX 로 유지할지 사용자 결정 필요
+
+---
+
+## 2. Per-item Detailed Analysis
+
+### 2.1 D3-A — `@typescript-eslint/*` ^6.0.0 → ^7.18.0
+
+#### Current state (source of truth: installed lockfile)
+- `src/ai-adapter/package.json:48-49`
+  ```json
+  "@typescript-eslint/eslint-plugin": "^6.0.0",
+  "@typescript-eslint/parser": "^6.0.0",
+  ```
+- Installed: `6.21.0` (eslint-plugin + parser 둘 다, `node_modules/@typescript-eslint/{eslint-plugin,parser}/package.json` 확인)
+- eslint 버전: `eslint@^8.42.0` (ai-adapter)
+- `.eslintrc.js`: `extends: ['plugin:@typescript-eslint/recommended', 'plugin:prettier/recommended']`, rule 4건 off
+- **적용 범위**: ai-adapter 만 (`@typescript-eslint/*` 사용). frontend/admin 은 eslint 9 + eslint-config-next 로 독자 스택이며 `@typescript-eslint/*` 직접 의존성 없음
+
+#### CVE / Advisory 매핑
+`@typescript-eslint/eslint-plugin@6.x` 의 High 취약점은 모두 transitive `minimatch` 경유:
+- **GHSA-3ppc-4f35-3m26** — minimatch ReDoS via repeated wildcards with non-matching literal (High)
+- **GHSA-7r86-cg39-jmmj** — minimatch matchOne() combinatorial backtracking (High)
+- **GHSA-23c5-xmqv-rm74** — minimatch nested *() extglob catastrophic backtracking (High)
+
+npm audit `fixAvailable` 필드는 `@typescript-eslint/eslint-plugin@7.x` upgrade 를 권장. (Day 2 `78-sec-a-b-c-audit-delta.md` 잔존 High 4건 중 3건이 여기에 속함.)
+
+#### Actual change scope
+| 파일 | 변경 | 예상 LOC |
+|------|------|--------|
+| `src/ai-adapter/package.json` | `"^6.0.0"` → `"^7.18.0"` (2줄) | 2 |
+| `src/ai-adapter/package-lock.json` | `npm install` 재생성 | ~120~250 |
+| `src/ai-adapter/.eslintrc.js` | 미변경 예상 (rule 설정 변경 없음) | 0 |
+
+**Total: 2 files, 2 직접 LOC + lockfile diff**
+
+#### Risk level: **LOW**
+
+#### Breaking change flags (6.x → 7.x)
+- [x] **ESLint peer**: 7.x 는 `eslint@^8.56.0` 요구. 현재 `eslint@^8.42.0` — **8.42 ≤ 8.56 이라 peer 경고 가능**. eslint 도 `^8.56.0` 이상으로 동반 올릴지 검토
+- [x] **TypeScript peer**: 7.x 는 `typescript>=4.7.4 <5.5.0` 권장 (7.18.0 은 5.4 까지). 현재 `typescript@^5.1.3` → 설치 lockfile 실제 버전 확인 필요. 만약 TS 5.5+ 이면 parser 경고 발생 가능 (기능은 동작)
+- [x] **Rule deprecation**: 7.x 에서 `@typescript-eslint/no-throw-literal` → `@typescript-eslint/only-throw-error` 로 rename. `.eslintrc.js` 현재 해당 rule 미사용 → 영향 없음
+- [ ] 나머지 deprecated rule 은 `recommended` preset 에 포함되지 않음 — 영향 없음 예상
+- [ ] eslint 9 로는 올리지 않음 (7.x 는 eslint 9 미지원). eslint 9 이관은 Sprint 7+ 별건
+
+#### Verification plan
+1. `cd src/ai-adapter && npm install @typescript-eslint/eslint-plugin@^7.18.0 @typescript-eslint/parser@^7.18.0 --save-dev`
+2. `npm run lint` → 오류 0 / 경고 회귀 없음 확인
+3. `npm test` → **428/428 PASS** 유지 (lint 가 test 에 영향 없음 확인용)
+4. `npm audit --audit-level=high` → minimatch ReDoS High 3건 **모두 소멸** 확인
+5. 경고 텍스트 확인: `npm install` 출력에 `peer dep` warning 0건 (있다면 eslint 8.56 로 동반 bump)
+
+#### Estimated duration: **S (30m~45m)**
+- npm install 5분, lint 실행 5분, test 15분, audit 확인 5분, 트러블슈팅 여유 15분
+
+#### Recommended agent: **node-dev**
+
+#### Branch naming: `chore/sec-d3a-typescript-eslint-bump`
+
+#### Dependencies: 독립 (D3-B, D3-C 와 파일 충돌 없음)
+
+---
+
+### 2.2 D3-B — `@nestjs/cli` ^10.0.0 → ^11.0.21 (SemVer major)
+
+#### Current state
+- `src/ai-adapter/package.json:41`: `"@nestjs/cli": "^10.0.0"`
+- Installed: `10.4.9` (`node_modules/@nestjs/cli/package.json`)
+- 용도: `npm run start`, `start:dev`, `start:debug` 에서 `nest start` CLI 실행
+- `nest-cli.json`:
+  ```json
+  {
+    "$schema": "https://json.schemastore.org/nest-cli",
+    "collection": "@nestjs/schematics",
+    "sourceRoot": "src",
+    "compilerOptions": { "deleteOutDir": true }
+  }
+  ```
+- `@nestjs/schematics@^10.0.0` (현재) — CLI 11 은 `@nestjs/schematics@^11.0.1` 요구 → **schematics 도 동반 bump 필수**
+- `@nestjs/common / core / platform-express / testing` 는 모두 `^10.0.0` 유지 (본 PR 에서 건드리지 않음)
+
+#### CVE / Advisory 매핑
+- **GHSA-5j98-mcp5-4vw2** — glob CLI Command injection via `-c/--cmd` executes matches with shell:true (High, transitive `glob@<10.3.0` 경유)
+  - `@nestjs/cli@10.4.9` 는 `glob@10.4.5` 를 사용하지만, 내부 CLI 는 `-c/--cmd` 기능을 사용하지 않음 — **이론적 위험 낮음**이나 npm audit 는 경로 존재만으로 High 판정
+- 추가 transitive: `@angular-devkit/core` ajv ReDoS (Moderate), picomatch ReDoS (High), webpack buildHttp 2건 (Low), tmp symlink (Low), inquirer 관련
+
+npm audit `fixAvailable`: `@nestjs/cli@11.0.0+` upgrade (SemVer major)
+
+#### Actual change scope
+| 파일 | 변경 | 예상 LOC |
+|------|------|--------|
+| `src/ai-adapter/package.json` | `"@nestjs/cli": "^10.0.0"` → `"^11.0.21"` + `"@nestjs/schematics": "^10.0.0"` → `"^11.0.2"` (2줄) | 2 |
+| `src/ai-adapter/package-lock.json` | `npm install` 재생성 (Angular DevKit + webpack 등 transitive 대량 교체) | ~400~900 |
+| `src/ai-adapter/nest-cli.json` | 변경 없음 (포맷 유지) | 0 |
+| `src/ai-adapter/tsconfig.build.json` | 변경 없음 예상 | 0 |
+| `src/ai-adapter/Dockerfile` | 변경 없음 (runtime 에 영향 없음, CLI 는 build-time only) | 0 |
+
+**Total: 2 files, 2 직접 LOC + 대량 lockfile diff**
+
+#### Risk level: **MEDIUM**
+
+#### Breaking change flags (CLI 10 → 11)
+공식 릴리즈 노트 (https://github.com/nestjs/nest-cli/releases) 및 설치된 `@nestjs/cli@11.0.21` 패키지 메타데이터 기반:
+
+- [x] **Node engine 요구**: 10.x `>= 16.14` → 11.x `>= 20.11`
+  - 현재 개발 환경 `node v22.21.1`, CI Dockerfile `node:20-alpine` 이상 → OK
+- [x] **TypeScript 내장 버전**: CLI 10 은 ts 5.7.2 번들, CLI 11 은 ts 5.9.3 번들. `start:dev` watch 모드에서 체감 변화 가능 (더 엄격한 타입 체크)
+- [x] **Webpack 번들 버전**: 5.97 → 5.106. 대부분 backward compatible 하나, 프로젝트에 `webpack.config.js` 가 있을 경우 확인 필요 (**현재 ai-adapter 에 해당 파일 없음** 확인)
+- [x] **glob 13 로 bump**: `@nestjs/cli` 내부 glob 사용 패턴이 `-c/--cmd` 를 사용하지 않으므로 CLI 동작 변경 없음
+- [x] **`@inquirer/prompts` 로 교체**: CLI 10 `inquirer@8.2.6` → CLI 11 `@inquirer/prompts@7.10.1`. `nest new` / `nest generate` 의 interactive prompt UI 가 바뀌지만 **CI 및 본 프로젝트 스크립트는 non-interactive 만 사용** → 영향 없음
+- [x] **`fork-ts-checker-webpack-plugin` 9.0.2 → 9.1.0**: watch 성능 개선 (breaking 없음)
+- [ ] **nest-cli.json schema**: `$schema` URL 동일 유지. `compilerOptions.deleteOutDir` 옵션 유지
+- [ ] **schematics 10 → 11**: `@nestjs/schematics@11.x` 는 `nest generate` 의 생성 파일 포맷 변경 가능 — **본 PR 에서는 기존 코드만 빌드하고 `nest generate` 는 실행하지 않으므로 영향 없음**
+
+#### Verification plan
+1. `cd src/ai-adapter && npm install @nestjs/cli@^11.0.21 @nestjs/schematics@^11.0.2 --save-dev`
+2. `npm install` peer warning 확인 (없어야 함)
+3. `npm run build` → dist 생성 성공. `dist/main.js` 파일 크기 편차 확인 (참고용)
+4. `npm run start` (백그라운드 10초) → 부팅 로그에 `Nest application successfully started` 확인 → Ctrl+C
+5. `npm test` → **428/428 PASS** 유지
+6. `npm audit --audit-level=high` → glob High 1건 **소멸** 확인
+7. Docker 로컬 빌드: `docker build -t rummiarena/ai-adapter:d3b src/ai-adapter/` → 성공 확인
+8. CI 파이프라인: `quality-node-ai-adapter` + `build-ai-adapter` + `test-node-ai-adapter` 3 잡 GREEN 확인
+
+#### Estimated duration: **M (1.5h~2h)**
+- npm install 10분, 빌드 검증 15분, start 스모크 10분, test 20분, Docker 빌드 15분, CI 실행 25분, 트러블슈팅 여유 30분
+
+#### Recommended agent: **node-dev** (메인) + **devops** (Docker/CI 검증)
+
+#### Branch naming: `chore/sec-d3b-nestjs-cli-major-bump`
+
+#### Dependencies: 독립. D3-A 와 lockfile 충돌 가능 → **같은 브랜치 통합 권장** (lockfile 1회 재생성)
+
+---
+
+### 2.3 D3-C — `jest-environment-jsdom` ^29.7.0 → ^30.3.0 (SemVer major) — **HOLD (조건부)**
+
+#### Current state
+- `src/frontend/package.json:40`: `"jest-environment-jsdom": "^29.7.0"`
+- Installed: `29.7.0`
+- `src/frontend/package.json:39`: `"jest": "^29.7.0"` — 함께 묶인 dep
+- `src/frontend/jest.config.js:9`: `testEnvironment: "jsdom"` 지정
+- `src/admin/package.json`: jest 및 jest-environment-jsdom **미사용** (admin 은 Playwright 전용, unit test 프레임워크 없음 확인)
+- frontend 테스트 파일: **12 \*.test.tsx** (`src/frontend/src/**/__tests__/`)
+
+#### CVE / Advisory 매핑
+jest-environment-jsdom@29.7.0 기준 transitive 4건 (모두 Low, dev-only):
+- **GHSA-vpq2-c234-7xj6** — `@tootallnate/once` Incorrect Control Flow Scoping (CWE-705, CVSS 3.3 Low)
+- transitive `http-proxy-agent@4.x` (`@tootallnate/once` 경유)
+- transitive `jsdom@<23` (http-proxy-agent 경유)
+- jest-environment-jsdom 자체 범위 `27.0.1 - 30.0.0-rc.1`
+
+npm audit `fixAvailable`: `jest-environment-jsdom@30.3.0` (SemVer major)
+
+#### Actual change scope — **여기가 문제**
+
+jest-environment-jsdom@30.3.0 의 실제 의존성:
+```json
+{
+  "@jest/environment": "30.3.0",
+  "@jest/environment-jsdom-abstract": "30.3.0",
+  "jsdom": "^26.1.0"
+}
+```
+
+현재 frontend 의 jest 의존성 체인:
+- `jest@29.7.0` → `@jest/environment@29.7.0` → **고정 major 29**
+- `jest-environment-jsdom@30` 이 요구하는 `@jest/environment@30.3.0` 과 **버전 불일치**
+
+**결론**: jest-environment-jsdom 만 v30 으로 올릴 수 없다. `npm install` 은 peer warning + 런타임 에러 (e.g., `TypeError: ... is not a function`) 를 발생시킬 가능성 높음.
+
+#### 선택지 분석
+
+**Option C1 — jest 30 동반 bump (권장)**
+| 파일 | 변경 | 예상 LOC |
+|------|------|--------|
+| `src/frontend/package.json:39-40` | `"jest": "^29.7.0"` → `"^30.3.0"` + `"jest-environment-jsdom": "^29.7.0"` → `"^30.3.0"` | 2 |
+| `src/frontend/package.json:30` | `"@testing-library/jest-dom": "^6.9.1"` — jest 30 호환 재확인 (6.9+ 는 jest 30 지원) | 0 |
+| `src/frontend/package.json:33` | `"@types/jest": "^29.5.14"` → `"^30.0.0"` 동반 | 1 |
+| `src/frontend/package-lock.json` | `npm install` 재생성 | ~200~500 |
+| `src/frontend/jest.config.js` | 미변경 (testEnvironment 지정 동일) | 0 |
+
+- **추가 리스크**: jest 29 → 30 은 SemVer major. next/jest (next.js 번들 jest transformer) 의 jest 30 호환성 확인 필요. Next 15.5 에는 jest 30 호환 transformer 포함 (검증 필요)
+- **Breaking change 가능성**: `jest.useFakeTimers('modern')` 기본값 변경, Node 18 미만 drop, snapshot serializer 계약 미세 변경 등
+- **중요**: `next/jest.js` (jest.config.js 1행) 가 jest 30 과 호환되는지는 코드 검증 필요
+
+**Option C2 — WONTFIX (Low × 4 허용)**
+- Low 4건 모두 dev-only, frontend test 실행 시에만 로드
+- production 에 영향 없음, CI 게이트 기준 `--audit-level=high` 이므로 파이프라인도 통과
+- ADR-025 스타일 WONTFIX 문서화 + Issue 로 백로그
+
+**Option C3 — jest-environment-jsdom 만 v29 내 최신 유지**
+- 실제로 `jest-environment-jsdom@29.7.0` 이 이미 v29 최신. 우회로 없음
+- **불가능** — 이 옵션은 배제
+
+#### Risk level
+- **Option C1**: **HIGH** (jest 30 메이저 동반 bump — 12 test file 회귀 가능성)
+- **Option C2**: **NONE** (현상 유지)
+
+#### Verification plan (Option C1 기준)
+1. `cd src/frontend && npm install jest@^30.3.0 jest-environment-jsdom@^30.3.0 @types/jest@^30.0.0 --save-dev`
+2. peer warning 확인 (next/jest 가 jest 30 허용해야 함)
+3. `npm test` → **12 테스트 파일 전부 PASS** 확인 (기존 182/182 기준선 유지)
+4. `npm run build` → Next 빌드 성공 (jest 는 build-time 영향 없음, 회귀 탐지용)
+5. Playwright E2E 전체 (SEC-B 성공 기준 재사용, ~376 PASS / 4 Known FAIL)
+6. `npm audit --audit-level=high --omit=dev` → exit 0 유지
+7. `npm audit` 전수 → Low 4건 소멸 확인
+
+#### Verification plan (Option C2 기준)
+1. `docs/ADR-026-jest-env-jsdom-low-4-wontfix.md` 작성 (Low 4건 목록, rationale, 재평가 조건)
+2. GitHub Issue open — `wontfix` 라벨 + `sec-rev-013-phase2` milestone
+
+#### Estimated duration
+- **Option C1**: **M~L (2h~4h)** — jest 30 breaking change 조사 + Next 15.5 호환성 검증 + 회귀 테스트
+- **Option C2**: **S (< 30m)** — ADR 1건 + Issue 1건
+
+#### Recommended agent
+- Option C1: **frontend-dev** + **qa** (회귀)
+- Option C2: **architect** (ADR) + **pm** (Issue)
+
+#### Branch naming
+- Option C1: `chore/sec-d3c-jest-major-bump`
+- Option C2: `docs/adr-026-jest-env-jsdom-wontfix`
+
+#### Dependencies: D3-A, D3-B 와 완전 독립 (ai-adapter vs frontend 파일 분리)
+
+---
+
+## 3. Parallel Execution Matrix
+
+### 3.1 병렬성 매트릭스
+
+| 항목 A | 항목 B | 병렬 가능? | 이유 |
+|-------|-------|---------|-----|
+| D3-A | D3-B | **NO (통합 권장)** | 동일 lockfile (`src/ai-adapter/package-lock.json`) 충돌 |
+| D3-A | D3-C | YES | ai-adapter vs frontend 파일 분리 |
+| D3-B | D3-C | YES | ai-adapter vs frontend 파일 분리 |
+
+### 3.2 권장 실행 형태
+
+**옵션 P1 (권장, 2 worktree 병렬 — C1 선택 시)**
+1. `chore/sec-d3ab-ai-adapter-dev-deps` — D3-A + D3-B 통합 (node-dev, lockfile 1회 재생성, ~2.5h)
+2. `chore/sec-d3c-jest-major-bump` — D3-C Option C1 (frontend-dev + qa, ~3h)
+
+→ 두 PR 병렬, 총 소요 시간 ≈ **3시간 (wall-clock)**
+
+**옵션 P2 (보수적, D3-C WONTFIX)**
+1. `chore/sec-d3ab-ai-adapter-dev-deps` — D3-A + D3-B 통합 (~2.5h)
+2. `docs/adr-026-jest-env-jsdom-wontfix` — D3-C WONTFIX (~30m)
+
+→ 총 소요 시간 ≈ **2.5~3시간 (wall-clock)**
+
+**옵션 P3 (순차)**
+D3-A → D3-B → D3-C 순서 (4~5h)
+
+→ **옵션 P1 또는 P2 중 사용자 결정 필요** (§5 참조)
+
+### 3.3 실행 흐름도
+
+```mermaid
+flowchart TB
+    Start(["Sprint 7 Day 3 Start"]) --> D3AB["D3-A + D3-B 통합 브랜치<br/>chore/sec-d3ab-ai-adapter-dev-deps<br/>node-dev 메인"]
+    Start --> D3C["D3-C Option C1 or C2"]
+    D3AB --> Merge1(["Merge to main"])
+    D3C --> Decision{"Option 결정"}
+    Decision -->|C1| Impl["jest 30 동반 bump<br/>frontend-dev + qa"]
+    Decision -->|C2| ADR["ADR-026 WONTFIX<br/>architect + pm"]
+    Impl --> Merge2(["Merge to main"])
+    ADR --> Merge2
+    Merge1 --> CI["CI 17/17 GREEN"]
+    Merge2 --> CI
+```
+
+---
+
+## 4. Risk Budget
+
+### 4.1 최악의 경우 (Worst-case) 소요 시간
+
+| 단계 | D3-A | D3-B | D3-C (C1) | D3-C (C2) |
+|-----|------|------|-----------|-----------|
+| 코드 변경 | 5m | 10m | 15m | 10m (ADR) |
+| 로컬 테스트 | 20m | 30m | 45m | 0 |
+| CI 파이프라인 | 25m | 25m | 25m | 0 |
+| K8s smoke | 0 | 10m | 0 | 0 |
+| 리뷰 대기 / 수정 | 15m | 30m | 40m | 20m |
+| **합계** | **1h 05m** | **1h 45m** | **2h 05m** | **30m** |
+
+통합 (D3-A+B) + 병렬 (D3-C): **~3h wall-clock**
+
+### 4.2 리스크 시나리오
+
+| 시나리오 | 가능성 | 영향 | 대응 |
+|---------|------|-----|-----|
+| `@typescript-eslint@7` + `eslint@8.42` peer warning | 중 | LOW | `eslint@^8.57.0` 동반 bump (~+3 LOC), eslint 8 내 최종 버전 |
+| `@nestjs/cli@11` schematics 불일치로 `start:dev` 실패 | 낮음 | MED | `@nestjs/schematics@11.0.2` 동반 bump 이미 계획 |
+| Next `next/jest` 가 jest 30 미지원 | 중 | HIGH (C1) | Next 15.5.15 릴리즈 노트 재확인, 미지원 시 C2 WONTFIX 전환 |
+| jest 30 에서 snapshot serializer 차이로 12 test 중 3+ 건 fail | 중 | MED (C1) | `--updateSnapshot` 로 snapshot 갱신 + reviewer 에게 "snapshot 변경 사유" PR 본문 명시 |
+| `@types/jest@30` 이 없을 수 있음 | 낮음 | LOW (C1) | `@types/jest@^29.5.14` 유지하고 jest 30 과 `ts-jest` 호환성 확인 |
+| transitive ajv/picomatch 잔존 audit finding | 중 | LOW | D3-B 로 대부분 소멸, 잔여는 별건 WONTFIX |
+
+### 4.3 Rollback 계획
+
+- **D3-A**: `git revert` 1 커밋. package.json + lockfile 복원
+- **D3-B**: `git revert` 1 커밋. CLI 10 복원. 개발 환경 즉시 `npm install` 후 정상화
+- **D3-C (C1)**: `git revert` 1 커밋. jest 29 복원. 12 test 파일의 snapshot 파일이 jest 30 에서 생성되었을 수 있으므로 snapshot 도 회귀 확인
+- **D3-C (C2)**: ADR 삭제만. 코드 영향 없음
+
+---
+
+## 5. Phase 2 Recommendation — Go Now vs. Need User Decision
+
+### 5.1 **즉시 착수 가능 (Go Now)**
+
+| 항목 | 근거 |
+|-----|------|
+| **D3-A + D3-B 통합 PR** | 리스크 LOW~MED, Day 2 SEC-A/B/C 와 동일 패턴. node-dev 에이전트로 즉시 위임 가능 |
+| lockfile 1회 재생성 규율 | D3-A 와 D3-B 를 같은 브랜치에서 `npm install` 한 번에 처리 (SEC-BC 와 동일 교훈) |
+
+### 5.2 **사용자 결정 필요 (Need User GO)**
+
+| 항목 | 결정 사항 |
+|-----|---------|
+| **D3-C Option C1 vs C2** | Low × 4 취약점 수용 여부. C1 (jest 30 동반 bump) 은 ~3h + 회귀 리스크 HIGH. C2 (WONTFIX) 는 30m + production 영향 없음. **기본 권장: C2 (WONTFIX) + Sprint 8 에 jest 30 + next-jest 호환 확인 후 재추진** |
+| **eslint 8.42 → 8.57 동반 bump** | D3-A 의 peer warning 해소용. LOC +3, 리스크 LOW. **기본 권장: 동반 bump** |
+| **@types/jest@30 bump (C1 선택 시만)** | jest@30 과 타입 정합성. LOC +1, 리스크 LOW |
+| **NestJS core/common/platform-express 10 → 11 메이저 bump** | 본 계획에 **포함하지 않음** (Moderate injection GHSA-36xv-jgw5-4q75 해소용, §75 에서 Sprint 7 Week 2 이관). Day 3 와 분리 |
+
+### 5.3 실행 순서 요약
+
+```mermaid
+gantt
+    title Sprint 7 Day 3 — dev-only 의존성 패치 실행 계획
+    dateFormat HH:mm
+    axisFormat %H:%M
+    section D3-A+B (node-dev)
+    typescript-eslint 7 + eslint 8.57  :a1, 09:00, 15m
+    npm install lockfile              :a2, after a1, 10m
+    lint + test 실행                   :a3, after a2, 20m
+    nestjs/cli 11 bump                :b1, after a3, 10m
+    npm install + build               :b2, after b1, 20m
+    test + start:dev smoke            :b3, after b2, 25m
+    CI 파이프라인                      :b4, after b3, 25m
+    리뷰 및 merge                      :b5, after b4, 20m
+    section D3-C (frontend-dev + qa) — Option 결정 후
+    Option C2 ADR 작성                :c1, 09:00, 20m
+    Issue open + label                :c2, after c1, 10m
+    리뷰 및 merge                      :c3, after c2, 10m
+```
+
+**예상 완료 (Option P2 기준)**: **Day 3 오전 9시 시작 → 11~12시 두 PR 모두 merge**. 오후는 Sprint 7 Day 3 P2 (V-13a `ErrNoRearrangePerm` orphan 리팩터, V-13e 조커 재드래그 UX) 착수 가능.
+
+---
+
+## 6. 후속 이슈 예방 체크리스트
+
+### 6.1 Day 3 패치 완료 후
+
+- [ ] Day 3 마감 시 `npm audit --json` 결과를 `docs/04-testing/80-sec-d3-audit-delta.md` 로 저장 (78 패턴 재사용)
+- [ ] Option C2 선택 시 `docs/02-design/ADR-026-jest-env-jsdom-wontfix.md` 생성 + 재평가 조건 명시 ("Next 16 이관 또는 Sprint 8 Week 2 에 jest 30 재추진")
+- [ ] `@nestjs/cli@11` merge 후 `nest --version` 출력을 개발 가이드에 반영 (`docs/03-development/01-setup-manual.md`)
+
+### 6.2 Sprint 7 Week 2+
+
+- [ ] `@nestjs/core / common / platform-express / testing` 10 → 11 메이저 bump (GHSA-36xv-jgw5-4q75 Moderate injection 해소, §75 §6.1 인용)
+- [ ] `file-type` Moderate 2건 해소 (`@nestjs/common` 내부 경로)
+- [ ] `next-auth@4` → `@auth/nextjs` 전환 검토 (next-auth uuid Moderate GHSA-w5hq-g745-h8pq, frontend 본체)
+- [ ] eslint 8 → 9 이관 + `@typescript-eslint@7` → `@typescript-eslint/utils@8` 재평가
+
+### 6.3 CI 게이트 강화 (§75 §6.1 과 통합)
+
+- [ ] `.gitlab-ci.yml` 에 `sca-npm-audit` 잡 추가 — `--audit-level=high --omit=dev` 기준 fail
+- [ ] `weekly-dependency-audit` cron 잡 — 매주 월요일 npm/Go 양쪽 audit 결과를 Issue 로 기록
+
+---
+
+## 7. 최종 결론
+
+| 질문 | 답변 |
+|-----|-----|
+| 3건 중 실제 작업 대상 | **2~3건** (D3-A, D3-B 확정 + D3-C Option 결정 대기) |
+| 병렬 실행 시 총 소요 | **~3시간** (wall-clock, Option P1 기준) |
+| 순차 실행 시 총 소요 | **~4~5시간** |
+| 사용자 GO 필요 항목 | D3-C Option C1 vs C2 결정 (권장: C2 WONTFIX), eslint 8.57 동반 bump 여부 (권장: 포함) |
+| 즉시 착수 항목 | D3-A + D3-B 통합 브랜치 (node-dev 위임 가능) |
+| 발견한 핵심 주의점 | **jest-environment-jsdom@30 은 `@jest/environment@30.3.0` + `jsdom@^26.1.0` 를 요구 → jest 29 와 비호환, 단독 bump 불가.** Option C1 은 jest 30 동반 bump + Next 15.5 의 `next/jest` 호환성 재검증 필수. Option C2 (WONTFIX) 선택 시 Low 4건 모두 dev-only 라 production 안전하며 Sprint 8 로 이관 가능 |
+
+**권장 실행 결정**:
+1. 사용자는 D3-C 의 C1/C2 중 선택한다 (default: **C2 WONTFIX** + Sprint 8 재추진)
+2. D3-A + D3-B 는 즉시 `node-dev` agent 에게 위임 — `chore/sec-d3ab-ai-adapter-dev-deps` 브랜치, lockfile 1회 재생성
+3. eslint `^8.42.0` → `^8.57.0` 동반 bump (D3-A peer warning 예방)
+4. Day 3 오후는 `V-13a` (`ErrNoRearrangePerm` orphan 리팩터) + `V-13e` (조커 재드래그 UX) 착수
+5. 본 계획서 채택 시 다음 세션 시작 시 Day 3 Plan 상단에 링크 (`docs/04-testing/79-dev-only-deps-impact.md`)
+
+---
+
+## 부록 A. 조사한 read-only 근거 Inventory
+
+| 확인 대상 | 파일 / 명령 | 확인한 사실 |
+|---------|-----------|----------|
+| 현재 설치 버전 | `src/ai-adapter/node_modules/@typescript-eslint/eslint-plugin/package.json` | 6.21.0 |
+| 현재 설치 버전 | `src/ai-adapter/node_modules/@typescript-eslint/parser/package.json` | 6.21.0 |
+| 현재 설치 버전 | `src/ai-adapter/node_modules/@nestjs/cli/package.json` | 10.4.9 |
+| 현재 설치 버전 | `src/frontend/node_modules/jest-environment-jsdom/package.json` | 29.7.0 |
+| 현재 설치 버전 | `src/frontend/node_modules/jest/package.json` | 29.7.0 |
+| admin 의 jest 부재 | `src/admin/package.json` | devDependencies 에 jest 없음 (Playwright 전용) |
+| 최신 npm 버전 | `npm view @typescript-eslint/eslint-plugin version` | 8.59.0 (본 계획은 7.18.0 선택, eslint 8 호환) |
+| 최신 npm 버전 | `npm view @nestjs/cli version` | 11.0.21 |
+| 최신 npm 버전 | `npm view jest-environment-jsdom version` | 30.3.0 |
+| peer dep 충돌 | `npm view jest-environment-jsdom@30.3.0 dependencies` | `@jest/environment@30.3.0` 고정 → jest 29 비호환 |
+| Node engine | `npm view @nestjs/cli@11.0.21 engines` | `>= 20.11` (현재 개발 `v22.21.1` OK) |
+| peer 요구 | `npm view @typescript-eslint/eslint-plugin@7.18.0 peerDependencies` | eslint `^8.56.0` + parser `^7.0.0` |
+| Advisory | GHSA-3ppc-4f35-3m26, GHSA-7r86-cg39-jmmj, GHSA-23c5-xmqv-rm74 (minimatch ReDoS) | `@typescript-eslint/*` transitive |
+| Advisory | GHSA-5j98-mcp5-4vw2 (glob CLI command injection) | `@nestjs/cli` transitive |
+| Advisory | GHSA-vpq2-c234-7xj6 (@tootallnate/once control flow) | `jest-environment-jsdom` transitive |
+
+## 부록 B. 감사 리포트 §4.2 P1 과의 매핑
+
+| 감사 리포트 §4.2 P1 권장 | 본 계획서 매핑 | 상태 |
+|-------------------|-------------|-----|
+| (1) `@typescript-eslint/*` 7.6.0+ bump | D3-A | PROCEED |
+| (2) `@nestjs/cli` 11.1+ bump | D3-B (11.0.21 으로 조정, 11.1 은 현재 미출시) | PROCEED |
+| (3) `jest-environment-jsdom` 30.3.0 bump | D3-C | HOLD (Option 결정 대기) |
+
+## 부록 C. Day 2 SEC-A/B/C 완료 이후 잔존 high 4건 소멸 매핑
+
+본 계획 완료 시 잔존 High 는 다음과 같이 처리된다 (78 세부 audit delta 기준):
+
+| Day 2 잔존 High | 처리 | 본 계획 적용 후 |
+|---------------|-----|---------------|
+| `@typescript-eslint/*` minimatch ReDoS × 3 | D3-A | 소멸 |
+| `@nestjs/cli` glob command injection × 1 | D3-B | 소멸 |
+
+→ Day 3 완료 후 `npm audit --audit-level=high` = **0 High (전체)** 목표 달성 가능. production (`--omit=dev`) 은 이미 Day 2 SEC-C 로 0 High 확보. 전체 audit 깨끗 상태는 Sprint 7 Week 1 마감 시점 달성.

--- a/docs/04-testing/80-ci-cd-audit-jobs-impact.md
+++ b/docs/04-testing/80-ci-cd-audit-jobs-impact.md
@@ -1,0 +1,621 @@
+# 80. CI/CD 의존성 감사 잡 3건 영향도 분석 및 Day 3 구현 계획서
+
+- **작성일**: 2026-04-23 (Sprint 7 Day 2 작성, Day 3 2026-04-24 구현 착수 대비)
+- **작성자**: architect (Opus 4.7 xhigh)
+- **목적**: GitLab CI 에 의존성 감사 잡 3건(`sca-npm-audit`, `sca-govulncheck`, `weekly-dependency-audit`) 신규 추가 전 사전 영향도 분석 + YAML 초안 확정 + 파이프라인 duration/캐시/Fail 정책 점검
+- **선행 근거**:
+  - `docs/04-testing/70-sec-rev-013-dependency-audit-report.md` §6 — SCA 게이트 제안 원본 (1차 초안 포함)
+  - `docs/04-testing/78-sec-a-b-c-audit-delta.md` §7.2 #10 — Sprint 7 W1~W2 후속 조치로 등재
+- **모드**: Read-only + write docs. `.gitlab-ci.yml` 수정 / 커밋 금지. 구현은 Day 3 devops 가 담당
+- **범위**: 3잡 모두 `quality` stage (기존 초안은 `scan` 이었으나 현 CI 에는 scan 스테이지 없음 — 본 분석에서 정정)
+
+---
+
+## 1. Executive Summary
+
+| ID | 잡 이름 | 스테이지 | 목적 | 판정 | 예상 duration (cold / warm) |
+|----|--------|---------|------|------|-------------------------------|
+| **J1** | `sca-npm-audit` | quality | 3개 Node 프로젝트 production dependency High/Critical=0 강제 | **PROCEED** | ~2m / ~45s |
+| **J2** | `sca-govulncheck` | quality | game-server code-called 취약점 차단 | **PROCEED** | ~3m / ~1m |
+| **J3** | `weekly-dependency-audit` | quality (schedule only) | 주 1회 prod+dev LOW 포함 드리프트 스캔 + artifact 리포트 | **PROCEED** | ~4m (전수 LOW 포함) |
+
+**3잡 모두 Day 3 구현 착수 가능**. 주의점 3가지:
+
+1. **스테이지 배치는 `quality`** — 70번 §6 원본 초안도 `quality` 였으나 사용자 프롬프트 배경에는 "scan (또는 quality)" 로 표기됨. 현 `.gitlab-ci.yml` 은 스테이지 5개 (`lint|test|quality|build|update-gitops`) 로 `scan` 스테이지가 **없다**. Trivy 이미지 스캔은 `build` 스테이지에서 `scan-*` 잡으로 실행된다. 따라서 **본 분석은 `quality` 로 확정**한다. `scan` 스테이지 신설은 본 PR 범위 초과.
+2. **Fail 정책 이원화** — `sca-npm-audit` + `sca-govulncheck` = strict (`allow_failure: false`), `weekly-dependency-audit` = warn-only (`allow_failure: true`).
+3. **파이프라인 duration 순증 최소** — 두 PR 잡은 `quality` 에 병렬 추가되므로 기존 critical path (`sonarqube` ~20m) 를 **증가시키지 않는다**. 실제 wall-clock 순증 0m (sonarqube < 20m 종료 전 완료).
+
+---
+
+## 2. 기존 CI/CD 구조 요약 + 추가 위치
+
+### 2.1 현재 스테이지 + 잡 인벤토리 (`.gitlab-ci.yml` 659 lines 기준)
+
+```
+stages:
+  - lint        # 5 jobs: lint-go, lint-nest, lint-frontend, lint-admin, rule-matrix-check
+  - test        # 2 jobs: test-go, test-nest
+  - quality     # 2 jobs: sonarqube (needs test-*), trivy-fs
+  - build       # 8 jobs: build-* (4) + scan-* (4) — build-kaniko + trivy image scan
+  - update-gitops  # 1 job: update-gitops (needs all builds+scans)
+```
+
+총 **17잡** (MEMORY.md 상 "Pipeline #113: 17/17 PASS" 와 일치). quality 에 J1+J2 추가 → **19잡**.
+
+### 2.2 기존 감사/보안 커버리지
+
+| 도구 | 잡 | 커버리지 도메인 | 본 신규 잡과의 중복 |
+|-----|----|---------------|------------------|
+| **Trivy FS** (`trivy-fs`) | quality | 파일시스템 OS 패키지 + lockfile | ⚠️ lockfile 커버 일부 중복. 그러나 `trivy fs` 는 lockfile-level advisory DB 기반, `npm audit` 은 npm registry advisory DB 기반 — **advisory source 상이**. Defense-in-depth 관점 유지 권장 |
+| **Trivy Image** (`scan-*`) | build | 빌드된 컨테이너 이미지 | 이미지 빌드 **후** 스캔. J1/J2 는 빌드 **전** 게이트 → 시점 상이 |
+| **SonarQube** (`sonarqube`) | quality | SAST (코드 품질+일부 보안 버그) | 의존성 취약점은 커버 안 함 — **중복 없음** |
+| (없음) | — | npm registry advisory code-called 게이트 | J1 **신규** |
+| (없음) | — | Go stdlib + module code-called 게이트 | J2 **신규** |
+
+**결론**: J1+J2 는 Trivy 와 일부 도메인 중복이나 **advisory source 와 검사 시점이 다르므로 defense-in-depth 에 해당**. 제거 대상 아님.
+
+### 2.3 추가 위치
+
+```
+stages:
+  - lint
+  - test
+  - quality       ← J1 (sca-npm-audit), J2 (sca-govulncheck), J3 (weekly-dependency-audit) 추가
+  - build
+  - update-gitops
+```
+
+`quality` stage 는 현재 `sonarqube` + `trivy-fs` 2잡뿐이다. J1/J2 병렬 추가 시 **sonarqube 의 20m timeout 이 critical path** 이므로 wall-clock 증가 없음.
+
+---
+
+## 3. J1 — `sca-npm-audit` YAML 초안 + 설명
+
+### 3.1 설계 의도
+
+- **3개 Node 프로젝트** (`ai-adapter`, `frontend`, `admin`) 각각 `npm audit --audit-level=high --omit=dev` 실행.
+- production dependency 에서 **High/Critical 1건이라도 발견되면 실패** (`allow_failure: false`).
+- dev dependency 는 본 잡에서 검증하지 않음 (J3 scheduled 잡에서 warn-only 로 커버).
+- `npm ci` 는 **lockfile 만 인스톨** — `.gitlab-ci.yml` 의 `npm_config_cache: /cache/npm` 덕분에 PVC 재사용.
+
+### 3.2 YAML 초안
+
+```yaml
+# =============================================================================
+# SCA (Software Composition Analysis) — Node 프로젝트 production 의존성 게이트
+# =============================================================================
+#
+# 목적:
+#   ai-adapter / frontend / admin 의 production dependency 에서 High/Critical
+#   취약점을 0 으로 강제한다. 새 CVE 드리프트를 매 MR/푸시마다 차단.
+#
+# 근거: docs/04-testing/70-sec-rev-013-dependency-audit-report.md §6
+#       docs/04-testing/78-sec-a-b-c-audit-delta.md §7.2 #10
+#       docs/04-testing/80-ci-cd-audit-jobs-impact.md (본 설계서)
+#
+# Fail 정책:
+#   --audit-level=high --omit=dev → exit 1 이면 production High+ 존재.
+#   allow_failure: false 로 파이프라인 실패 게이트화.
+#
+# dev dependency:
+#   본 잡에서는 검증 안 함 (SEC-C 머지 후에도 typescript-eslint High 잔존).
+#   weekly-dependency-audit 잡에서 warn-only 로 커버.
+#
+# 캐시:
+#   npm_config_cache=/cache/npm (전역 variables) → PVC 재사용. cold ~2m / warm ~45s.
+
+sca-npm-audit:
+  stage: quality
+  <<: *local-runner
+  timeout: 10m
+  image: node:22-alpine
+  script:
+    # 3개 프로젝트 순차 실행. 하나라도 High+ 발견 시 전체 실패.
+    # || (echo FAIL; exit 1) 은 script 라인별 실패를 명확히 로그에 표시.
+    - cd src/ai-adapter && npm ci --prefer-offline --no-audit && npm audit --audit-level=high --omit=dev
+    - cd "$CI_PROJECT_DIR/src/frontend" && npm ci --prefer-offline --no-audit && npm audit --audit-level=high --omit=dev
+    - cd "$CI_PROJECT_DIR/src/admin" && npm ci --prefer-offline --no-audit && npm audit --audit-level=high --omit=dev
+  allow_failure: false
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == "main"
+    - if: $CI_COMMIT_BRANCH == "develop"
+  interruptible: true
+```
+
+### 3.3 설계 결정 근거
+
+| 결정 | 값 | 근거 |
+|------|----|------|
+| Stage | `quality` | 70번 §6 원본 + 기존 구조 존중 |
+| Image | `node:22-alpine` | 기존 `lint-nest`, `test-nest`, `lint-frontend`, `lint-admin` 와 동일 — Pod 재사용 캐시 히트 |
+| Timeout | 10m | cold 예상 ~2m + 안전 margin |
+| Runner | `*local-runner` | 기존 패턴. 공유 runner 금지 원칙 |
+| `--prefer-offline` | 포함 | PVC 캐시 히트 시 네트워크 skip |
+| `--no-audit` (ci) | 포함 | `npm ci` 자체 audit 을 생략하고 명시적 `npm audit` 으로 game-plan 분리 |
+| `--omit=dev` | 포함 | 본 잡은 production 게이트. dev 는 J3 |
+| `--audit-level=high` | 포함 | production High/Critical = 0 정책 (78번 §4.4 기준) |
+| `allow_failure` | `false` | Fail 정책: production High 는 절대 허용 안 함 |
+| `interruptible` | `true` | MR 재푸시 시 이전 파이프 cancel |
+
+### 3.4 예상 duration
+
+| 단계 | cold (캐시 미스) | warm (캐시 히트) |
+|-----|---------------|---------------|
+| image pull (node:22-alpine) | ~15s | 0s (re-use) |
+| ai-adapter `npm ci` + audit | ~60s + 5s | ~20s + 3s |
+| frontend `npm ci` + audit | ~45s + 4s | ~15s + 3s |
+| admin `npm ci` + audit | ~30s + 3s | ~10s + 3s |
+| **합계** | **~162s (2m42s)** | **~54s** |
+
+현 `sonarqube` 잡이 20m timeout (실측 ~10~15m) critical path 이므로 wall-clock 순증 **0m**.
+
+### 3.5 예상 실패 시나리오 (Day 3 착수 시점)
+
+**중요**: J1 은 SEC-A/B/C 머지 전에 추가하면 현 상태 **자동 FAIL** 예정.
+
+- ai-adapter: `axios 1.14.0` High 2건 (SEC-C 미머지 시)
+- frontend: `next 15.2.9` High (SEC-B 미머지 시)
+- admin: `next 16.1.6` High (SEC-B 미머지 시)
+
+→ **SEC-A/B/C 3건 모두 머지 완료 후 본 잡 추가 권장**. Day 3 실행 시점에는 Day 2 머지 완료 전제.
+
+---
+
+## 4. J2 — `sca-govulncheck` YAML 초안 + 설명
+
+### 4.1 설계 의도
+
+- game-server Go 코드에 `govulncheck -mode=source ./...` 실행 → code-called 취약점만 실패로 간주.
+- 78번 §2.8 결론: `toolchain go1.25.9` directive 포함 상태에서 code-called=0 달성.
+- SEC-A 머지 전 추가하면 **19건 code-called 로 자동 FAIL**. Day 2 머지 완료 전제.
+
+### 4.2 YAML 초안
+
+```yaml
+# =============================================================================
+# SCA — game-server Go code-called 취약점 게이트
+# =============================================================================
+#
+# 목적:
+#   `govulncheck -mode=source` 는 실제 호출 그래프에 있는 취약점만 보고한다
+#   (imported-but-unreachable 는 무시). 따라서 false positive 최소화 + 실 exploit
+#   가능성 있는 취약점만 파이프라인 차단 게이트로 기능.
+#
+# 근거: docs/04-testing/78-sec-a-b-c-audit-delta.md §2.3 (stdlib 19건 code-called)
+#       docs/04-testing/70-sec-rev-013-dependency-audit-report.md §6.3 #3
+#
+# SEC-A 머지 전제:
+#   go.mod 의 `toolchain go1.25.9` directive + Docker `golang:1.25.9-alpine` pin
+#   상태에서 code-called=0 달성. 본 잡은 SEC-A 머지 후 추가.
+#
+# 캐시:
+#   GOMODCACHE=/cache/go/mod + GOCACHE=/cache/go/build (전역 variables) 재사용.
+
+sca-govulncheck:
+  stage: quality
+  <<: *local-runner
+  timeout: 10m
+  image: golang:1.25.9-alpine   # SEC-A pin 과 일치
+  variables:
+    GOFLAGS: "-buildvcs=false"
+    GOGC: "50"
+  before_script:
+    - apk add --no-cache gcc musl-dev git
+  script:
+    - cd src/game-server
+    - go install golang.org/x/vuln/cmd/govulncheck@v1.2.0
+    # -mode=source: 실 호출 그래프만. imported-but-unreachable 는 스킵.
+    # exit code != 0 이면 code-called 취약점 존재 → 파이프라인 실패.
+    - govulncheck -mode=source ./...
+  allow_failure: false
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == "main"
+    - if: $CI_COMMIT_BRANCH == "develop"
+  interruptible: true
+```
+
+### 4.3 설계 결정 근거
+
+| 결정 | 값 | 근거 |
+|------|----|------|
+| Stage | `quality` | J1 과 동일 스테이지 → 병렬 실행 |
+| Image | `golang:1.25.9-alpine` | 78번 §2.7 권고 pin. `lint-go`/`test-go` 의 `golang:1.25-alpine` 과 분리하지 않고 Day 2 SEC-A 머지 시 함께 pin 변경하는 것도 대안 |
+| govulncheck 버전 | `@v1.2.0` | 78번 리포트 실행 버전 — 재현성 |
+| `-mode=source` | 포함 | false positive 최소화. 70번 §6.3 #3 |
+| `GOFLAGS=-buildvcs=false` | 포함 | CI git info 경고 억제 (기존 `lint-go` 와 동일) |
+| `GOGC=50` | 포함 | 16GB RAM 제약 대응 |
+| `allow_failure` | `false` | strict 게이트 |
+
+### 4.4 예상 duration
+
+| 단계 | cold | warm |
+|-----|-----|-----|
+| image pull (golang:1.25.9-alpine) | ~20s | 0s |
+| apk add gcc musl-dev git | ~10s | 0s (layer) |
+| `go install govulncheck` | ~45s | ~5s (GOMODCACHE hit) |
+| `govulncheck -mode=source ./...` | ~120s | ~40s |
+| **합계** | **~195s (3m15s)** | **~45s** |
+
+### 4.5 SEC-A 상태 의존 — 머지 순서 중요
+
+**반드시 다음 순서 준수**:
+1. Day 2: SEC-A 머지 (`toolchain go1.25.9` + Docker pin 포함)
+2. Day 3 Morning: SEC-A 머지 후 `main` 브랜치에서 로컬 `govulncheck -mode=source ./...` → code-called=0 확인
+3. Day 3: 본 잡 (J1+J2) 추가 PR 생성 → 파이프라인 GREEN 확인 → 머지
+
+**역순으로 하면** Day 2 SEC-A 미머지 상태에서 J2 추가 시 code-called 19건으로 파이프라인 즉시 RED.
+
+---
+
+## 5. J3 — `weekly-dependency-audit` YAML 초안 + 설명
+
+### 5.1 설계 의도
+
+- **주 1회 (월요일 09:00 KST)** 전체 의존성 드리프트 스캔.
+- production + dev 모두 + LOW severity 포함 → **리포트 only**. 빌드 실패 안 시킴 (`allow_failure: true`).
+- artifact 로 JSON 리포트 보관 → 매주 드리프트 추이 수동 분석.
+- **통지**: MEMORY.md "카카오톡 API (Slack 아님)" — 본 잡 자체는 통지 미포함. 별도 notification 인프라 구축 후 추가.
+- **GitLab Schedules** UI 에서 `AUDIT_SCHEDULE=weekly` variable 설정 + cron `0 0 * * 1` (월 00:00 UTC = 월 09:00 KST) 로 트리거.
+
+### 5.2 YAML 초안
+
+```yaml
+# =============================================================================
+# 주간 의존성 드리프트 스캔 — scheduled only
+# =============================================================================
+#
+# 목적:
+#   주 1회 전체 의존성 (prod + dev + LOW) 드리프트 리포트. 새 CVE 공개 감지용.
+#   사례: 70번 §7 — 6일 사이 Go stdlib 에 GO-2026 계열 8건 신규 공개되어
+#   code-called 취약점이 8건 → 25건으로 3배 증가. 정적 1회 audit 만으로는
+#   드리프트를 막을 수 없어 주간 감사 필수.
+#
+# 근거: docs/04-testing/70-sec-rev-013-dependency-audit-report.md §6.3 #4
+#       docs/04-testing/78-sec-a-b-c-audit-delta.md §7.2 #10
+#
+# 트리거:
+#   GitLab UI → Build → Pipeline schedules → "Weekly dependency audit"
+#   - Cron: `0 0 * * 1` (월 00:00 UTC = 월 09:00 KST)
+#   - Target branch: main
+#   - Variable: AUDIT_SCHEDULE=weekly
+#
+# Fail 정책:
+#   allow_failure: true — 빌드 차단 안 함. 리포트만.
+#   운영자가 매주 월요일 오전 artifact 다운로드 후 triage.
+#
+# 통지 (Phase 2):
+#   카카오톡 API 통합 후 High+ 발견 시 자동 알림 추가 예정.
+
+weekly-dependency-audit:
+  stage: quality
+  <<: *local-runner
+  timeout: 15m
+  image: node:22-alpine
+  before_script:
+    - apk add --no-cache go git
+  script:
+    - mkdir -p audit-reports
+    # Node.js 3 프로젝트 — prod + dev + LOW 포함 JSON 리포트
+    - cd src/ai-adapter && npm ci --prefer-offline --no-audit
+    - npm audit --audit-level=low --json > "$CI_PROJECT_DIR/audit-reports/ai-adapter-full.json" || true
+    - npm audit --audit-level=low --omit=dev --json > "$CI_PROJECT_DIR/audit-reports/ai-adapter-prod.json" || true
+    - cd "$CI_PROJECT_DIR/src/frontend" && npm ci --prefer-offline --no-audit
+    - npm audit --audit-level=low --json > "$CI_PROJECT_DIR/audit-reports/frontend-full.json" || true
+    - npm audit --audit-level=low --omit=dev --json > "$CI_PROJECT_DIR/audit-reports/frontend-prod.json" || true
+    - cd "$CI_PROJECT_DIR/src/admin" && npm ci --prefer-offline --no-audit
+    - npm audit --audit-level=low --json > "$CI_PROJECT_DIR/audit-reports/admin-full.json" || true
+    - npm audit --audit-level=low --omit=dev --json > "$CI_PROJECT_DIR/audit-reports/admin-prod.json" || true
+    # Go — govulncheck JSON 리포트
+    - cd "$CI_PROJECT_DIR/src/game-server"
+    - go install golang.org/x/vuln/cmd/govulncheck@v1.2.0
+    - govulncheck -mode=source -json ./... > "$CI_PROJECT_DIR/audit-reports/govulncheck.json" || true
+    # 요약 출력 (파이프라인 로그 확인 용도)
+    - cd "$CI_PROJECT_DIR"
+    - echo "=== Summary ==="
+    - for f in audit-reports/*.json; do echo "$f size=$(wc -c < $f)"; done
+  artifacts:
+    name: "weekly-audit-$CI_COMMIT_SHORT_SHA-$CI_PIPELINE_ID"
+    paths:
+      - audit-reports/
+    expire_in: 90 days
+    when: always
+  allow_failure: true
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule" && $AUDIT_SCHEDULE == "weekly"
+  interruptible: false
+```
+
+### 5.3 설계 결정 근거
+
+| 결정 | 값 | 근거 |
+|------|----|------|
+| Stage | `quality` | 다른 scheduled 잡 없음. quality 배치 유지 (구조 일관) |
+| Image | `node:22-alpine` + `apk add go` | Node+Go 동시 실행 위해 Node 이미지에 Go 설치 (별도 잡 분리 가능하나 artifact 일원화 위해 병합) |
+| Timeout | 15m | 4단계 npm audit + govulncheck JSON dump 여유 포함 |
+| `\|\| true` | 모든 audit 뒤 | High 발견해도 artifact 수집 계속 |
+| `allow_failure` | `true` | 리포트 only. 빌드 차단 안 함 |
+| Artifact | JSON + 90일 보존 | 주간 드리프트 추이 분석용 |
+| Rules | `schedule + AUDIT_SCHEDULE=weekly` | GitLab Schedule variable 로 명시적 트리거. MR/push 에서는 실행 안 됨 |
+| `interruptible` | `false` | scheduled 잡은 중단 불가 (다음 schedule 까지 1주) |
+
+### 5.4 Scheduled Pipeline 설정 (UI 단계)
+
+devops 담당자가 Day 3 실행 시 GitLab 웹 UI 에서 설정:
+
+1. **Settings → CI/CD → Schedules → "New schedule"**
+   - Description: `Weekly dependency audit`
+   - Interval Pattern: `0 0 * * 1` (매주 월 00:00 UTC = 09:00 KST)
+   - Cron Timezone: `UTC` (또는 `Seoul` — GitLab 지원)
+   - Target branch: `main`
+   - Variables: `AUDIT_SCHEDULE` = `weekly`
+   - Activated: ✅
+2. 최초 1회 수동 `Play` 로 검증 → artifact 확인.
+
+### 5.5 예상 duration
+
+| 단계 | 예상 |
+|-----|-----|
+| image pull + apk add | ~30s |
+| ai-adapter ci+audit×2 | ~90s |
+| frontend ci+audit×2 | ~70s |
+| admin ci+audit×2 | ~50s |
+| go install + govulncheck | ~80s |
+| artifact 업로드 | ~10s |
+| **합계** | **~330s (5m30s)** |
+
+주간 1회 실행이므로 파이프라인 총량 기여도 무시할 수준.
+
+---
+
+## 6. 캐시 / Runner / 리소스 영향 분석
+
+### 6.1 PVC `/cache` 공유 분석
+
+현 CI 는 `/cache` PVC 2Gi 를 모든 잡이 공유한다 (`.gitlab-ci.yml` line 47~58).
+
+| 캐시 키 | 기존 소비 | J1 추가 소비 | J2 추가 소비 | J3 추가 소비 | 합산 위험 |
+|--------|---------|-----------|-----------|-----------|---------|
+| `/cache/npm` | lint-nest / lint-frontend / lint-admin / test-nest 공유 | +0 (동일 lockfile, 신규 패키지 없음) | 0 | +0 | **위험 없음** |
+| `/cache/go/mod` | lint-go / test-go | 0 | +`govulncheck` 모듈 ~30MB | 동일 | 미미 |
+| `/cache/go/build` | test-go | 0 | +source 분석 캐시 ~100MB | 동일 | 미미 |
+| `/cache/trivy` | trivy-fs / scan-* | 0 | 0 | 0 | 영향 없음 |
+
+**결론**: 2Gi PVC 여유 있음 (현재 ~700MB 사용 추정). J2 govulncheck 추가로 ~150MB 증가 → 총 850MB, 여전히 60% 여유.
+
+### 6.2 K8s Runner Pod 메모리 (2Gi limit)
+
+MEMORY.md 상 "K8s Executor (cicd NS), Pod 2Gi". 동시 실행 가능성 점검:
+
+- J1 `sca-npm-audit` peak: npm ci 시 ~400MB (Node heap + patch unpack)
+- J2 `sca-govulncheck` peak: `govulncheck -mode=source` 시 ~800MB (전체 패키지 build+분석)
+- J3 `weekly-dependency-audit` peak: Node + Go 동시 실행 ~1.2GB
+
+**병렬 실행 시나리오**:
+- J1 + J2 동시 실행 (quality stage 병렬) → peak ~1.2GB → **안전** (Runner 2Gi 내)
+- quality stage 기존 잡: `sonarqube` peak ~800MB (JVM 384m + Node 256m + overhead). 세 잡 동시 실행 → ~2.0GB → **빠듯하나 가능** (GOGC=50 + NODE_OPTIONS=256m 설정 덕분)
+
+**리스크**: `sonarqube` + J1 + J2 동시 peak 겹치면 OOM 가능. 완화책:
+- (a) J2 `needs: []` 명시로 sonarqube 완료 후 실행 (직렬화, duration +3m)
+- (b) 현 상태 유지 (병렬, 낮은 확률 OOM)
+
+**권고**: 초기 배포는 **(b) 병렬**, 실측 후 OOM 관측 시 **(a) 직렬화** 로 후속 조정.
+
+### 6.3 Kaniko 빌드 잡과의 충돌
+
+Kaniko 빌드 잡 (`build-*`) 은 **build** 스테이지. J1/J2 는 **quality** 스테이지 → 직렬 실행. **충돌 없음**.
+
+---
+
+## 7. Fail 정책 매트릭스
+
+| 잡 | severity 기준 | `allow_failure` | 실패 시 영향 | 해소 경로 |
+|---|-------------|----------------|-----------|---------|
+| J1 `sca-npm-audit` | High+ production | `false` | 머지 차단 | `npm audit fix` 또는 `npm install <pkg>@patched` + lockfile 커밋 |
+| J2 `sca-govulncheck` | code-called (`-mode=source`) | `false` | 머지 차단 | `go.mod` bump (패치 버전) 또는 call path 제거 |
+| J3 `weekly-dependency-audit` | LOW+ (모든 범위) | `true` | 리포트만 (운영자 triage) | 다음 주 PR 로 배치 수정 |
+
+**원칙 (70번 §6.3 유지)**:
+1. production High/Critical = 0 강제 (J1)
+2. code-called = 0 강제 (J2)
+3. dev + LOW drift 는 warn-only, 주간 리포트 (J3)
+4. 3도구 합의 (Trivy + npm audit + govulncheck) = defense-in-depth
+
+---
+
+## 8. Verification Plan — Day 3 착수 시 dry-run
+
+### 8.1 로컬 사전 검증 (브랜치 생성 전)
+
+```bash
+# 1. SEC-A 머지 완료 + toolchain directive 확인
+cd src/game-server
+grep -E "^go |^toolchain " go.mod
+#   go 1.25
+#   toolchain go1.25.9   ← 있어야 함
+
+# 2. J1 로컬 reproduce
+cd src/ai-adapter && npm ci --prefer-offline --no-audit && npm audit --audit-level=high --omit=dev
+# exit 0 기대 (SEC-C 머지 후)
+
+cd ../frontend && npm ci --prefer-offline --no-audit && npm audit --audit-level=high --omit=dev
+# exit 0 기대 (SEC-B 머지 후)
+
+cd ../admin && npm ci --prefer-offline --no-audit && npm audit --audit-level=high --omit=dev
+# exit 0 기대 (SEC-B 머지 후)
+
+# 3. J2 로컬 reproduce
+cd ../game-server
+go install golang.org/x/vuln/cmd/govulncheck@v1.2.0
+govulncheck -mode=source ./...
+# exit 0 + code-called=0 기대 (SEC-A 머지 후)
+
+# 4. J3 드라이런 (수동 트리거 상당)
+mkdir -p /tmp/audit-reports
+cd src/ai-adapter && npm audit --audit-level=low --json > /tmp/audit-reports/ai-adapter-full.json || true
+# (나머지 반복)
+```
+
+**모든 dry-run 통과 후** Day 3 구현 PR 생성.
+
+### 8.2 CI dry-run (PR 단계)
+
+1. `feature/sprint7-ci-audit-jobs` 브랜치 생성
+2. `.gitlab-ci.yml` 에 J1+J2+J3 추가 (본 §3/§4/§5 YAML 그대로)
+3. PR 생성 → MR pipeline 실행
+4. 기대 결과:
+   - J1 (`sca-npm-audit`): GREEN (~2m)
+   - J2 (`sca-govulncheck`): GREEN (~3m)
+   - J3 (`weekly-dependency-audit`): **실행 안 됨** (rule: schedule only)
+   - 기존 17잡 모두 GREEN 유지
+5. GitLab UI → Schedules → "Weekly dependency audit" 생성 → `Play` 수동 트리거 → artifact 확인
+6. artifact download → JSON 리포트 구조 검증
+7. Day 3 마감 직전 머지
+
+### 8.3 Fail 시나리오 테스트 (선택)
+
+J1/J2 의 `allow_failure: false` 정책 검증을 위해 의도적 RED PR 1건 생성 가능:
+- (a) `ai-adapter/package.json` 에 `"uuid": "9.0.0"` (known High) 추가 → J1 RED 확인 → revert
+- (b) game-server 에 취약 stdlib call path 추가 → J2 RED → revert
+
+권장은 **(a)만 수행**. (b) 는 로컬 govulncheck 로 이미 검증됨.
+
+---
+
+## 9. Risk Budget + Rollback 절차
+
+### 9.1 Risk 매트릭스
+
+| Risk | Probability | Impact | 완화책 |
+|-----|-----------|-------|------|
+| SEC-A/B/C 미머지 상태에서 J1/J2 추가 → 즉시 RED | HIGH (순서 위반 시) | HIGH (main 차단) | 구현 순서 §4.5 엄수 + PR description 에 SEC-A/B/C 머지 확인 체크박스 |
+| npm registry advisory 새 High 공개 → 갑작스런 RED | MEDIUM | MEDIUM | 머지 직전 재실행 + J3 가 월요일 드리프트 사전 감지 |
+| govulncheck v1.2.0 → 신버전 결과 변화 | LOW | LOW | 버전 pin (`@v1.2.0`) 유지. 6개월마다 수동 bump |
+| 2Gi Runner OOM (sonarqube + J1+J2 동시) | LOW | MEDIUM | 6.2절 완화책 (a) 직렬화 fallback |
+| Scheduled 잡 설정 실수 (cron/variable 미설정) | MEDIUM | LOW | Day 3 체크리스트 §5.4 명시 + 최초 1회 수동 Play 검증 |
+| J3 artifact 가 2Gi PVC 소진 | LOW | LOW | expire_in 90일 + GitLab job artifact retention 정책 |
+
+### 9.2 Rollback 절차
+
+J1/J2/J3 추가 이후 문제 발생 시:
+
+**Option A — 잡 비활성화 (빠른 hotfix)**:
+```yaml
+# .gitlab-ci.yml 해당 잡의 rules 를 never 로 교체 (임시 차단)
+sca-npm-audit:
+  rules:
+    - when: never   # ← 임시 비활성화
+```
+→ 커밋 + 푸시 → 파이프라인 skip. 원인 분석 후 복구.
+
+**Option B — allow_failure 완화**:
+```yaml
+sca-npm-audit:
+  allow_failure: true   # ← strict → warn-only 강등
+```
+→ 긴급 상황에만 사용. 보안 게이트 상실 주의.
+
+**Option C — revert 커밋**:
+```bash
+git revert <sprint7-ci-audit-jobs-PR-merge-commit>
+git push
+```
+→ 완전 원복. 후속 재도입 필요.
+
+**권고**: 대부분의 문제는 **Option A** 로 대응. B/C 는 최후 수단.
+
+---
+
+## 10. Day 3 실행 시 예상 파이프라인 duration 변화
+
+### 10.1 기존 baseline (Pipeline #113 기준 추정)
+
+| Stage | Jobs | Wall-clock (parallel) |
+|-------|------|--------------------|
+| lint | 5 | ~3m (longest: lint-go 3m) |
+| test | 2 | ~4m (longest: test-go 4m) |
+| quality | 2 | ~15m (longest: sonarqube 15m) |
+| build | 8 (4 build + 4 scan, Phase 직렬) | ~25m (cold) / ~8m (warm) |
+| update-gitops | 1 | ~1m |
+| **Total critical path** | — | **~48m (cold) / ~31m (warm)** |
+
+### 10.2 J1+J2 추가 후 (PR/main pipeline)
+
+| Stage | Jobs | Wall-clock |
+|-------|------|-----------|
+| lint | 5 | ~3m |
+| test | 2 | ~4m |
+| **quality** | **4** (sonarqube, trivy-fs, **sca-npm-audit**, **sca-govulncheck**) | **~15m (sonarqube 여전히 longest, J1/J2 병렬)** |
+| build | 8 | ~25m / ~8m |
+| update-gitops | 1 | ~1m |
+| **Total critical path** | — | **~48m / ~31m** — **순증 0m** |
+
+### 10.3 J3 추가 후 (scheduled pipeline only)
+
+| Stage | Jobs | Wall-clock |
+|-------|------|-----------|
+| quality | 1 (weekly-dependency-audit only) | ~5m30s |
+| **Total** | — | **~6m** (scheduled 전용, MR/push 와 별개) |
+
+### 10.4 결론
+
+- **PR/push 파이프라인**: critical path 순증 **0m** (sonarqube 가 여전히 longest).
+- **Scheduled 파이프라인**: 주 1회 ~6m 신규 실행. 기존 파이프라인에 영향 없음.
+- Runner 점유 시간 증가: PR 당 최대 +5m (J1+J2 병렬 wall-clock, Runner slot 관점).
+- **총 CI 비용 증가 미미**. 보안 게이트 강화 이득이 훨씬 큼.
+
+---
+
+## 11. Day 3 실행 체크리스트 (devops 용)
+
+- [ ] **전제**: Day 2 SEC-A/B/C 3개 PR 모두 머지 완료 + main GREEN 확인
+- [ ] **전제**: `src/game-server/go.mod` 에 `toolchain go1.25.9` 라인 존재 확인
+- [ ] §8.1 로컬 dry-run 4단계 모두 exit 0 확인
+- [ ] 브랜치 `feature/sprint7-ci-audit-jobs` 생성
+- [ ] `.gitlab-ci.yml` 에 J1 (`sca-npm-audit`) 추가 — 본 문서 §3.2 YAML
+- [ ] `.gitlab-ci.yml` 에 J2 (`sca-govulncheck`) 추가 — 본 문서 §4.2 YAML
+- [ ] `.gitlab-ci.yml` 에 J3 (`weekly-dependency-audit`) 추가 — 본 문서 §5.2 YAML
+- [ ] PR 생성 + description 에 "근거: docs/04-testing/80" 링크
+- [ ] MR pipeline → J1+J2 GREEN, J3 skip 확인 (§8.2 기대 결과)
+- [ ] GitLab UI → Schedules → "Weekly dependency audit" 등록 (§5.4)
+- [ ] Schedule 수동 Play 1회 → artifact 확인
+- [ ] PR 리뷰 + 머지
+- [ ] Sprint 7 TODO 에서 "CI 감사 잡 3건 추가" 항목 ✅ 처리
+- [ ] MEMORY.md 갱신 ("Pipeline #XXX: lint(5) + test(2) + quality(**4**) + build(8) + gitops(1) = **20/20 GREEN**")
+
+---
+
+## 12. 후속 조치 (Sprint 7 W2+)
+
+| # | 조치 | 담당 | 근거 |
+|---|------|------|------|
+| 1 | 카카오톡 API 통지 통합 (J3 High+ 발견 시 자동 알림) | devops + backend | MEMORY.md Tech Stack "카카오톡 API" |
+| 2 | J3 artifact 를 GitOps repo 에 주간 커밋 (장기 추이 추적) | devops | 90일 이후 artifact 만료 대비 |
+| 3 | J2 `-mode=binary` 병행 (빌드 이미지 대상) → Trivy 이미지 스캔과 삼각측량 | security | defense-in-depth 강화 |
+| 4 | 4도구 합의 대시보드 (Trivy + npm audit + govulncheck + Snyk?) | security + devops | Snyk 도입 타당성 ADR 선행 |
+| 5 | govulncheck DB 갱신 검증 (최소 주 1회 latest 보장) | devops | stdlib 신규 CVE 감지 지연 방지 |
+
+---
+
+## 13. 부록 A — 참조
+
+- `.gitlab-ci.yml` line 35~40 (stages), line 62~65 (`*local-runner`), line 43~58 (cache variables)
+- `docs/04-testing/70-sec-rev-013-dependency-audit-report.md` §6 (원본 초안)
+- `docs/04-testing/78-sec-a-b-c-audit-delta.md` §7.2 #10 (Sprint 7 W1~W2 후속 조치 등재)
+- `docs/04-testing/75-sec-day12-impact-and-plan.md` §2.2 (Verification 원칙)
+- MEMORY.md "CI/CD 파이프라인 현황" 섹션 (Pipeline #113, 17/17)
+- GitLab docs — Pipeline Schedules: https://docs.gitlab.com/ee/ci/pipelines/schedules.html
+- GitLab docs — `npm audit` 예시: https://docs.gitlab.com/ee/ci/examples/authenticating-with-hashicorp-vault/
+- govulncheck: https://go.dev/security/vuln/
+- npm audit docs: https://docs.npmjs.com/cli/v9/commands/npm-audit
+
+## 14. 부록 B — 판정 요약표
+
+| 잡 | PROCEED 조건 | Day 3 즉시 추가 가능 여부 |
+|----|------------|------------------------|
+| J1 `sca-npm-audit` | SEC-B + SEC-C 머지 완료 | ✅ (Day 2 완료 전제) |
+| J2 `sca-govulncheck` | SEC-A 머지 완료 + `toolchain go1.25.9` directive 존재 | ✅ (Day 2 완료 전제) |
+| J3 `weekly-dependency-audit` | 무조건 | ✅ |
+
+**3잡 모두 Day 3 PROCEED**. Day 2 SEC-A/B/C 3건 머지 완료가 J1/J2 의 유일한 의존성.

--- a/work_logs/daily/2026-04-23.md
+++ b/work_logs/daily/2026-04-23.md
@@ -1,0 +1,318 @@
+# 데일리 로그
+
+- **날짜**: 2026-04-23 (Thu)
+- **Sprint**: Sprint 7 Day 2 (Day 13)
+- **상태**: 진행 중 (qa Playwright 전수 재실행 대기 중 작성, 마감 전 append 예정)
+
+---
+
+## 오늘 한 일 (한 줄 요약)
+
+**보안 패치 3건 + 게임 안정성 이슈 3건 + 테스트 인프라 1건 = 한 세션 5 PR 머지 + K8s 재배포 + Security 감사에서 Sprint 6 이월 보안 TODO 3건 종결 확인**:
+Day 12 에 architect 가 사전 분석한 영향도 문서 (`75-sec-day12-impact-and-plan.md`, `76-issue-47-48-49-impact-and-plan.md`) 기반으로 go-dev·frontend-dev·security·devops·qa·pm 6 에이전트 순차·병렬 투입 → 원래 wall-clock 5h 예상이던 P1 8.5 SP 를 ~1.5h 에 완료.
+
+---
+
+## 오늘 개선된 것 — 사용자 관점 상세
+
+### 1. 눈에 바로 보이는 개선
+
+#### 더블클릭 해도 엉뚱한 에러 메시지 안 나옵니다 (Issue #48, PR #55)
+
+**이전 상태**:
+- 턴에서 "확정" 버튼을 빠르게 두 번 누르면 `PLACE_TILES` + `CONFIRM_TURN` 요청이 서버에 2번 발사됨
+- 두 번째 요청은 이미 서버 턴이 넘어간 상태에서 `INVALID_MOVE` 로 반려 → 빨간 에러 토스트 노출
+- 실제 게임 진행은 깨지지 않지만 사용자에게 불필요한 "잘못된 행동" 피드백이 나감
+
+**개선 후**:
+- `confirmBusy` state 추가. 첫 클릭 직후 버튼이 회색(disabled)으로 전환
+- 서버 응답이 와서 `pendingTableGroups` 가 `null` 로 reset 되면 자동 해제
+- 긴박한 상황에서 연타해도 깔끔하게 1회만 실행
+
+**기술 배경**:
+- 파일: `src/frontend/src/app/game/[roomId]/GameClient.tsx` + `src/components/game/ActionBar.tsx`
+- useEffect 의존성 배열은 `[pendingTableGroups, confirmBusy]` 만 — 지난 I-18 불완전 롤백 사례(PR #41 → qa 회귀 발견 → PR #51 완전 롤백) 재발 방지를 위해 architect 가 의존성 설계 사전 검토
+- Jest 단위 테스트 2건 신규 (`ActionBar.test.tsx`) — 201/201 → 203/203 PASS
+
+---
+
+#### 게임 중 "방 나가기" 누르면 서버가 명확히 거부합니다 (Issue #47, PR #53)
+
+**이전 상태**:
+- `LeaveRoom` 서비스가 `RoomStatusFinished` 와 `RoomStatusCancelled` 만 차단. PLAYING 상태는 체크 없음
+- 네트워크 재연결 시도 중 이중 요청이나 프론트 버그로 PLAYING 중 LeaveRoom 이 호출되면 방 상태가 이상해질 수 있었음 (race window)
+- 프론트엔드 UI 자체는 PLAYING 중 LeaveRoom 버튼을 노출하지 않지만, 서버가 거부하지 않는 것 자체가 방어 누락
+
+**개선 후**:
+- `LeaveRoom` 에 PLAYING 상태 가드 추가. 새 에러 코드 `GAME_IN_PROGRESS` (HTTP 409)
+- 에러 메시지: "게임 진행 중에는 방을 나갈 수 없습니다. 기권 기능을 이용하세요."
+- 게임 중 이탈은 FORFEIT(기권) 경로로만 허용. 정상 UI 경로 회귀 없음
+
+**기술 배경**:
+- 파일: `src/game-server/internal/service/room_service.go` L308 근처
+- `checkDuplicateRoom` 의 self-call (L478) 은 WAITING 상태 전제 — L475-479 에서 이미 가드됨. PLAYING 가드 추가해도 영향 없음을 architect 가 사전 확인
+- 신규 단위 테스트 3건: `TestLeaveRoom_RejectsPlayingStatus` (호스트/게스트), `TestLeaveRoom_AllowsWaitingStatus` (회귀 방지), `TestCheckDuplicateRoom_StillWorksOnWaiting`
+- go test 530/530 → 533/533 PASS
+
+---
+
+### 2. 눈에 안 보이지만 공격 위험을 크게 줄인 개선
+
+#### 서버 언어(Go) 1년치 보안 패치 한번에 반영 (SEC-A, PR #54)
+
+**이전 상태**:
+- `src/game-server/go.mod`: `go 1.24` + `github.com/redis/go-redis/v9 v9.7.0`
+- `govulncheck -mode=source ./...` 결과: **code-called 25건**
+  - stdlib 24건: `crypto/tls`, `crypto/x509`, `net/http`, `net/url`, `html/template`
+  - go-redis 1건: **GO-2025-3540** (out-of-order responses, CVSS Medium)
+- 실제 호출 경로가 있는 취약점이므로 외부에서 악용 시도 시 서버 다운이나 인증서 검증 우회 가능
+
+**개선 후**:
+- Go 1.24 → **1.25.9** (toolchain directive 포함). `toolchain go1.25.9` 가 핵심 — `go 1.25` 만으로는 1.25.0 기준이라 잔여 취약점 남음
+- go-redis **v9.7.0 → v9.7.3** (patch bump, API 호환)
+- Dockerfile `golang:1.24-alpine` → `golang:1.25-alpine`
+- `.gitlab-ci.yml` 의 test-go 이미지 동일 교체
+- **govulncheck code-called: 25건 → 0건** (완전 해소)
+- 추가로 **GO-2026 계열 8건** (지난 6일 이내 공개) 까지 커버됨 (1.25.9 가 1.24.13 보다 경제적)
+
+**반영된 CVE / Advisory**:
+- `GO-2025-3540` go-redis out-of-order responses — 패치됨
+- `crypto/tls`, `crypto/x509` 일련의 인증서 검증 관련 구멍 — 패치됨
+- `net/http`, `net/url` 요청 파싱 관련 구멍 — 패치됨
+- `html/template` 컨텍스트 이스케이프 관련 구멍 — 패치됨
+- `GO-2026-*` 최신 8건 — 선행 적용
+
+**기술 배경**:
+- 변경 4 파일 / ~11 LOC (코드 LOC 기준)
+- `go mod tidy` 결과 `gin-contrib/cors` 와 `keyfunc/v3` 가 indirect → direct 로 승격됨 (실제 직접 사용 중이던 것을 정식화)
+- K8s 재배포: `rummiarena/game-server:day2-2026-04-23` 이미지 45.7MB
+
+---
+
+#### 사용자 화면(Next.js)의 주요 공격 2건 차단 (SEC-B, PR #56)
+
+**우리 프로젝트에 실제 영향 있던 2건 — 이것이 해소됨**:
+
+- **Server Components DoS (CVSS 7.5, HIGH)** — 특수한 요청 반복으로 서버 렌더링을 마비시킬 수 있는 취약점. 루미큐브는 Server Components 를 사용하므로 실제 영향 있음
+- **admin postponed resume DoS** (`GHSA-*`) — admin 대시보드에서 특정 요청으로 메모리 고갈 유발. admin 이 16.1.6 에서 노출
+
+**해당 없음으로 확인된 4건 — security 감사에서 프로젝트 구조상 trigger 불가 판정**:
+
+- `GHSA-4342-x723-ch2f` SSRF (middleware redirect) — 프로젝트에 `middleware.ts` 미사용
+- `GHSA-9g9p-9gw9-jx7f` next/image remotePatterns DoS — `images.remotePatterns` 는 쓰지만 15.5.15 패치로 해소됨
+- `GHSA-mq59-m269-xvcx` Server Actions null origin CSRF — 프로젝트에 Server Actions 미사용
+- Request smuggling — `rewrites` 경로 간단하고 악용 경로 없음
+
+**변경 범위**:
+- `src/frontend/package.json`: `"next": "15.2.9"` → `"^15.5.15"` (3 minor 점프)
+- `src/admin/package.json`: `"next": "16.1.6"` → `"^16.2.4"` (1 minor)
+- `eslint-config-next` 도 동일 버전으로 동기화
+- lockfile 재생성 (frontend 약 500라인 변경, admin 약 130라인)
+
+**검증**:
+- Jest frontend 203/203 + ai-adapter 599/599 PASS
+- production 빌드 정상 (Next 15.5.15 + Turbopack 16.2.4)
+- `npm audit --omit=dev --audit-level=high`: frontend 1 high → **0 high**, admin 1 high → **0 vulnerabilities**
+
+---
+
+#### 간접 의존성 보안 구멍 차단 (SEC-C, PR #56 동일 브랜치)
+
+**이전 상태 (ai-adapter production 경로)**:
+- `axios` moderate 2건 (SSRF, ReDoS 계열)
+- `@nestjs/core` moderate 1건 (Injection)
+- `file-type` moderate 2건
+- `follow-redirects` moderate 1건
+
+**개선 후**:
+- `npm audit fix --audit-level=high` 기준으로 non-breaking 범위만 자동 bump
+- `axios` `^1.6.0` 범위 내 실제 설치 버전 1.14.0 으로 패치됨
+- transitive 의존성 (`brace-expansion`, `picomatch`) 도 함께 해소
+- **ai-adapter Critical/High 0** 유지 (Moderate 4건은 `@nestjs/core` v11 메이저 bump 로 해소 — Sprint 7 Week 2 이관)
+
+**의도적 제외** (기술 부채로 문서화):
+- `@typescript-eslint/*` dev-only High → Sprint 7 Week 1 P1 별도 PR
+- `@nestjs/cli` dev-only High → 메이저 bump 필요, Week 1
+- `jest-environment-jsdom` dev-only low × 4 → Week 1
+
+---
+
+### 3. 품질·생산성 측 개선
+
+#### 고장난 자동 테스트 3건 복구 (Issue #49, PR #57)
+
+**이전 상태**:
+- `e2e/day11-ui-bug-fixes.spec.ts` 내 T-B1-01, T-B1-02, T-BNEW-01, T-BNEW-02, T7-02 총 5개 시나리오가 Day 11 당시 잘못 작성됨
+- 기대치: "Practice 모드에서 타일 드롭 시 '미확정' 라벨 표시"
+- 실제: Practice 모드는 서버 round-trip 없는 로컬 연습 모드 → "서버 미확정" 개념 자체가 설계상 부적합
+- T7-02 는 stage 1 hand 에 없는 `R1a` 를 드래그 시도 → timeout/silent fail
+
+**기각된 대안 — Option B (PracticeBoard 리팩터 ~150 LOC)**:
+- Practice 모드에 pending/committed 개념 도입
+- 설계 정합성 낮음: practice 는 단일 플레이어 로컬 연습이며, "미확정" 은 서버 검증 대기 상태를 시각화하는 장치
+- 기존 StageSelector/TutorialOverlay/Stage 1~6 완주 테스트 회귀 리스크
+
+**채택 — Option A + C 결합 (~30 LOC 테스트 전용 수정)**:
+- B-1 계열: 기대치를 "보드 타일 배치 확인" (`[role="img"]` count) 으로 변경
+- B-NEW 계열: "그룹" 또는 "런" 라벨 단독 존재 확인 (미확정 suffix 없음)
+- T7-02: `R1a` → `R7a` (stage 1 실제 hand 에 존재하는 타일 코드)
+- **프로덕션 코드 0 LOC**. 45 LOC 테스트 수정만
+
+**효과**:
+- 자동 회귀 감지 신뢰성 회복 — "원래 이 테스트 빨강이야" 로 넘어가는 위험 제거
+- Practice 모드 설계 의도 ("로컬 검증만") 가 테스트에도 명시적으로 반영됨
+
+---
+
+#### Sprint 7 TODO 3건 제거 — Security 감사 부산물 (docs/04-testing/78, 410줄)
+
+**발견**:
+- Sprint 6 이월 Medium 보안 이슈로 MEMORY.md 에 "미완료" 로 표시돼 있던 **SEC-REV-002/008/009** 3건
+- security 에이전트 감사 결과 **3건 모두 이미 해소됨** 확인
+- 해소 지점: `ws_rate_limiter.go` + `ws_hub.go` 에서 Sprint 6 다른 PR 에 묻혀 처리됐으나 추적 문서만 남아있었음
+- `gh issue list --search "SEC-REV"` 도 empty — 추적 이슈 자체가 없음
+
+**효과**:
+- Sprint 7 Week 1 에서 이 3건에 투입될 예정이던 공수 면제
+- V-13a (`ErrNoRearrangePerm` orphan 리팩터) / V-13e (조커 재드래그 UX) 를 앞당길 여유
+- MEMORY.md "보안 현황" 섹션 전면 갱신 (Day 2 기준 Critical/High 잔존 = 0 명시)
+
+---
+
+#### 추가 발견 — next-auth v5 이주 ADR 필요 (Sprint 8 후보)
+
+**security 감사 중 신규 발견**:
+- frontend 의 `next-auth v4` 가 의존하는 `uuid<14` 에 `GHSA-w5hq-g745-h8pq` moderate 존재
+- next-auth v4 semver 범위 안에서는 해소 불가 → **next-auth v5 (Auth.js) 이주만이 유일 경로**
+- 세션/콜백/어댑터 전면 재설계 필요 → Sprint 8 ADR 선행 결정으로 이관
+
+**행동**:
+- Sprint 8 후보 섹션에 "next-auth v5 이주 ADR" 항목 신설 (MEMORY.md + sprint7-decisions.md)
+- 현 시점 "우리가 아는 잔존 moderate 1건" 으로 명시. 추적 단절 방지
+
+---
+
+## 시간대별 세션
+
+### 아침 (09:00 ~ 10:00) — 스탠드업 전원 참석 + 영향도 문서 재독
+
+- 스크럼 로그 `2026-04-23-01.md` 작성. **에이전트 10명 전원 참석** 공식 포맷 도입 (대기 에이전트도 "대기" 상태 공식 기록)
+- architect 가 Day 12 에 작성한 영향도 문서 2건 재독:
+  - `docs/04-testing/75-sec-day12-impact-and-plan.md` — SEC-A/B/C 상세 계획 + Day 12 P0 ALREADY DONE 판정
+  - `docs/04-testing/76-issue-47-48-49-impact-and-plan.md` — Issue 3건 구체적 구현안 + Option A+C 선택 근거
+
+### 오전 (10:00 ~ 10:30) — 1차 웨이브 4 에이전트 병렬
+
+- **go-dev (isolation: worktree)** → SEC-A: PR #54 `chore/sec-a-go-toolchain-bump`
+- **go-dev (isolation: worktree)** → Issue #47: PR #53 `fix/issue-47-leave-room-playing-guard`
+- **frontend-dev (isolation: worktree)** → Issue #48: PR #55 `fix/issue-48-confirm-busy-lock`
+- **security (read-only)** → SEC-A/B/C CVE delta 감사 → `docs/04-testing/78-sec-a-b-c-audit-delta.md` (410줄)
+
+1차 결과:
+- 3 PR MERGEABLE 확인 후 순차 머지 (#54 → #53 → #55)
+- security 감사에서 SEC-REV-002/008/009 3건 모두 해소됨 발견 + next-auth v5 신규 moderate 1건 발견
+
+### 오전 (10:30 ~ 11:30) — 2차 웨이브 SEC-BC
+
+- **frontend-dev (isolation: worktree)** → SEC-B + SEC-C 통합 브랜치 `chore/sec-bc-npm-next-bump` (같은 lockfile 충돌 방지)
+- Next 15.5.15 + admin 16.2.4 + npm audit fix 일괄
+- frontend Jest 203 + ai-adapter 599 + production audit high 0 확인 후 PR #56 머지
+- Playwright 전수 재실행은 qa 별도 위임 (이번 PR 에서는 Jest + build 만)
+
+### 오전 (11:30 ~ 12:00) — 3차 웨이브 Issue #49 + K8s 재배포
+
+- **frontend-dev (isolation: worktree)** → Issue #49 fixture Option A+C: PR #57 `fix/issue-49-day11-fixture`
+- K8s 서버 꺼진 상태 감지 → 사용자에게 Docker Desktop 기동 요청
+- 기동 완료 후 **devops** 에이전트 투입:
+  - 이미지 3개 재빌드: `rummiarena/game-server:day2-2026-04-23` (45.7MB), `frontend` (337MB), `admin` (309MB)
+  - K8s rollout: game-server/frontend/admin 신규 Pod RESTARTS=0
+  - rooms dual-write 회귀 없음 확인 (`rooms dual-write enabled (D-03 Phase 1)` 로그 존재)
+  - Smoke: frontend 307 CSP 정상, game-server health `{"redis":true,"status":"ok"}`
+
+### 오후 (12:00 ~ 진행 중) — pm TODO 정리 + qa Playwright 전수
+
+- **pm** → `docs/01-planning/sprint7-decisions.md` 54 → 144줄 확장. Day 2 결정 + Sprint 7 Week 1/Week 2/Sprint 8 후보 재분류
+- **qa** (백그라운드 진행 중) → Playwright 전수 재실행 + 회귀 보고서 `docs/04-testing/77-*.md` 작성 예정
+- MEMORY.md "다음 할 일" + "보안 현황" Day 2 기준 갱신 완료
+
+---
+
+## PR 목록 (5건 전량 머지)
+
+| PR | 제목 | 머지 시각 (UTC) | 브랜치 |
+|----|------|------------------|--------|
+| #54 | chore(sec-a): Go 1.25.9 + go-redis v9.7.3 toolchain bump | 05:07:25 | `chore/sec-a-go-toolchain-bump` |
+| #53 | fix(#47): LeaveRoom PLAYING 상태 가드 + GAME_IN_PROGRESS 409 | 05:07:33 | `fix/issue-47-leave-room-playing-guard` |
+| #55 | fix(#48): handleConfirm confirmBusy state | 05:08:13 | `fix/issue-48-confirm-busy-lock` |
+| #56 | chore(sec-bc): Next 15.5.15 + admin 16.2.4 + npm audit fix | ~05:28 | `chore/sec-bc-npm-next-bump` |
+| #57 | fix(#49): day11 FINDING-02 test fixture Option A+C | 05:39:26 | `fix/issue-49-day11-fixture` |
+
+## Issue 클로즈
+- **#47** CLOSED (PR #53 auto-close)
+- **#48** CLOSED (PR #55 auto-close)
+- **#49** CLOSED (PR #57 auto-close)
+
+---
+
+## 신규 문서 (4건 미커밋)
+
+1. `work_logs/scrums/2026-04-23-01.md` — 오늘 아침 전원 참석 스탠드업 (약 160줄)
+2. `docs/04-testing/78-sec-a-b-c-audit-delta.md` — security 감사 delta (410줄) — SEC-REV 종결 + next-auth v5 발견 근거
+3. `docs/01-planning/sprint7-decisions.md` — 54 → 144줄 확장 (pm 갱신)
+4. (qa 완료 시) `docs/04-testing/77-day2-regression-report.md` — Playwright 전수 결과
+
+---
+
+## 테스트 현황 (Day 2 갱신, qa 완료 후 확정)
+
+| 스위트 | Day 12 | Day 2 (현재) | 비고 |
+|--------|--------|---------------|------|
+| go test (game-server) | 530/530 | **533/533** | Issue #47 테스트 3건 신규 |
+| Jest (frontend) | 201/201 | **203/203** | Issue #48 테스트 2건 신규 |
+| Jest (ai-adapter) | 428/428 | **599/599** | 누적 증가분 (SEC-BC 영향 없음) |
+| govulncheck (go) code-called | 25건 | **0건** | SEC-A 완전 해소 |
+| npm audit production High | frontend 1 + admin 1 | **0 + 0** | SEC-BC 해소 |
+| Playwright E2E | 376 PASS / 4 KNOWN FAIL | **TBD (qa 진행 중)** | 완료 시 append |
+
+---
+
+## 오늘 결정 사항
+
+1. **데일리 마감 TaskCreate 선제 생성 금지** — 사용자 지적 수용. MEMORY.md 피드백 추가 (`feedback_no_preemptive_daily_close_task.md`). 앞으로 사용자 명시 요청("/daily-close" 또는 "마감") 시에만 실행.
+2. **PracticeBoard 리팩터 기각 (Option B)** — 설계 정합성 우선. Practice 모드의 "서버 미확정" 개념 도입은 도메인 왜곡.
+3. **next-auth v5 이주 ADR 은 Sprint 8** — Sprint 7 범위 밖 (세션/콜백/어댑터 전면 재설계).
+4. **Day 12 backend P0 제거 확정** — PR #38 + #42 로 이미 해결됨 (architect 재확인). Sprint 7 TODO 에서 삭제.
+5. **Sprint 7 Day 2 소화율 이례적** — 8.5 SP / ~1.5h. Week 1 후반 속도 조절 / 번아웃 리스크 주시 (pm 관점).
+
+---
+
+## 다음 세션 킥오프 (Day 3 예정)
+
+1. **dev-only P2 3건 병렬**: `@typescript-eslint/*` 7.6+, `@nestjs/cli` 10→11, `jest-environment-jsdom` 30.3
+2. **V-13a / V-13e** 앞당김 검토 (Day 2 여유분)
+3. **PostgreSQL 001 마이그레이션** staging dry-run
+4. **qa 회귀 보고서 77 내용 기반** 추가 Issue 생성 (있다면)
+
+---
+
+## 메모
+
+- **세션 리밋 대비 사전 기록**: 사용자 요청으로 qa Playwright 완료 전에 데일리 로그 미리 작성. qa 결과는 완료 시 섹션 append 예정.
+- **오늘 적용한 SKILL**: code-modification (전 에이전트), pr-workflow (L5 PR-then-merge), pre-deploy-playbook (qa 진행 중), ui-regression (qa 준비), layered-architecture-enforcer (Issue #47 service layer 국한), simplify (SEC-A 후 검토).
+- **agent isolation=worktree 운영** — 같은 에이전트 유형(go-dev) 을 2개 병렬 띄울 때 worktree 분리. 머지 후 `git worktree unlock` + `remove` 정리 절차 필수.
+- **Docker Desktop 기동 이슈** — WSL 에서 `powershell.exe Start-Process` 로 직접 기동 가능. 다음엔 시도 예정 (사용자 지적).
+- **보안 변화 총평**: Day 1(Day 12) 은 플레이어 경험 P0 (FINDING-01) 중심이었다면, Day 2(Day 13) 은 **인프라·보안 기반 강화의 날**. Go 1년치 + Next.js 3 minor + npm audit + Sprint 6 이월 3건 정리까지 한 번에 올라갔다. Critical/High 잔존 = 0 상태로 Sprint 7 Week 1 에 들어감.
+
+---
+
+## (qa 완료 시 append 예정)
+
+### Playwright 전수 재실행 결과
+- 전체 테스트 수 / PASS / FAIL / SKIP 분포
+- FINDING-02 해소 증명 (day11-ui-bug-fixes.spec.ts 결과)
+- SEC-B 회귀 여부
+- NEW FAIL 건수 + 카테고리
+- 최종 판정 GO / HOLD
+
+### 회귀 보고서 참조
+- `docs/04-testing/77-day2-regression-report.md`

--- a/work_logs/plans/2026-04-23-day3-prep-plan.md
+++ b/work_logs/plans/2026-04-23-day3-prep-plan.md
@@ -1,0 +1,164 @@
+# Plan — Day 3 (2026-04-24) Sprint 7 Week 1+Week 2 몰아 완주
+
+## Context
+
+사용자 결정: **"내일 하루에 모두 끝내버리죠"** — Sprint 7 Week 1 잔여 + Week 2 대부분을 하루에 몰아 처리.
+
+오늘 Day 2 가 architect 사전 분석(`75-*.md`, `76-*.md`) 덕에 ~1.5h 에 5 PR 완주. 동일 패턴으로 내일 대비 **저녁 세션에 architect × 5 + pm × 1 을 병렬 투입해 사전 분석 문서 6건을 방금 완성**했다. 이 plan 은 그 위에 얹는 실행 승인 요청서이다.
+
+**적용 범위**: Day 3 (2026-04-24) 하루.
+**제외**: next-auth v5 이주 (Sprint 8), DashScope API 키 발급(사용자 액션, 0 SP).
+
+---
+
+## Prerequisite — 오늘 밤 완성된 사전 분석 6문서
+
+| 문서 | 대상 | 판정 | 핵심 발견 |
+|------|------|------|-----------|
+| `docs/04-testing/80-ci-cd-audit-jobs-impact.md` (621줄) | **A** CI/CD 감사 잡 3건 | PROCEED | `quality` 스테이지 배치, pipeline 순증 0m |
+| `docs/02-design/49-v13a-v13e-refactor.md` (451줄) | **B** V-13a + **D** V-13e | PROCEED | V-13a 옵션 A (유지+호출 추가), V-13e `removeRecoveredJoker` 호출 지점 추가 |
+| `docs/04-testing/79-dev-only-deps-impact.md` (458줄) | **C** dev-only deps 3건 | **D3-A PROCEED + D3-B PROCEED + D3-C HOLD** | jest-env-jsdom 30.3 이 jest 30 동반 bump 요구 → Option C2 WONTFIX + Sprint 8 이관 권장 |
+| `docs/02-design/51-nestjs-v11-migration.md` (350줄) | **E** @nestjs/core v11 | PROCEED with gates | MED risk 재평가 (rxjs/WS/Microservices 미사용). Jest 599 유지 확신도 85% |
+| `docs/02-design/50-d03-phase2-cutover-plan.md` (430줄) | **H** D-03 Phase 2a shadow read | **HIGH risk, Phase 2a 한정** | **DeleteRoom dual-write 누락 발견** → IS-PH2A-01 선수정 필수. Phase 2b/2c 는 48h 관찰 후 Week 2 후반 |
+| `docs/01-planning/day3-execution-plan.md` (280줄) | 전체 시간표 | S/A/B 3단 기준 | A (30~35 SP) 공식 목표. 번아웃 방지선 B (20~25 SP) |
+
+---
+
+## Execution Order (pm day3-execution-plan.md 기반)
+
+### 오전 09:00~13:00 — LOW risk 독립 4트랙 병렬
+
+| 트랙 | 작업 | 담당 | 예상 |
+|------|------|------|------|
+| A | CI/CD 감사 잡 3건 (`sca-npm-audit` + `sca-govulncheck` + `weekly-dep-audit`) | devops + go-dev | 180m |
+| B | V-13a `ErrNoRearrangePerm` 호출 경로 추가 | go-dev | 120m |
+| C | dev-only deps 2건 (`@typescript-eslint` + `@nestjs/cli`) ※ jest-env-jsdom 은 HOLD | node-dev | 150m |
+| D | V-13e 조커 재드래그 UX + `removeRecoveredJoker` 호출 | frontend-dev | 240m |
+| I | PostgreSQL 001 마이그 staging dry-run | devops | 60m (11:00~) |
+
+### 점심 13:00~14:00 (필수 60m 휴식)
+
+### 오후 14:00~18:00 — MED risk + 여유분
+
+| 트랙 | 작업 | 담당 | 예상 |
+|------|------|------|------|
+| E | @nestjs/core v11 + file-type transitive bump | node-dev | 150m |
+| F | FORFEIT 경로 완결성 점검 (#47 후속) | go-dev | 120m |
+| G | Istio DestinationRule 세밀 조정 (여유분) | devops | 60m |
+| merge | 오후 PR 일괄 머지 + K8s smoke | Claude main | 60m |
+
+### 저녁 18:30~20:00 — HIGH risk + 최종 검증
+
+| 트랙 | 작업 | 담당 | 예상 |
+|------|------|------|------|
+| IS-PH2A-01 | DeleteRoom dual-write 누락 선수정 (H 선수) | go-dev | 30m |
+| H | D-03 Phase 2a shadow read 구현 + ConfigMap + rollout | go-dev + devops | 75m |
+| J | Playwright 전수 + 회귀 보고서 81 | qa | 60m (병렬) |
+
+---
+
+## Critical Files — 작업별 수정 대상
+
+### A (CI/CD 감사 잡)
+- `.gitlab-ci.yml` L659줄 파일의 `quality` 스테이지에 3 job 추가
+- 기존 anchor (`*local-runner`, 캐시) 재사용
+
+### B (V-13a)
+- `src/game-server/internal/engine/validator.go` L100-131 `validateInitialMeld`
+- 분기 추가: before 테이블 감소 검출 → `newValidationError(ErrNoRearrangePerm, ...)`
+- 상수는 `src/game-server/internal/engine/errors.go:52,79` 이미 존재 (호출만 추가)
+- 테스트 신규 2건 `validator_test.go`
+
+### C (dev-only deps, jest-env-jsdom 제외)
+- `src/ai-adapter/package.json` — `@typescript-eslint/*` 7.6+ + `@nestjs/cli` 11.1+
+- `src/ai-adapter/package-lock.json` 재생성
+- eslint peer ^8.57 동반 bump (79 §D3-A 발견)
+- **제외**: `jest-environment-jsdom` — 사용자 결정 대기 (WONTFIX Sprint 8 권장)
+
+### D (V-13e)
+- `src/frontend/src/app/game/[roomId]/GameClient.tsx` handleDragEnd 3개 분기
+- `src/frontend/src/store/gameStore.ts` — `removeRecoveredJoker` 는 이미 정의됨, 호출만 추가
+- Playwright 신규 SC4/SC5 2건
+
+### E (@nestjs/core v11)
+- `src/ai-adapter/package.json` — `@nestjs/common`, `@nestjs/config`, `@nestjs/core`, `@nestjs/platform-express` 동반
+- `src/ai-adapter/src/guards/rate-limit.guard.ts` `canActivate` 시그니처 재확인 (throttler v6 peer)
+- Jest 599 회귀 1건이라도 발견 시 **즉시 revert**
+
+### F (FORFEIT 경로)
+- `src/game-server/internal/service/room_service.go` FORFEIT 진입 경로 감사
+- `src/game-server/internal/handler/ws_handler.go` broadcastGameOver 연계
+- 보고서 + (필요 시) 수정 PR
+
+### H (D-03 Phase 2a shadow read) + IS-PH2A-01
+- **선수정**: `src/game-server/internal/service/room_service.go:413-424` DeleteRoom dual-write 추가
+- Shadow read: 같은 파일의 `GetRoom` 에 goroutine + 500ms timeout PostgreSQL 조회
+- `helm/charts/game-server/values.yaml` + ConfigMap 에 `D03_PHASE2_SHADOW_READ=false` 기본값
+- 메트릭: `rooms_shadow_read_consistency` gauge, `rooms_shadow_read_drift_total` counter
+- Roll-back: env 한 줄 변경 + rollout (30s)
+
+---
+
+## Reused Patterns (Day 2 에서 검증됨)
+
+- **Agent isolation=worktree**: 같은 에이전트(go-dev)를 병렬 띄울 때 worktree 격리. 머지 후 `git worktree unlock` + `remove` 정리 필수.
+- **kubectl 경로**: `/mnt/c/Program Files/Docker/Docker/resources/bin/kubectl.exe`
+- **Docker 이미지 태그**: `day3-2026-04-24` (latest 금지)
+- **K8s set image**: `kubectl set image deployment/<svc> <container>=<image>:<tag> -n rummikub` + `rollout status --timeout=3m`
+- **rooms dual-write 로그 확인**: `kubectl logs -l app=game-server | grep "rooms dual-write"` (Phase 1 회귀 방지)
+- **code-modification SKILL** 4단계 + **pr-workflow SKILL** PR-then-merge
+- `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` 커밋 라인
+
+---
+
+## Key Decisions Needed — 사용자 판단 필요 (AskUserQuestion)
+
+1. **C (dev-only D3-C jest-env-jsdom)**: Option C2 **WONTFIX + Sprint 8 이관** 확정할지? (dev-only low × 4, production 안전)
+2. **H (D-03 Phase 2a)**: 내일 저녁 1.25h 박스에 **진짜 착수**? 아니면 Week 2 로 이관 (더 보수적)?
+3. **IS-PH2A-01 DeleteRoom dual-write 선수정**: H 착수 전 선수정으로 처리 OK? (자동 포함 권장)
+4. **목표 SP**: **A (30~35 SP, 공식 목표)** vs **B (20~25 SP, 번아웃 방지선)**?
+
+---
+
+## Verification — 내일 종료 전 체크리스트
+
+1. **go test** `cd src/game-server && go test ./... -count=1 -timeout 120s` — **535+ PASS** (B +2 + H +2)
+2. **Jest ai-adapter** `cd src/ai-adapter && npm test` — **599/599 유지** (E 게이트)
+3. **Jest frontend** `cd src/frontend && npm test` — **205+ PASS** (D +2)
+4. **Playwright 전수** `cd src/frontend && npx playwright test` — 376+ PASS / 4 KNOWN FAIL, **신규 FAIL 0**
+5. **govulncheck** `cd src/game-server && govulncheck -mode=source ./...` — code-called 0건 유지
+6. **npm audit production** 3프로젝트 모두 `--audit-level=high --omit=dev` exit 0
+7. **K8s smoke** frontend NodePort 30000 + game-server `/health` + ai-adapter `/health`
+8. **rooms dual-write 로그** 확인 + **DeleteRoom** 후 PG row 삭제 확인 (IS-PH2A-01 검증)
+9. **D03_PHASE2_SHADOW_READ=false** 기본 OFF 확인 (수동 on 시 drift 로그 + gauge 정상)
+10. **회귀 보고서 81** 작성 (`docs/04-testing/81-day3-regression-report.md`)
+
+---
+
+## Rollback Plan
+
+| 작업 | 롤백 방법 | 소요 |
+|------|-----------|------|
+| A CI/CD 잡 | `.gitlab-ci.yml` revert | 5m |
+| B/D/F | PR revert | 5m |
+| C dev-only | lockfile revert | 5m |
+| E nestjs v11 | 이미지 tag `ai-adapter:day2-2026-04-23` 복귀 | 2m |
+| H Phase 2a | `D03_PHASE2_SHADOW_READ=false` env + rollout | 30s |
+| IS-PH2A-01 | DeleteRoom 코드 revert | 5m |
+
+---
+
+## Exit Conditions (내일 종료 판단)
+
+- **GREEN (A 목표)**: Week 1 완주 + Week 2 3~4건 머지 + Phase 2a shadow read 관찰 시작. 회귀 0.
+- **YELLOW (B 방어)**: Week 1 완주만. Week 2 이월. 회귀 0~1 (허용).
+- **RED (revert)**: Jest/go test 회귀 2건 이상 또는 Playwright 신규 FAIL 3건 이상 → 해당 PR revert + Day 4 복구.
+
+---
+
+## 변경 규모 예상
+
+- PR 머지: 6~9건 (A 기준)
+- 신규 문서: 81 (회귀) + Day 3 데일리 + Day 3 마감 스탠드업 + 바이브 로그
+- Critical/High 보안 잔존: **0 유지**
+- D-03 Phase 2 진행도: Phase 1 → Phase 2a (shadow read) — Phase 2b/2c 는 48h 관찰 후 결정

--- a/work_logs/scrums/2026-04-23-01.md
+++ b/work_logs/scrums/2026-04-23-01.md
@@ -1,0 +1,117 @@
+# 스크럼 미팅 로그 — Sprint 7 Day 2 데일리 스탠드업 (전원 참석)
+
+- **날짜**: 2026-04-23 (Thu)
+- **Sprint**: Sprint 7 — Day 2 (전체 Day 13)
+- **회차**: 01 (오늘 첫 스크럼)
+- **참석자**: 애벌레 (PO) + Claude main (Opus 4.7 xhigh) + **에이전트 10명 전원**
+  - 추론·전략 (Opus 4.7 xhigh): pm, architect, security, qa, ai-engineer
+  - 구현·설정 (Sonnet 4.6): go-dev, node-dev, frontend-dev, devops, designer
+
+---
+
+## 각자 공유 (3가지)
+
+### 애벌레 (PO)
+- **어제 (Day 12)**: 심야 실측(00:45~02:10)에서 I-18/I-19 발견 → 3-agent 재검토 지시. PR #37~#39 먼저 머지 후 "리밋 해제"로 세션 재개 → rooms PostgreSQL 옵션 B 채택, Agent Teams 7명 병렬 투입. L5→L6 Scope 전환으로 PR #50~#52 자동 머지 권한 부여. 총 **13 PR 머지**, Issue 6건 관리.
+- **오늘 (Day 2)**: Day 12 P0 이미 해결됨 확인 → Sprint 7 Day 2 P1 6건 병렬 구현 지시. SEC 패치 (Go/Next/admin) + Issue #47/#48/#49 구현 일괄 처리. worktree 분할 전략 확인.
+- **블로커**: 전원 참석 스탠드업 요청 — 10명 에이전트의 어제/오늘/블로커 공식 트래킹 필요.
+
+### Claude main (Opus 4.7 xhigh)
+- **어제**: (같은 세션) Day 12 8 PR + 3 ADR 연속 머지, architect 4회 투입, FINDING-01 3단계 추적 해소, rebase 1건.
+- **오늘**: Day 2 킥오프 — `docs/04-testing/75/76` 읽고 worktree 3갈래 분할. (1) go-dev + devops 공동 worktree: SEC-A + Issue #47, (2) frontend-dev 단독 worktree: SEC-BC + Issue #48, (3) qa + frontend-dev 공동 worktree: Issue #49. security 감사 병렬, pm 진행률 트래킹. 구현 우선순위: SEC-A(LOW) → #47/#48 → SEC-BC(MEDIUM) → #49.
+- **블로커**: 없음. MEMORY.md 232줄 초과 구조화는 세션 중후반 여유 시 처리.
+
+### pm (Opus 4.7)
+- **어제**: Issue #43 (I-17) rooms 전환 결정 문서화, PR #38 description 정정(StartGame TODO → I-17 재분류), `docs/01-planning/sprint7-decisions.md` 신설 (54줄), PR #44 머지.
+- **오늘**: Sprint 7 Week 1 진행률 보드 업데이트 — SEC-A/B/C + Issue #47/#48/#49 6건 실시간 추적. PR 설명 일관성 점검 (Conventional Commit). 백로그 우선순위 재정렬: V-13a/V-13e 를 Day 3 이후 배치. Day 12 P0 해결분 반영해 Sprint 7 번다운 차트 +6h 여유 공시.
+- **블로커**: 없음.
+
+### architect (Opus 4.7)
+- **어제**: 4회 투입 — ADR D-03 rooms Phase 1 Dual-Write (445줄), PR #41/#42 회귀 테스트 계획 71 (431줄), FINDING-01 근본 분석 73 (367줄), WARN triage 74 + SEC-REV-013 + Day12 75 + Issue 47-49 영향도 76.
+- **오늘**: Day 2 병렬 구현 기간에는 **설계 의사결정 lookup 대기**. frontend-dev 가 Issue #48 에서 useEffect 의존성 판정 필요 시 즉시 컨설팅. V-13a `ErrNoRearrangePerm` orphan refactor 예비 분석 (Week 1 후순위). D-03 Phase 2 (read path cutover) 사전 초안 검토 시작 — rooms → games FK 방향 유지 여부.
+- **블로커**: 없음.
+
+### go-dev (Sonnet 4.6)
+- **어제**: D-03 Phase 1 Dual-Write 구현 — `room_converter.go` 신규 + `NewRoomService` 3-arg + 17 call-site 마이그레이션 + persistGameResult roomID wire + 단위 테스트 5건. 전체 **530/530 PASS**, 3 커밋 push (PR #42 머지).
+- **오늘**: **SEC-A + Issue #47 worktree 공동 작업** (with devops). (1) SEC-A: `go.mod` toolchain go1.25.9 + `go-redis/v9` 9.7.3 bump, `go test ./...` + `go vet ./...` + `govulncheck` 전수 통과 확인. (2) Issue #47: `LeaveRoom` 에 PLAYING 상태 guard 추가 (`ErrRoomPlaying` 신규) + 단위 테스트 2건 + integration 1건. 예상 wall-clock 3.5h.
+- **블로커**: devops 측 CI 이미지(golang:1.25.9-alpine) 교체 동기화 필요.
+
+### node-dev (Sonnet 4.6)
+- **어제**: 직접 참여 없음 (ai-adapter 428/428 유지, Day 12 는 game-server + frontend 중심).
+- **오늘**: ai-adapter **유지보수 대기** 및 Sprint 7 Week 1 백로그 점검. `package.json` 의존성 현황 스캔 — NestJS 11.x / axios / openai SDK 최신 릴리스 delta 정리. Round 6 Phase 3 준비 시 v2 baseline 확정 상태 재확인 (`USE_V2_PROMPT=true` 의도적 고정, docs/02-design/42 §2). Claude / DeepSeek 어댑터 Thinking Budget 노브 현황 재문서화 (코드 그대로, 문서만).
+- **블로커**: ai-engineer 측 Round 6 실행 여부 결정 (Week 2 후보) — 결정 전까지 코드 변경 금지.
+
+### frontend-dev (Sonnet 4.6)
+- **어제**: 2회 투입 — PR #41 (I-18 I-2 롤백 + I-19 조커 데드락, 불완전), PR #51 (FINDING-01 완전 롤백 `targetServerGroup && !hasInitialMeld` early-return + K8s 재배포), PR #50 WARN-03 `addRecoveredJoker` guard + Jest 2건.
+- **오늘**: **단독 worktree 1건 + 공동 worktree 1건**. (1) SEC-BC: Next 15.5.15 + admin 16.2.4 bump + `npm audit fix` (lockfile 충돌 방지 위해 SEC-B/C 같은 브랜치). Playwright 전수 재실행 전제. (2) Issue #48: `handleConfirm` 에 `confirmBusy` state 추가로 더블클릭/레이스 차단 (useEffect 의존성 주의 — architect 컨설팅 대기 가능). (3) Issue #49: qa 와 공동 — PracticeBoard test fixture 수정 (Option A+C, ~30 LOC) 구현 부분. 예상 wall-clock 4.5h.
+- **블로커**: SEC-B Next.js 메이저 bump 이후 Playwright 회귀 1~2건 가능성 → qa 의 회귀 재실행 슬롯 필요.
+
+### devops (Sonnet 4.6)
+- **어제**: `rummiarena/game-server:phase1-smoke` 빌드 + K8s rollout + `verify-rooms-persistence.sh` **5/5 PASS**. `rooms dual-write enabled (D-03 Phase 1)` 로그 확인. games.room_id NOT NULL 전수 확인 (PR #38 nil 우회 해소).
+- **오늘**: (1) SEC-A 지원 — CI 이미지 `golang:1.25.9-alpine` 으로 교체, GitLab CI `.gitlab-ci.yml` lint-go/test-go job 동기화. (2) SEC-BC 머지 후 frontend/admin 이미지 재빌드 + K8s rollout. (3) Kaniko 캐시 무효화 여부 판단 (base image 교체 = 전체 캐시 미스 수용). (4) rooms Phase 2 준비 — PostgreSQL 001 마이그레이션 staging dry-run 일정 조율 (애벌레 결정 대기).
+- **블로커**: argocd-repo-server 간헐 Error (Minor, 워치만 유지).
+
+### qa (Opus 4.7)
+- **어제**: PR #45 회귀 테스트 세션 — Jest 199/199, 신규 Playwright 7/7, hotfix-p0-i2 **SC1/SC2 REAL FAIL** (FINDING-01 발견). pre-deploy-playbook 6 PASS + 3 skip. DB 실측 16건 games.room_id NOT NULL. 보고서 72 (334줄).
+- **오늘**: (1) SEC-A 머지 후 game-server 테스트 530/530 재확인. (2) SEC-BC 머지 후 **Playwright 전수 재실행** (MEDIUM risk, 반드시 진행) + FINDING-02 수정 검증. (3) Issue #49 Option A+C 리뷰 — fixture 변경이 다른 테스트 영향 주는지 검증. (4) Day 2 종료 시 회귀 보고서 77 (예정) 작성.
+- **블로커**: SEC-BC 머지 타이밍 조율 필요 — 너무 늦으면 Playwright 실행 시간(약 25분) 여유 부족.
+
+### security (Opus 4.7)
+- **어제**: 직접 참여 없음 — Day 12 SEC 영향도 평가는 architect 가 `docs/04-testing/75-*.md` 에서 통합 처리.
+- **오늘**: **병렬 감사 3건**. (1) SEC-A Go/go-redis CVE mapping 재확인 (GHSA 레퍼런스 + `govulncheck` 크로스체크). (2) SEC-B Next.js 15.5.15 CVE delta (SSRF / cache poisoning 관련 변경) 리뷰. (3) SEC-C npm audit 결과 분석 — 실제로 적용되는 transitive dep 목록 + false positive 분류. 추가로 SEC-REV-002/008/009 (Sprint 6 이월 Medium) 현황 재점검 예정.
+- **블로커**: 없음.
+
+### ai-engineer (Opus 4.7)
+- **어제**: 직접 참여 없음 — v6 Kill 결정으로 Round 6 Phase 3 대기 상태.
+- **오늘**: **대기 + 준비**. (1) `docs/02-design/42-prompt-variant-standard.md` §2 표 B 상태 재확인 — `USE_V2_PROMPT=true` per-model override 레지스트리 최신성. (2) Round 6 Phase 3 대조군 v2 baseline 확정 근거 복습 (`docs/04-testing/57` + `docs/03-development/17` 부록 A). (3) 다른 모델 비교 재실험 (Claude/GPT "28% 천장" 재현성) 실험 설계 초안 — Sprint 8 후보로 pm 과 협의. 코드 변경 **없음** (prompt variant SSOT 유지).
+- **블로커**: DashScope 실제 API 키 발급 대기 (production 활성화 전제, Sprint 7 준비 항목).
+
+### designer (Sonnet 4.6)
+- **어제**: 직접 참여 없음.
+- **오늘**: **대기**. Sprint 7 Week 1 은 backend SEC + guard 중심 → UI/UX 변경 없음. V-13e (조커 재드래그 UX, Week 1 후순위) 착수 시점 알림 대기. 여유 시간에 대시보드 컴포넌트 스펙 (Sprint 5 Day 7 산출물 `docs/02-design/33`) 재독 + Sprint 8 admin 방 관리 화면 초안 스케치 검토.
+- **블로커**: 없음 (대기).
+
+---
+
+## 논의 사항
+
+1. **worktree 3갈래 병렬 전략** — (A) go-dev + devops: SEC-A + Issue #47, (B) frontend-dev: SEC-BC + Issue #48, (C) qa + frontend-dev: Issue #49. 중간 rebase 충돌 회피 위해 SEC-A 먼저 완주 → SEC-BC → Issue 3건 순서. frontend-dev 는 SEC-BC 와 #48 를 같은 브랜치에서 하지 않음 (리뷰 단위 분리).
+2. **SEC-BC 머지 타이밍** — qa Playwright 전수 재실행(25분) 슬롯 확보 위해 **15:00 이전** 머지 목표. 이후에는 Day 2 종료 내 회귀 검증 불가능.
+3. **Issue #48 useEffect 의존성** — frontend-dev 작업 중 의존성 배열 판정 애매한 경우 즉시 architect 호출. 지난 I-18 불완전 롤백 사례(PR #41 → PR #51)를 반복하지 않음.
+4. **Day 12 P0 해결분 반영** — Sprint 7 번다운에 +6h 여유 반영. V-13a/V-13e 를 Day 3~4 에 앞당길지는 Day 2 종료 시점에 pm 이 재판단.
+5. **전원 참석 스탠드업의 기본 포맷** — 오늘부로 Sprint 7 은 데일리 전원 스탠드업으로 전환. 미참여 에이전트도 "대기" 상태 공식 기록 (node-dev, ai-engineer, designer).
+6. **Round 6 Phase 3 실행 여부** — Week 2 결정 사안. ai-engineer 가 실험 설계만 준비, pm 과 비용/시간 협의 후 결정.
+
+---
+
+## 액션 아이템
+
+| 담당 | 할 일 | 기한 |
+|------|-------|------|
+| go-dev + devops | SEC-A Go 1.25.9 + go-redis 9.7.3 bump + CI 이미지 교체 (LOW risk, 1.5h) | Day 2 오전 |
+| go-dev | Issue #47 LeaveRoom PLAYING guard + `ErrRoomPlaying` + 테스트 3건 (2h) | Day 2 오전 |
+| frontend-dev | Issue #48 `handleConfirm` `confirmBusy` state (1h, useEffect 의존성 주의) | Day 2 오전 |
+| frontend-dev | SEC-B Next 15.5.15 + SEC-C npm audit fix 같은 브랜치 (MEDIUM, 2.5h) | Day 2 오후 15:00 전 |
+| qa | SEC-BC 머지 후 Playwright 전수 재실행 (25분) + FINDING-02 검증 | Day 2 오후 |
+| frontend-dev + qa | Issue #49 FINDING-02 test fixture Option A+C (~30 LOC, 1.5h) | Day 2 오후 |
+| security | SEC-A/B/C CVE delta 감사 + SEC-REV-002/008/009 현황 재점검 | Day 2 병렬 |
+| architect | frontend-dev useEffect 의존성 컨설팅 대기 + V-13a 예비 분석 | Day 2 lookup |
+| pm | Sprint 7 번다운 +6h 여유 반영 + Day 2 실시간 추적 + 종료 시 리포트 | Day 2 종일 |
+| devops | SEC-BC 머지 후 frontend/admin 이미지 재빌드 + K8s rollout | Day 2 오후 |
+| qa | Day 2 종료 회귀 보고서 77 작성 | Day 2 종료 |
+| node-dev | ai-adapter 유지보수 대기 + Round 6 준비 상태 점검 | Day 2 병렬 |
+| ai-engineer | Round 6 Phase 3 대조군 재확인 + Sprint 8 재실험 설계 초안 | Day 2 병렬 |
+| designer | V-13e 착수 시점 알림 대기 + Sprint 8 admin 초안 검토 | 대기 |
+| Claude main | MEMORY.md 232줄 구조화 (여유 시) + Day 2 종료 시 데일리 마감 | Day 2 종료 |
+
+---
+
+## 메모
+
+- **Day 2 목표**: SEC 3건 + Issue 3건 = **총 6 PR 머지**. 예상 wall-clock ~5h (병렬 worktree 기준).
+- **우선순위 게이트**: SEC-A (LOW, blocker 없음) → Issue #47/#48 (간단, 독립) → SEC-BC (MEDIUM, 회귀 필요) → Issue #49 (test fixture).
+- **전원 참석 이유**: Sprint 7 착수 확증 — 모든 에이전트 상태 공식 트래킹 (대기 상태 포함). 이전에는 투입 에이전트만 기록했으나 오늘부터 전체 가용성 공시.
+- **모델 배치 원칙 재확인**: 추론·전략 5명 (pm/architect/security/qa/ai-engineer) = Opus 4.7 xhigh, 구현·설정 5명 (go-dev/node-dev/frontend-dev/devops/designer) = Sonnet 4.6. `docs/CLAUDE.md` §Agent Model Policy.
+- **리스크 관리**: SEC-B Next 메이저 bump 가 가장 큰 리스크 → frontend-dev 단독 브랜치 + qa Playwright 전수 재실행 게이트. 실패 시 SEC-B 단독 revert 가능하도록 Issue #48 과 분리.
+- **오늘 확정 SKILL 활용**: code-modification (전 에이전트), pr-workflow (L5/L6 명시), pre-deploy-playbook (qa), ui-regression (frontend-dev + qa), simplify (go-dev SEC-A 후 검토).
+- **Day 12 교훈 지속 적용**: 내부 약어 풀어쓰기, Auto mode 에서 Phase 0 기계 적용 금지, 이전 PR 패턴 default 유지.


### PR DESCRIPTION
## Summary
Day 2 저녁 세션 Agent Teams (pm-sprint7, architect-docs, qa-day2) + main 작성 문서 **12건 일괄 커밋**.

## Sprint 7 Scope 재편 (사용자 지시 2026-04-23)
- 이관/WONTFIX/Sprint 8 후보/Week 2 이월 표현 **금지**
- dev-only low 도 Production 기준 해소
- next-auth v5 이주 Sprint 7 편입 (uuid<14 해소)
- UI 수정 **architect + frontend-dev 페어 의무**
- 프로그램 외 내일까지 완료, 프로그램은 오류 0 까지 반복

## 포함 문서

### 기획·집행 (1)
- `docs/01-planning/day3-execution-plan.md` (421줄)

### 설계·ADR (4)
- `docs/02-design/49-v13a-v13e-refactor.md` — V-13a + V-13e Pair Coding Spec
- `docs/02-design/50-d03-phase2-cutover-plan.md` — D-03 Phase 2 전체
- `docs/02-design/51-nestjs-v11-migration.md` — nestjs v11 영향도
- `docs/02-design/52-adr-next-auth-v5-migration.md` — next-auth v5 이주 ADR

### 기술 가이드 (1)
- `docs/03-development/19-next-auth-guide.md`

### 영향도 분석 (3)
- `docs/04-testing/78-sec-a-b-c-audit-delta.md` — SEC-A/B/C 감사 + SEC-REV-002/008/009 종결
- `docs/04-testing/79-dev-only-deps-impact.md`
- `docs/04-testing/80-ci-cd-audit-jobs-impact.md`

### Work logs (3)
- `work_logs/daily/2026-04-23.md`
- `work_logs/scrums/2026-04-23-01.md`
- `work_logs/plans/2026-04-23-day3-prep-plan.md`

## 제외 (후속 PR)
- `docs/01-planning/sprint7-decisions.md` — pm-sprint7 재작성 중 (reset 사고 복구)
- qa Playwright 77 회귀 보고서 — qa-day2 진행 중

## Test plan
- [x] 코드 변경 0. docs only
- [x] 기존 .md 파일명 규칙 준수 (YYYY-MM-DD 또는 번호 prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)