### PR TITLE
infra(istio): DestinationRule game-server 방향 추가 + outlier 튜닝

### DIFF
--- a/docs/02-design/20-istio-selective-mesh-design.md
+++ b/docs/02-design/20-istio-selective-mesh-design.md
@@ -874,9 +874,33 @@ Istio 관련 K8s 매니페스트는 아래 구조로 관리한다.
 istio/
   peer-authentication-default.yaml       # PERMISSIVE (namespace 기본)
   peer-authentication-ai-adapter.yaml    # STRICT (ai-adapter 전용)
-  destination-rule-ai-adapter.yaml       # 서킷 브레이커 + 연결 풀
+  destination-rule-ai-adapter.yaml       # 서킷 브레이커 + 연결 풀 (outlier 튜닝: 2026-04-23)
+  destination-rule-game-server.yaml      # game-server 내부 트래픽 DR (신규: 2026-04-23)
   virtual-service-ai-adapter.yaml        # 타임아웃 + 재시도
 ```
+
+### 13.1 game-server DR 설계 요약 (2026-04-23 신규)
+
+| 항목 | 값 | 비고 |
+|------|-----|------|
+| host | `game-server.rummikub.svc.cluster.local` | mesh 내부 접근 대상 |
+| h2UpgradePolicy | `DO_NOT_UPGRADE` | WebSocket 장기 연결 지원 |
+| http1MaxPendingRequests | 50 | WS + REST 혼합 트래픽 |
+| maxRequestsPerConnection | 0 | WS 장기 연결 무제한 |
+| tcp.maxConnections | 100 | Traefik + mesh 내부 복합 |
+| consecutive5xxErrors | 5 | ai-adapter(3) 보다 완화 |
+| interval | 30s | |
+| baseEjectionTime | 60s | ai-adapter(120s) 보다 짧게 |
+| tls.mode | `ISTIO_MUTUAL` | mesh 내부 mTLS 적용 |
+
+### 13.2 ai-adapter DR outlierDetection 튜닝 (2026-04-23)
+
+| 항목 | 이전 | 변경 후 | 근거 |
+|------|------|---------|------|
+| interval | 30s | 60s | LLM 응답 최대 700s — 30s 간격은 false eject 위험 |
+| baseEjectionTime | 30s | 120s | 짧은 eject 후 재실패 → flapping 방지 |
+| splitExternalLocalOriginErrors | (없음) | true | 외부 LLM 에러 / 내부 네트워크 에러 분리 추적 |
+| consecutiveLocalOriginFailures | (없음) | 5 | 내부 에러 임계값 별도 설정 |
 
 ---
 

--- a/istio/destination-rule-ai-adapter.yaml
+++ b/istio/destination-rule-ai-adapter.yaml
@@ -1,6 +1,18 @@
 # Istio DestinationRule -- ai-adapter 서킷 브레이커 + 연결 풀
 # game-server -> ai-adapter 구간에 적용
 # 설계 근거: docs/02-design/20-istio-selective-mesh-design.md Section 4.5
+#
+# 변경 이력:
+#   2026-04-23 (Sprint 7 Day 2): outlierDetection 미세조정
+#     - consecutive5xxErrors: 3 (유지 — LLM 장애 빠른 감지)
+#     - interval: 30s → 60s (LLM 호출이 최대 700s 소요. 30s 간격은 너무 짧아
+#       정상 LLM 응답 중 false eject 위험. 60s 로 완화.)
+#     - baseEjectionTime: 30s → 120s (LLM vendor 회복에 120s 여유 부여.
+#       30s 에서 재시도 → 또 실패 → 불필요한 서킷 flapping 방지)
+#     - splitExternalLocalOriginErrors: true 추가 (외부 LLM 에러와
+#       내부 네트워크 에러를 분리 추적. 로그 노이즈 감소)
+#     - consecutiveLocalOriginFailures: 5 (내부 네트워크 에러 임계값 별도 설정)
+#   2026-03-XX (초기): consecutive5xxErrors=3, interval=30s, baseEjectionTime=30s
 ---
 apiVersion: networking.istio.io/v1
 kind: DestinationRule
@@ -19,11 +31,21 @@ spec:
         maxConnections: 50
         connectTimeout: 10s
     outlierDetection:
-      # 연속 5xx 에러 3회 시 서킷 오픈
+      # LLM 호출 실패 5xx 3회 연속 시 서킷 오픈 (임계값 유지)
+      # 근거: 3회면 정상적인 LLM 재시도(max 3회) 소진 + 추가 실패를 의미 → 빠른 차단 적절
       consecutive5xxErrors: 3
-      interval: 30s
-      baseEjectionTime: 30s
+      # interval 30s → 60s: LLM 응답이 최대 700s 이므로 30s 스캔은 너무 빈번.
+      # 60s 스캔으로 false eject(정상 응답 처리 중 임시 5xx) 위험 감소.
+      interval: 60s
+      # baseEjectionTime 30s → 120s: LLM vendor 회복에 120s 여유.
+      # 짧은 eject 후 재시도 → 재실패 → flapping 방지.
+      baseEjectionTime: 120s
       # Pod 1개이므로 100% (전체 차단 후 복구 대기)
       maxEjectionPercent: 100
+      # 외부(LLM vendor) 에러와 내부(네트워크) 에러 분리 추적
+      # splitExternalLocalOriginErrors: true 시 consecutive5xxErrors 는 외부 HTTP 에러만 카운트
+      # consecutiveLocalOriginFailures 는 TCP 연결 실패/타임아웃 등 내부 에러 카운트
+      splitExternalLocalOriginErrors: true
+      consecutiveLocalOriginFailures: 5   # 내부 네트워크 에러 임계값 (별도 추적)
     tls:
       mode: ISTIO_MUTUAL

--- a/istio/destination-rule-game-server.yaml
+++ b/istio/destination-rule-game-server.yaml
@@ -1,0 +1,48 @@
+# Istio DestinationRule -- game-server 내부 트래픽 정책
+#
+# 목적:
+#   Traefik -> game-server 구간은 mesh 외부(PERMISSIVE) 이나,
+#   향후 mesh 내부(예: admin -> game-server) 트래픽에 대해
+#   mTLS + outlierDetection 을 선제적으로 설정한다.
+#
+# 현재 구성 (2026-04-23):
+#   - Traefik(외부) -> game-server: PERMISSIVE (PeerAuth default 정책)
+#   - mesh 내 서비스 -> game-server: ISTIO_MUTUAL (mTLS 적용)
+#   - outlierDetection: 연속 5xx 5회 → 60s eject (ai-adapter 보다 완화)
+#
+# 설계 근거:
+#   docs/02-design/20-istio-selective-mesh-design.md §8.2
+#   game-server 는 Traefik 을 통한 외부 접근이 주 경로이므로
+#   ai-adapter 처럼 strict 서킷 브레이커가 필요하지 않다.
+#   consecutive5xxErrors=5 (ai-adapter 의 3 보다 완화) + baseEjectionTime=60s.
+#
+# 참조 이슈: Sprint 7 Day 2 infra/istio-dr-tuning
+# 갱신일: 2026-04-23
+---
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: game-server
+  namespace: rummikub
+spec:
+  host: game-server.rummikub.svc.cluster.local
+  trafficPolicy:
+    connectionPool:
+      http:
+        h2UpgradePolicy: DO_NOT_UPGRADE   # game-server 는 HTTP/1.1 WebSocket 사용
+        http1MaxPendingRequests: 50        # WS 연결 + REST 혼합. ai-adapter(20) 보다 넉넉하게
+        maxRequestsPerConnection: 0        # WS 장기 연결 허용 (0 = 제한 없음)
+      tcp:
+        maxConnections: 100               # Traefik + mesh 내부 복합 트래픽
+        connectTimeout: 5s
+    outlierDetection:
+      # game-server 는 단일 Pod. 5xx 5회 연속 발생 시 60s eject.
+      # ai-adapter 보다 임계값 완화 (3→5): 일시적 WS 오류가 많을 수 있음.
+      consecutive5xxErrors: 5
+      interval: 30s
+      baseEjectionTime: 60s
+      maxEjectionPercent: 100   # Pod 1개이므로 100%
+    tls:
+      # ISTIO_MUTUAL: mesh 내부 -> game-server 는 mTLS.
+      # Traefik -> game-server 는 PERMISSIVE PeerAuth 로 평문 허용.
+      mode: ISTIO_MUTUAL


### PR DESCRIPTION
## Summary
- `istio/destination-rule-game-server.yaml` 신규: mesh 내부 → game-server mTLS + outlierDetection
- `istio/destination-rule-ai-adapter.yaml` 튜닝: interval/baseEjectionTime 완화 + 에러 분리 추적
- `docs/02-design/20-istio-selective-mesh-design.md` §13 업데이트: 파일 구조 + 튜닝 표

## 변경 상세

### game-server DR (신규)
| 항목 | 값 | 비고 |
|------|-----|------|
| consecutive5xxErrors | 5 | ai-adapter(3)보다 완화 — WS 일시 오류 허용 |
| baseEjectionTime | 60s | |
| h2UpgradePolicy | DO_NOT_UPGRADE | WebSocket 장기 연결 지원 |
| tls.mode | ISTIO_MUTUAL | mesh 내부 mTLS |

### ai-adapter DR 튜닝
| 항목 | 이전 | 변경 |
|------|------|------|
| interval | 30s | 60s — LLM 700s 응답 중 false eject 방지 |
| baseEjectionTime | 30s | 120s — flapping 방지 |
| splitExternalLocalOriginErrors | (없음) | true — 에러 분리 추적 |

## Test plan
- [ ] PR 머지 후 `kubectl apply -f istio/destination-rule-game-server.yaml -n rummikub`
- [ ] `kubectl apply -f istio/destination-rule-ai-adapter.yaml -n rummikub`
- [ ] 7 pod 모두 Running 유지 확인: `kubectl get pods -n rummikub`
- [ ] `istioctl proxy-config cluster game-server-xxxxx -n rummikub` — game-server DR 적용 확인
- [ ] ai-adapter 응답 정상 확인 (WS 게임 1라운드 실행)

## kubectl apply 명령 (머지 후 실행)
```bash
KUBECTL="/mnt/c/Program Files/Docker/Docker/resources/bin/kubectl.exe"
"$KUBECTL" apply -f istio/destination-rule-game-server.yaml -n rummikub
"$KUBECTL" apply -f istio/destination-rule-ai-adapter.yaml -n rummikub
"$KUBECTL" get pods -n rummikub
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)