### PR TITLE
Phase1-qa: pre-deploy-playbook 배포 게이트 편입 + BUG-UI-011/012/013 재현 spec 3종 RED

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,44 @@
+# Pull Request
+
+## Summary
+<!-- 이 PR 이 해결하는 문제 / 추가하는 기능을 1~3줄로 -->
+
+## Changes
+<!-- 변경 사항 bullet 3~7개 -->
+-
+-
+-
+
+## Related Issue / Ticket
+<!-- Closes #NNN / Fixes BUG-UI-NNN -->
+
+## Testing
+<!-- 어떻게 검증했는가. 로컬 재현, Playwright 실행 로그 등 -->
+- [ ] 단위 테스트 (`go test ./...` / `pnpm test`) GREEN
+- [ ] Playwright 관련 spec GREEN
+- [ ] 재현 spec 을 **구현 전에 먼저 커밋** (RED → GREEN 히스토리 존재)
+
+## Deployment Gate — Pre-deploy Playbook
+<!-- 정책: docs/05-deployment/09-pre-deploy-playbook-gate.md -->
+<!-- release / hotfix 라벨 PR 은 아래 체크 필수. docs / test-only / configmap-only PR 은 면제 -->
+- [ ] **pre-deploy-playbook 스킬 실행 증거 첨부** (release / hotfix 라벨 PR 에 한함)
+  - 로그 요약 (GO/NO-GO 판정 포함)
+  - Playwright `trace.zip` 경로 또는 artifact 링크
+  - BUILD_ID 검증 (release 태그 배포 시)
+- [ ] Playbook 면제 대상이면 사유 명시 (예: `docs-only`, `test-only`, `infra configmap value-only`)
+
+## Review Checklist (Sprint 7 재편 원칙)
+- [ ] UI 수정 PR 은 architect + frontend-dev 페어 리뷰 증거 (PR 코멘트 2인 승인 이상)
+- [ ] 한글 i18n / 마이크로카피 변경 시 designer 승인
+- [ ] 동일 함수 3회 이상 핫픽스 누적 시 리팩터 ADR 링크 (architect 구조 부채 누적 카운터 정책)
+- [ ] `.env`, `*.pem`, `*-key.pem` 파일 포함 없음 확인
+
+## Screenshots / Evidence (UI PR 에 한함)
+<!-- before / after 스크린샷 or 영상 -->
+
+## Breaking Changes
+- [ ] 없음
+- [ ] 있음 — 하단에 migration 경로 기재
+
+---
+Generated with Claude Code

--- a/docs/05-deployment/09-pre-deploy-playbook-gate.md
+++ b/docs/05-deployment/09-pre-deploy-playbook-gate.md
@@ -1,0 +1,177 @@
+# 09. Pre-deploy Playbook — 배포 게이트 편입 정책
+
+- **작성일**: 2026-04-24 (Day 3 AM 스탠드업 직후)
+- **작성자**: qa (RummiArena)
+- **상태**: 제안 → 사용자 승인 대기
+- **상위 문서**: `.claude/skills/pre-deploy-playbook/SKILL.md` (v1.1, 2026-04-21)
+- **연관 정책**: `docs/01-planning/17-merge-gate-policy.md` (pm 작성 예정, Day 3 Phase 1)
+
+---
+
+## 1. 배경 — 왜 이 게이트가 필요한가
+
+### 1.1 사고 경위 (2026-04-23 Day 2)
+
+Day 2 Week 1 P1 8.5 SP 를 한 세션에 5 PR(#53~#57) 머지하고 `day2-2026-04-23` 태그로 K8s 재배포. 05:39 UTC smoke PASS 판정. 같은 날 22:04~22:18 실사용자 플레이테스트 15분 구간에서 **BUG-UI-009~014 6건 + UX-004 오해 1건** 이 쏟아짐. 사용자 진술 "**고쳐진 게 하나도 없는 듯**". 원인은 `smoke PASS` 정의가 `/health 200 OK + helm list DEPLOYED` 수준에 머물렀기 때문.
+
+### 1.2 직접 원인 — Playbook 스킬 미실행
+
+`.claude/skills/pre-deploy-playbook/SKILL.md` 는 2026-04-21 v1.0 신설, 4월 21일 qa 에이전트에 의한 첫 실전 발동(170801 잡종 방지) 이후 **Day 2 배포 때 호출 안 됨**. 스킬은 존재했지만 강제할 게이트가 없었다. 자유 재량에 맡겨진 스킬은 시간 압박 앞에서 "이번만 생략" 된다.
+
+### 1.3 Playbook 으로 잡힐 수 있었던 시나리오 3개 (사후 검증)
+
+SKILL Phase 2.3 플레이 시퀀스(드래그 3회 + 확장 2회 + 조커 1회 + 확정 2회 + 드로우 2회 + 턴 10회) 를 실제로 돌렸다면 아래 버그가 배포 전에 드러남:
+
+| # | 버그 | Playbook 어느 단언에서 잡혔을 것인가 |
+|---|------|--------------------------------------|
+| 1 | **BUG-UI-009** 동일 멜드 9개 복제 렌더링 (22:15:43) | Phase 2.4 "같은 타일 code 가 여러 블록에 동시 표시되지 않음" 단언. 드래그 5회 이내 재현 확률 높음 |
+| 2 | **BUG-UI-011** AI 턴 중 플레이어 버튼 활성화 (22:12:37) | Phase 2.4 "라벨 정합성" 섹션 + "턴 진행 10회 이상" 단언. AI 턴 중 버튼 disabled 강제 점검 |
+| 3 | **BUG-UI-013** 손패 카운트 16→19→18→21 요동 (22:07:33) | Phase 2.4 "내 랙 타일 수 = 실제 rack 표시 수 (drift 없음)" 단언. 드로우 2회만 돌아도 재현 |
+
+즉 Playbook 은 **이미 설계 단계에서 이 세 버그를 잡도록 단언을 갖고 있었다**. 실행되지 않았기에 쓸모가 없었다.
+
+---
+
+## 2. 정책 — Playbook 스킬 실행 증거 필수 첨부
+
+### 2.1 적용 범위
+
+| 범위 | Playbook 실행 필요 | 근거 |
+|------|-------------------|------|
+| **release 라벨 PR** 머지 전 | **필수** | 사용자 노출 경로 변경은 실 플레이 완주 없이 머지 금지 |
+| K8s `rollout restart` 직후 (dev / prod) | **필수** | Pod 배포 성공 ≠ 게임 완주 가능 |
+| Hotfix PR (hotfix 라벨) | **필수** | 핫픽스일수록 회귀 확률 높음 |
+| docs-only PR (docs 라벨 단독) | 면제 | 문서 수정은 runtime 무관 |
+| test-only PR (`e2e/**` 또는 `*_test.go` 단독) | 면제 | 테스트 코드 수정은 Playbook 대상 아님 |
+| infra-only PR (helm/ 또는 argocd/ 단독) | 조건부 | deployment template 변경 시 필수, configmap value-only 는 면제 |
+
+### 2.2 실행 증거 형식 (PR 본문 필수 첨부)
+
+다음 3개 아티팩트를 PR 본문 또는 코멘트로 첨부해야 머지 승인:
+
+1. **로그 요약**
+   ```
+   ## Pre-deploy Playbook — PASS (or FAIL)
+
+   - Endpoint: http://localhost:30000
+   - BUILD_ID: <sha>
+   - 소요 시간: mm:ss
+   - 플레이 시퀀스: 드래그 N회 / 확정 M회 / 드로우 K회 / 턴 L회 완주
+   - 단언: 모두 PASS
+   - 판정: GO
+   ```
+
+2. **Playwright trace.zip 경로**
+   - `src/frontend/test-results/pre-deploy-playbook/YYYY-MM-DD-HHMM/trace.zip`
+   - 실패 시 trace.zip + screenshots 경로 필수
+
+3. **BUILD_ID 검증 스크린샷** (선택, release PR 에 한함)
+   - `kubectl exec -n rummikub deploy/frontend -- cat /app/.next/BUILD_ID` 출력
+   - 기대 커밋 해시와 일치 여부 확인
+
+### 2.3 NO-GO 처리
+
+Phase 3.2 의 4개 실패 분류(A 환경 / B backend / C UI 버그 / D 단언 실패) 중 **어느 하나라도 발생** 시:
+
+- **사용자 전달 금지**. "확인해주세요" 메시지 작성 금지
+- 실패 분류별 조치:
+  - A/B: devops 에이전트에 우선순위 P1 알림, 재시도 2회 후에도 실패면 배포 롤백
+  - C: 즉시 frontend-dev 또는 go-dev 스폰, 실패 시나리오를 `docs/04-testing/65-*.md` 에 등재
+  - D: regression. 원인 식별 전까지 태그 배포 중단
+
+---
+
+## 3. 자동화 훅 — `helm/deploy.sh` 연동
+
+### 3.1 배포 스크립트 변경
+
+`helm/deploy.sh` 에 `--with-playbook` 플래그 추가. `release` 또는 `hotfix` 태그 배포 시 자동 실행:
+
+```bash
+./helm/deploy.sh upgrade --with-playbook
+```
+
+동작:
+1. Phase 1~5 기존 배포 수행
+2. `verify_health` 통과 확인
+3. `scripts/run-pre-deploy-playbook.sh` 호출 (신규)
+4. Playbook PASS 시에만 완료 선언
+5. Playbook FAIL 시 배포 태그는 유지하되 **"user-facing 전달 차단" 플래그** 를 K8s ConfigMap 에 표기 (`playbook.pass=false`)
+
+### 3.2 호출 스크립트 (신규)
+
+`scripts/run-pre-deploy-playbook.sh`:
+
+```bash
+#!/usr/bin/env bash
+# .claude/skills/pre-deploy-playbook/SKILL.md v1.1 에 정의된 Phase 1~4 를 자동 실행.
+# Ollama warmup 포함.
+
+set -euo pipefail
+
+# Phase 1: Pre-flight
+kubectl exec -n rummikub deploy/frontend -- cat /app/.next/BUILD_ID
+kubectl exec -n rummikub deploy/ollama -- \
+  curl -s -X POST http://localhost:11434/api/generate \
+  -d '{"model":"qwen2.5:3b","prompt":"ready","stream":false}' > /dev/null
+
+# Phase 2: Playbook 실행
+cd src/frontend
+npx playwright test e2e/pre-deploy-playbook.spec.ts \
+  --workers=1 --reporter=list \
+  --output=test-results/pre-deploy-playbook/"$(date +%Y-%m-%d-%H%M)"
+```
+
+### 3.3 CI/CD (GitLab Runner) 연동
+
+- `release` 라벨이 붙은 MR 은 파이프라인 stage 에 `pre-deploy-playbook` 잡 추가
+- 잡 실패 시 머지 차단 (GitLab 의 "All threads must be resolved" 와 동급 게이트)
+- 상세는 `docs/05-deployment/06-test-run-guide.md` 에 연동 (devops 작업)
+
+---
+
+## 4. 시행 일정
+
+| 시점 | 액션 | 담당 |
+|------|------|------|
+| **2026-04-24 Day 3 오전** | 본 정책 문서 + `scripts/run-pre-deploy-playbook.sh` 커밋 | qa |
+| **2026-04-24 Day 3 오후** | `helm/deploy.sh --with-playbook` 플래그 구현 | devops |
+| **2026-04-24 Day 3 저녁** | Day 3 통합 태그 `day3-2026-04-24-ui-triage` 배포에 최초 적용 | devops + qa |
+| **2026-04-25 Day 4** | GitLab Runner 파이프라인 stage 편입 | devops |
+| **2026-04-26 Day 5** | PR Template 체크박스 강제화 완료, 옵트아웃 케이스 점검 | pm |
+| **2026-05-02 Week 2 마감** | 1주일 운영 데이터로 Playbook 평균 소요 시간 + 실패율 첫 회고 | qa + pm |
+
+---
+
+## 5. 예외 처리
+
+### 5.1 Ollama 미가동 시
+
+Playbook 기본값은 LLaMA(Ollama qwen2.5:3b) — 비용 $0. Ollama 장애로 Playbook 불가하면:
+- 1차 대응: DeepSeek Reasoner 로 교체 (비용 $0.001/턴, 속도 30~350s)
+- 2차 대응: GPT-5-mini ($0.025/턴) — 이 경우 `pm` 에이전트가 비용 승인 필요
+
+### 5.2 사용자 압박으로 인한 스킵 요청
+
+"급하니 이번만 스킵하자" 요청이 와도 **금지**. SKILL 문서 Phase 3.3 "Playbook 생략 후 사용자 전달 금지" 조항 준수. 스킵이 필요한 상황이면 배포 자체를 미루는 것이 원칙.
+
+---
+
+## 6. 측정 지표 (Week 2 이후)
+
+- **Playbook 실행율**: release PR 중 Playbook 실행 증거 첨부 비율 (목표 100%)
+- **Playbook 실패율**: 실행 중 FAIL 비율 (목표 &lt;10%, 높으면 배포 전 QA 파이프라인 상류에 문제)
+- **Playbook 평균 소요 시간**: Phase 1~4 전체 (목표 &lt;5분, 초과 시 튜닝)
+- **Post-Playbook 사용자 회귀 건수**: Playbook PASS 이후 사용자 스크린샷으로 발견된 버그 건수 (목표 0건/주)
+
+위 지표는 `docs/04-testing/` 아래 주간 리포트에 매주 기록.
+
+---
+
+## 7. 레퍼런스
+
+- Skill 원문: `.claude/skills/pre-deploy-playbook/SKILL.md`
+- Day 2 사고 스크린샷: `2026-04-23_220403.png` ~ `2026-04-23_221859.png` (16장, `d:\Users\KTDS\Pictures\FastStone`)
+- Day 3 스탠드업 로그: `work_logs/scrums/2026-04-24-01.md` §5 QA 반성
+- Day 3 실행 계획: `work_logs/plans/2026-04-24-standup-actions-execution-plan.md` §1 Phase 1
+- 관련 버그 티켓: BUG-UI-009, BUG-UI-010, BUG-UI-011, BUG-UI-012, BUG-UI-013, BUG-UI-014, UX-004

--- a/helm/deploy.sh
+++ b/helm/deploy.sh
@@ -6,7 +6,17 @@ set -euo pipefail
 
 NAMESPACE="rummikub"
 HELM_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${HELM_DIR}/.." && pwd)"
 ACTION="${1:-install}"
+WITH_PLAYBOOK=0
+
+# --with-playbook 플래그 파싱 (release / hotfix 태그 배포 시 필수)
+# 정책: docs/05-deployment/09-pre-deploy-playbook-gate.md
+for arg in "$@"; do
+  case "${arg}" in
+    --with-playbook) WITH_PLAYBOOK=1 ;;
+  esac
+done
 
 log() { echo "[$(date '+%H:%M:%S')] $*"; }
 err() { echo "[ERROR] $*" >&2; exit 1; }
@@ -101,6 +111,22 @@ uninstall_all() {
   log "완료. PVC는 수동으로 삭제하세요: kubectl delete pvc -n ${NAMESPACE} --all"
 }
 
+run_playbook() {
+  # SKILL.md v1.1 Phase 1~4 자동 실행. release/hotfix 태그 배포 시 필수.
+  # 정책: docs/05-deployment/09-pre-deploy-playbook-gate.md
+  log "=== Pre-deploy Playbook 실행 ==="
+  if [[ ! -x "${REPO_ROOT}/scripts/run-pre-deploy-playbook.sh" ]]; then
+    err "scripts/run-pre-deploy-playbook.sh 실행 권한 없음 (chmod +x 필요)"
+  fi
+  if "${REPO_ROOT}/scripts/run-pre-deploy-playbook.sh"; then
+    log "Playbook PASS — 사용자 전달 가능 (GO)"
+    return 0
+  else
+    log "Playbook FAIL — 사용자 전달 차단 (NO-GO). 배포 태그는 유지, playbook.pass=false 표기 필요"
+    return 1
+  fi
+}
+
 verify_health() {
   log "=== 헬스체크 ==="
   local failed=0
@@ -143,10 +169,16 @@ case "${ACTION}" in
     check_prereqs
     ensure_namespace
     deploy_all
+    if [[ ${WITH_PLAYBOOK} -eq 1 ]]; then
+      run_playbook || err "Pre-deploy Playbook FAIL — 배포 게이트 차단"
+    fi
     ;;
   upgrade)
     check_prereqs
     deploy_all
+    if [[ ${WITH_PLAYBOOK} -eq 1 ]]; then
+      run_playbook || err "Pre-deploy Playbook FAIL — 배포 게이트 차단"
+    fi
     ;;
   uninstall|remove)
     uninstall_all
@@ -157,8 +189,19 @@ case "${ACTION}" in
   health|verify)
     verify_health
     ;;
+  playbook)
+    # 수동 호출: ./helm/deploy.sh playbook
+    run_playbook
+    ;;
   *)
-    echo "사용법: $0 [install|upgrade|uninstall|status|health]"
+    echo "사용법: $0 [install|upgrade|uninstall|status|health|playbook] [--with-playbook]"
+    echo ""
+    echo "  install|deploy [--with-playbook]   설치 (release/hotfix 태그 시 --with-playbook 필수)"
+    echo "  upgrade [--with-playbook]           업그레이드 (동일)"
+    echo "  uninstall|remove                    제거"
+    echo "  status                              Helm 릴리즈 상태"
+    echo "  health|verify                       헬스체크"
+    echo "  playbook                            Pre-deploy Playbook 단독 실행"
     exit 1
     ;;
 esac

--- a/scripts/run-pre-deploy-playbook.sh
+++ b/scripts/run-pre-deploy-playbook.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# run-pre-deploy-playbook.sh
+#
+# .claude/skills/pre-deploy-playbook/SKILL.md v1.1 의 Phase 1~4 를 자동 실행.
+# release / hotfix 라벨 PR 머지 전 또는 K8s 재배포 직후 호출.
+#
+# 정책: docs/05-deployment/09-pre-deploy-playbook-gate.md
+# 배경: Day 2 (2026-04-23) smoke PASS 이후 22:04~22:18 사용자 플레이테스트 에서
+#       BUG-UI-009~014 6건 폭발. Playbook 이 호출되지 않은 것이 직접 원인.
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-rummikub}"
+ENDPOINT="${ENDPOINT:-http://localhost:30000}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPORT_DIR="${REPO_ROOT}/src/frontend/test-results/pre-deploy-playbook/$(date +%Y-%m-%d-%H%M)"
+
+log() { echo "[playbook $(date '+%H:%M:%S')] $*"; }
+err() { echo "[playbook ERROR] $*" >&2; exit 1; }
+
+# -----------------------------------------------------------------
+# Phase 1: Pre-flight
+# -----------------------------------------------------------------
+phase1_preflight() {
+  log "Phase 1: Pre-flight"
+
+  # 1. BUILD_ID 확인
+  local build_id
+  build_id=$(kubectl exec -n "${NAMESPACE}" deploy/frontend -- cat /app/.next/BUILD_ID 2>/dev/null || echo "UNKNOWN")
+  log "BUILD_ID: ${build_id}"
+
+  # 2. auth.json 존재 여부
+  if [[ ! -f "${REPO_ROOT}/src/frontend/e2e/auth.json" ]]; then
+    err "auth.json not found — global-setup 이 먼저 실행되어야 함"
+  fi
+
+  # 3. 네트워크 사전 점검
+  local http_code
+  http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "${ENDPOINT}" || echo "000")
+  if [[ ! "${http_code}" =~ ^(200|307|308)$ ]]; then
+    err "Endpoint ${ENDPOINT} returned HTTP ${http_code} — 배포 실패 가능"
+  fi
+  log "Endpoint ${ENDPOINT}: HTTP ${http_code} OK"
+
+  # 4. Ollama warmup (cold start 대응, SKILL v1.1)
+  log "Ollama warmup (qwen2.5:3b)..."
+  kubectl exec -n "${NAMESPACE}" deploy/ollama -- \
+    curl -s -X POST http://localhost:11434/api/generate \
+    -d '{"model":"qwen2.5:3b","prompt":"ready","stream":false}' \
+    --max-time 90 > /dev/null 2>&1 || log "WARN: Ollama warmup 실패 (무시하고 계속)"
+}
+
+# -----------------------------------------------------------------
+# Phase 2: Playbook 실행 (Playwright)
+# -----------------------------------------------------------------
+phase2_playbook() {
+  log "Phase 2: Playbook 실행 → ${REPORT_DIR}"
+  mkdir -p "${REPORT_DIR}"
+
+  cd "${REPO_ROOT}/src/frontend"
+
+  # pre-deploy-playbook.spec.ts 는 SKILL Phase 2.3 플레이 시퀀스 구현체
+  # --workers=1 K8s 부하 방지 (playwright.config.ts 와 동일)
+  if npx playwright test e2e/pre-deploy-playbook.spec.ts \
+      --workers=1 \
+      --reporter=list \
+      --output="${REPORT_DIR}"; then
+    log "Playbook PASS"
+    echo "PASS" > "${REPORT_DIR}/verdict.txt"
+    return 0
+  else
+    log "Playbook FAIL — artifacts: ${REPORT_DIR}"
+    echo "FAIL" > "${REPORT_DIR}/verdict.txt"
+    return 1
+  fi
+}
+
+# -----------------------------------------------------------------
+# Phase 4: 리포트
+# -----------------------------------------------------------------
+phase4_report() {
+  local verdict="$1"
+  local summary_file="${REPORT_DIR}/summary.md"
+
+  cat > "${summary_file}" <<EOF
+## Pre-deploy Playbook — ${verdict}
+
+- Endpoint: ${ENDPOINT}
+- Report dir: ${REPORT_DIR}
+- Trace zip: ${REPORT_DIR}/trace.zip (실패 시)
+- 판정: $( [[ "${verdict}" == "PASS" ]] && echo "GO — 사용자 전달 가능" || echo "NO-GO — 즉시 수정 필요, 사용자 전달 차단" )
+
+정책: docs/05-deployment/09-pre-deploy-playbook-gate.md §2.3
+EOF
+
+  log "Summary: ${summary_file}"
+  cat "${summary_file}"
+}
+
+# -----------------------------------------------------------------
+# main
+# -----------------------------------------------------------------
+main() {
+  log "=== Pre-deploy Playbook 시작 ==="
+
+  phase1_preflight
+
+  if phase2_playbook; then
+    phase4_report "PASS"
+    log "=== 완료 (GO) ==="
+    exit 0
+  else
+    phase4_report "FAIL"
+    log "=== 완료 (NO-GO) — 사용자 전달 금지 ==="
+    exit 1
+  fi
+}
+
+main "$@"

--- a/src/frontend/e2e/hand-count-sync.spec.ts
+++ b/src/frontend/e2e/hand-count-sync.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * BUG-UI-013 재현 스펙 — 손패 카운트 요동
+ *
+ * 배경: 2026-04-23 22:04:18 / 22:07:33 스크린샷.
+ * 손패 하단에 표시되는 타일 수("16장") 가 16 → 19 → 18 → 21 로 요동하며
+ * 실제 렌더된 타일 갯수와 불일치. 드로우/드래그 연속 시 재현.
+ *
+ * 근본 원인 가설 (architect 리뷰):
+ * 1. `tiles.length` vs `tiles.filter(t => !t.pending).length` 구분 누락
+ * 2. 드로우 애니메이션 state 가 실제 store state 와 격리 안 됨 (중복 병합)
+ * 3. drag preview 가 손패 카운트 계산에 포함됨
+ *
+ * 본 스펙은 Phase 2 frontend-dev 수정 전 **RED 확정** 용도.
+ *
+ * GREEN 만드는 방법:
+ *   1. `src/frontend/src/components/game/PlayerRack.tsx` 카운트 selector
+ *      → `selectMyTileCount` (gameStore) 단일 source 사용
+ *   2. drag preview 로 떠있는 타일은 아직 rack state 에 포함되므로 필터 불필요
+ *      단, pending(드로우 애니메이션 중인 타일) 은 제외 필터 필수
+ *   3. `tiles.length` 를 직접 쓰는 곳 grep → selector 로 치환
+ *
+ * 참조:
+ *   - work_logs/plans/2026-04-24-sprint7-ui-bug-triage-plan.md §3.1 BUG-UI-013
+ *   - d:\Users\KTDS\Pictures\FastStone\2026-04-23_220418.png (16→19)
+ *   - d:\Users\KTDS\Pictures\FastStone\2026-04-23_220733.png (21장 불일치)
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+import {
+  createRoomAndStart,
+  waitForGameReady,
+  waitForStoreReady,
+  getRackTileCodes,
+} from "./helpers/game-helpers";
+import { cleanupViaPage } from "./helpers/room-cleanup";
+
+/**
+ * 화면에 표시된 손패 카운트 숫자를 추출.
+ * PlayerRack 근처의 "N장" 또는 "N" 표기를 찾는다.
+ */
+async function readDisplayedTileCount(page: Page): Promise<number | null> {
+  // 1. aria-label 내 카운트 (예: "내 타일 랙 (16장)")
+  const rackLabel = await page
+    .locator('section[aria-label*="내 타일 랙"]')
+    .first()
+    .getAttribute("aria-label");
+
+  if (rackLabel) {
+    const m = rackLabel.match(/(\d+)\s*장/);
+    if (m) return parseInt(m[1], 10);
+  }
+
+  // 2. data-testid="hand-count" or "tile-count" 탐색
+  for (const testid of ["hand-count", "tile-count", "rack-count"]) {
+    const el = page.locator(`[data-testid="${testid}"]`);
+    if ((await el.count()) > 0) {
+      const txt = (await el.first().innerText()).trim();
+      const m = txt.match(/(\d+)/);
+      if (m) return parseInt(m[1], 10);
+    }
+  }
+
+  // 3. PlayerRack 섹션 내부 "N장" 텍스트 매칭
+  const rackSection = page.locator('section[aria-label*="내 타일 랙"]');
+  if ((await rackSection.count()) > 0) {
+    const text = await rackSection.first().innerText();
+    const m = text.match(/(\d+)\s*장/);
+    if (m) return parseInt(m[1], 10);
+  }
+
+  return null;
+}
+
+test.describe("BUG-UI-013: 손패 카운트 ↔ 실제 타일 수 일치", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/lobby");
+    await page.waitForLoadState("domcontentloaded");
+    await cleanupViaPage(page);
+  });
+
+  test("T13-01 [RED] 게임 시작 직후 손패 카운트 = 렌더 타일 수", async ({
+    page,
+  }) => {
+    // given: 게임 시작 (초기 14장)
+    await createRoomAndStart(page, { playerCount: 2, aiCount: 1 });
+    await waitForGameReady(page);
+    await waitForStoreReady(page);
+
+    // 상태 안정화 대기
+    await page.waitForTimeout(500);
+
+    // when: 손패 카운트와 실제 타일 갯수 비교
+    const displayedCount = await readDisplayedTileCount(page);
+    const actualCodes = await getRackTileCodes(page);
+
+    // then: 일치
+    expect(
+      displayedCount,
+      "displayedCount 를 읽을 수 없음 — aria-label 또는 data-testid 누락"
+    ).not.toBeNull();
+
+    // RED 확정 포인트: 실제 환경에서는 drift 발생
+    expect(
+      displayedCount,
+      `표시 카운트(${displayedCount}) ≠ 실제 타일 수(${actualCodes.length}). drift 감지.`
+    ).toBe(actualCodes.length);
+  });
+
+  test("T13-02 [RED] 드래그 preview 중에도 카운트 drift 없음", async ({
+    page,
+  }) => {
+    await createRoomAndStart(page, { playerCount: 2, aiCount: 1 });
+    await waitForGameReady(page);
+    await waitForStoreReady(page);
+    await page.waitForTimeout(500);
+
+    // when: 랙의 첫 타일을 보드로 드래그 시작 (활성화 constraint 8px 초과)
+    const firstTile = page
+      .locator('section[aria-label="내 타일 랙"] [aria-label*="타일 (드래그 가능)"]')
+      .first();
+    await firstTile.waitFor({ state: "visible", timeout: 5_000 });
+
+    const box = await firstTile.boundingBox();
+    if (box) {
+      const sx = box.x + box.width / 2;
+      const sy = box.y + box.height / 2;
+      await page.mouse.move(sx, sy);
+      await page.mouse.down();
+      // 활성화
+      await page.mouse.move(sx + 12, sy, { steps: 3 });
+      // drag preview 상태에서 100ms 유지 (카운트 재계산 유발)
+      await page.waitForTimeout(100);
+
+      // then: 드래그 중에도 카운트 = 랙 렌더 수
+      const displayedCount = await readDisplayedTileCount(page);
+      const actualCodes = await getRackTileCodes(page);
+
+      // 드롭 전 cleanup
+      await page.mouse.up();
+
+      expect(
+        displayedCount,
+        `drag preview 중 drift — 표시(${displayedCount}) vs 실제(${actualCodes.length})`
+      ).toBe(actualCodes.length);
+    }
+  });
+
+  test("T13-03 [RED] setStoreState 시뮬레이션 — 16/19/18/21 요동 재현", async ({
+    page,
+  }) => {
+    await createRoomAndStart(page, { playerCount: 2, aiCount: 1 });
+    await waitForGameReady(page);
+    await waitForStoreReady(page);
+
+    // 사용자 스크린샷(22:04:18, 22:07:33) 타일 수 변화 재현
+    // 매 상태 변경 후 표시값 = 실제 랙 타일 수 유지 확인
+    const mockTileCounts = [16, 19, 18, 21];
+
+    for (const count of mockTileCounts) {
+      // 랙 타일 배열을 count 만큼 강제 생성
+      const mockTiles = Array.from({ length: count }, (_, i) => ({
+        code: `R${((i % 13) + 1)}a`,
+        color: "R",
+        number: (i % 13) + 1,
+        setId: "a",
+      }));
+
+      await page.evaluate((tiles) => {
+        const store = (window as unknown as {
+          __gameStore?: {
+            setState: (s: Record<string, unknown>) => void;
+          };
+        }).__gameStore;
+        if (store) {
+          store.setState({ rack: { tiles } });
+        }
+      }, mockTiles);
+
+      await page.waitForTimeout(300);
+
+      const displayed = await readDisplayedTileCount(page);
+      const actual = await getRackTileCodes(page);
+
+      expect(
+        displayed,
+        `count=${count} 시뮬레이션에서 drift — 표시(${displayed}) vs 실제(${actual.length})`
+      ).toBe(actual.length);
+    }
+  });
+});

--- a/src/frontend/e2e/i18n-render.spec.ts
+++ b/src/frontend/e2e/i18n-render.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * BUG-UI-012 재현 스펙 — 한글 메시지 깨짐
+ *
+ * 배경: 2026-04-23 22:18:59 스크린샷 (`2026-04-23_221859.png`).
+ * 기권 종료 모달에 "상업 골셀하며 자동로 차집합 중단되었습니다" 같은
+ * mojibake / template 치환 실패 추정 문자열 노출.
+ * 같은 게임 동안 "조기/성급이 다른 타일..." 경고 배너도 한글 깨짐 관찰.
+ *
+ * 근본 원인 가설 (architect 리뷰):
+ * 1. i18n 리소스 오타 (ko.json 상당 / 또는 하드코딩)
+ * 2. WS 프레임 Content-Type charset=utf-8 미지정으로 Latin-1 오해석
+ * 3. 서버 문자열 template `{winner} 승리` 변수 치환 실패
+ *
+ * 본 스펙은 Phase 2 frontend-dev + go-dev 페어 수정 전 **RED 확정** 용도.
+ *
+ * GREEN 만드는 방법:
+ *   1. `src/frontend/src/**` grep "상업|골셀|차집합" → 오타 수정
+ *   2. `src/game-server/internal/ws/handler.go` TextMessage 인코딩 UTF-8 확인
+ *   3. 기권 종료 모달 template literal → 정적 한글 + 변수 분리
+ *
+ * 참조:
+ *   - work_logs/plans/2026-04-24-sprint7-ui-bug-triage-plan.md §3.1 BUG-UI-012
+ *   - d:\Users\KTDS\Pictures\FastStone\2026-04-23_221859.png (기권 모달)
+ *   - 같은 경기 전반 "조기/성급이 다른 타일" 경고 배너도 대상
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+import {
+  createRoomAndStart,
+  waitForGameReady,
+  waitForStoreReady,
+  setStoreState,
+} from "./helpers/game-helpers";
+import { cleanupViaPage } from "./helpers/room-cleanup";
+
+// 깨진 문자열 패턴 (22:18:59 스크린샷 기반)
+const MOJIBAKE_PATTERNS: RegExp[] = [
+  /상업/,        // "상대" 오타 추정
+  /골셀/,        // 의미 불명
+  /자동로/,      // "자동으로" 추정
+  /차집합/,      // "중지되었습니다" 혹은 유사 치환 실패
+  /조기\/성급이 다른/,  // 경고 배너 mojibake
+];
+
+// 기대 정상 문자열 (Phase 2 GREEN 이후)
+const EXPECTED_KOREAN_NORMAL_PATTERNS: RegExp[] = [
+  /상대방/,      // "상대방 기권"
+  /승리/,        // "rookie (GPT-4o) 승리"
+  /중단|종료/,   // "중단되었습니다" 또는 "게임 종료"
+];
+
+test.describe("BUG-UI-012: 한글 메시지 mojibake 금지", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/lobby");
+    await page.waitForLoadState("domcontentloaded");
+    await cleanupViaPage(page);
+  });
+
+  test("T12-01 [RED] 기권 종료 모달에 mojibake 패턴 0건 + 정상 문구 렌더", async ({ page }) => {
+    await createRoomAndStart(page, { playerCount: 2, aiCount: 1 });
+    await waitForGameReady(page);
+    await waitForStoreReady(page);
+
+    // when: 게임 상태를 'ended' + reason='opponent_forfeit' 로 강제
+    // 22:18:59 스크린샷 재현. Phase 2 수정 전에는 gameStore 에 해당 key 가
+    // 없어 모달이 트리거되지 않음 → RED 확정.
+    await setStoreState(page, {
+      gameStatus: "ended",
+      endReason: "opponent_forfeit",
+      winner: { userId: "ai-player-1", displayName: "rookie (GPT-4o)" },
+    });
+
+    // then 1: 화면에 mojibake 0건
+    const bodyText = await page.locator("body").innerText();
+    for (const pattern of MOJIBAKE_PATTERNS) {
+      expect(
+        bodyText,
+        `mojibake 패턴 '${pattern}' 가 화면에 노출됨 (BUG-UI-012). body text: ${bodyText.slice(0, 500)}`
+      ).not.toMatch(pattern);
+    }
+
+    // then 2: 종료 모달 영역이 반드시 렌더되어야 함
+    // 현재 store schema 에는 gameStatus/endReason/winner 키가 없어 RED.
+    // Phase 2 수정 시 (a) store key 추가 (b) 모달 트리거 배선 (c) 정상 문구 렌더.
+    const endModal = page
+      .locator('[role="dialog"]')
+      .or(page.locator('[aria-label*="종료"]'))
+      .or(page.locator("text=기권 종료"));
+    await expect(
+      endModal.first(),
+      "forfeit 모달이 렌더되지 않음 — gameStore schema 에 gameStatus/endReason/winner 키 추가 필요 (BUG-UI-012 Phase 2)"
+    ).toBeVisible({ timeout: 3_000 });
+
+    // then 3: 정상 한글 문구 반드시 포함
+    const modalText = await endModal.first().innerText();
+    const matched = EXPECTED_KOREAN_NORMAL_PATTERNS.some((p) => p.test(modalText));
+    expect(
+      matched,
+      `정상 한글 문구 누락. modal text: ${modalText.slice(0, 300)}`
+    ).toBe(true);
+  });
+
+  test("T12-02 [RED] 기권 모달에 최소 한 개의 정상 한글 문구 렌더", async ({
+    page,
+  }) => {
+    await createRoomAndStart(page, { playerCount: 2, aiCount: 1 });
+    await waitForGameReady(page);
+    await waitForStoreReady(page);
+
+    await setStoreState(page, {
+      gameStatus: "ended",
+      endReason: "opponent_forfeit",
+      winner: { userId: "ai-player-1", displayName: "rookie (GPT-4o)" },
+    });
+
+    // 종료 모달 영역 (role=dialog 또는 aria-label 로 탐색)
+    // 정확한 selector 가 프로덕션 마크업에 따라 달라질 수 있어 body 전체로 fallback
+    const modalOrBody = page.locator('[role="dialog"]').or(page.locator("body"));
+    const text = await modalOrBody.first().innerText();
+
+    // 적어도 하나의 정상 문구가 있어야 통과
+    const matched = EXPECTED_KOREAN_NORMAL_PATTERNS.some((p) => p.test(text));
+    expect(
+      matched,
+      `정상 한글 문구 (${EXPECTED_KOREAN_NORMAL_PATTERNS.join(", ")}) 중 하나도 없음. text: ${text.slice(0, 300)}`
+    ).toBe(true);
+  });
+
+  test("T12-03 [RED] 경고 배너 '재조립'/'다른 타일' 영역 mojibake 금지", async ({
+    page,
+  }) => {
+    await createRoomAndStart(page, { playerCount: 2, aiCount: 1 });
+    await waitForGameReady(page);
+    await waitForStoreReady(page);
+
+    // 22:04~22:06 구간 "조기/성급이 다른 타일..." 경고 배너 재현
+    // 경고 배너는 pending rearrangement 상태에서 노출됨
+    await setStoreState(page, {
+      rearrangeWarning: true,
+    });
+
+    const warnArea = page
+      .locator('[role="alert"]')
+      .or(page.locator('[aria-label*="경고"]'))
+      .or(page.locator('[aria-label*="재조립"]'));
+
+    const count = await warnArea.count();
+    if (count > 0) {
+      const text = await warnArea.first().innerText();
+      for (const pattern of MOJIBAKE_PATTERNS) {
+        expect(
+          text,
+          `경고 배너 mojibake '${pattern}' 매치. text: ${text.slice(0, 200)}`
+        ).not.toMatch(pattern);
+      }
+    } else {
+      // 경고 배너 미렌더인 경우 body 전체에서 검사 (덜 엄격)
+      const bodyText = await page.locator("body").innerText();
+      for (const pattern of MOJIBAKE_PATTERNS) {
+        expect(bodyText).not.toMatch(pattern);
+      }
+    }
+  });
+});

--- a/src/frontend/e2e/turn-sync.spec.ts
+++ b/src/frontend/e2e/turn-sync.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * BUG-UI-011 재현 스펙 — 턴 동기화 실패
+ *
+ * 배경: 2026-04-23 22:12:37 스크린샷 (`2026-04-23_221237.png`).
+ * AI 턴이 진행 중인데 플레이어 측 action 버튼(제출하기 / 되돌리기 / 새 그룹)
+ * 이 활성화되어 있는 상태로 촬영됨. 동시에 그룹 멜드(7 triplet)가 일시 소실.
+ *
+ * 근본 원인 가설 (architect 리뷰):
+ * - `isMyTurn = game.currentPlayerId === session.userId` 계산이
+ *   WebSocket `TURN_CHANGED` 이벤트 수신 후 useMemo 재계산 타이밍에서 누락
+ * - 또는 `ActionBar` 렌더 조건에 `disabled={!isMyTurn}` 전수 적용 안 됨
+ *
+ * 본 스펙은 Phase 2 frontend-dev 구현 전 **RED 확정** 용도.
+ * 현재 (qa/pre-deploy-playbook-gate 브랜치, pre-fix) 에서는 FAIL 이어야 정상.
+ *
+ * GREEN 만드는 방법 (Phase 2 담당 frontend-dev 참고):
+ *   1. `src/frontend/src/app/game/[roomId]/GameClient.tsx` 의 isMyTurn SSOT 강제
+ *   2. `ActionBar` 및 자식 버튼 모두 `disabled={!isMyTurn}`
+ *   3. WS `TURN_CHANGED` 수신 시 `currentPlayerId` store 업데이트 직후 렌더 강제
+ *
+ * 참조:
+ *   - work_logs/plans/2026-04-24-sprint7-ui-bug-triage-plan.md §3.1 BUG-UI-011
+ *   - work_logs/scrums/2026-04-24-01.md §5 QA 반성
+ *   - d:\Users\KTDS\Pictures\FastStone\2026-04-23_221237.png
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+import {
+  createRoomAndStart,
+  waitForGameReady,
+  waitForStoreReady,
+  setStoreState,
+} from "./helpers/game-helpers";
+import { cleanupViaPage } from "./helpers/room-cleanup";
+
+test.describe("BUG-UI-011: AI 턴 중 플레이어 버튼 활성화 금지", () => {
+  test.beforeEach(async ({ page }) => {
+    // 이전 테스트 잔존 방 정리
+    await page.goto("/lobby");
+    await page.waitForLoadState("domcontentloaded");
+    await cleanupViaPage(page);
+  });
+
+  test("T11-01 [RED] AI 턴 상태일 때 ActionBar 모든 버튼은 disabled", async ({
+    page,
+  }) => {
+    // given: 2인 방 생성 (사용자 + AI 1명), 게임 시작
+    await createRoomAndStart(page, {
+      playerCount: 2,
+      aiCount: 1,
+      turnTimeout: 120,
+    });
+    await waitForGameReady(page);
+    await waitForStoreReady(page);
+
+    // when: store 의 currentPlayerId 를 AI 로 강제 세팅 (22:12:37 재현)
+    // 실제 사용자 플레이에서는 WS TURN_CHANGED 로 진입하는 상태이나
+    // E2E 에서는 store bridge 를 통해 동일 상태 모사
+    await setStoreState(page, {
+      currentPlayerId: "ai-player-1", // 사용자 userId 와 달라야 isMyTurn=false
+    });
+
+    // then: ActionBar 가 보이면 안 됨 (또는 모든 버튼 disabled)
+    // 현재 구현은 isMyTurn=false 시 ActionBar 를 숨기거나 disabled 해야 함
+    const actionBar = page.locator('[aria-label="게임 액션"]');
+
+    // RED 확정 포인트 1: ActionBar 가 AI 턴에도 보이면 안 되는데
+    // 버그 환경에서는 보인다. hidden 이 기대값.
+    await expect(actionBar).toBeHidden({ timeout: 3_000 });
+  });
+
+  test("T11-02 [RED] AI 턴 중 '제출하기' 버튼 disabled 또는 미렌더", async ({
+    page,
+  }) => {
+    await createRoomAndStart(page, { playerCount: 2, aiCount: 1 });
+    await waitForGameReady(page);
+    await waitForStoreReady(page);
+
+    await setStoreState(page, {
+      currentPlayerId: "ai-player-1",
+    });
+
+    // 제출하기 버튼 탐색
+    const submitBtn = page.getByRole("button", { name: /제출/ });
+    const count = await submitBtn.count();
+
+    if (count === 0) {
+      // 미렌더도 GREEN 조건 (isMyTurn=false 시 ActionBar 자체 숨김)
+      expect(count).toBe(0);
+    } else {
+      // 렌더되어 있다면 반드시 disabled
+      await expect(submitBtn.first()).toBeDisabled({ timeout: 3_000 });
+    }
+  });
+
+  test("T11-03 [RED] AI 턴 중 '되돌리기' + '새 그룹' 버튼 모두 disabled", async ({
+    page,
+  }) => {
+    await createRoomAndStart(page, { playerCount: 2, aiCount: 1 });
+    await waitForGameReady(page);
+    await waitForStoreReady(page);
+
+    await setStoreState(page, {
+      currentPlayerId: "ai-player-1",
+    });
+
+    // 되돌리기 + 새 그룹 버튼 각각 점검
+    const undoBtn = page.getByRole("button", { name: /되돌리기/ });
+    const newGroupBtn = page.getByRole("button", { name: /새 그룹|새그룹/ });
+
+    for (const btn of [undoBtn, newGroupBtn]) {
+      const cnt = await btn.count();
+      if (cnt > 0) {
+        await expect(btn.first()).toBeDisabled({ timeout: 3_000 });
+      }
+    }
+
+    // 최소 하나라도 렌더되어 있어야 의미 있는 테스트
+    const totalCount = (await undoBtn.count()) + (await newGroupBtn.count());
+    expect(totalCount).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
Day 3 AM 스탠드업 QA 액션: (a) pre-deploy-playbook 스킬 배포 게이트 편입 + (b) BUG-UI-011/012/013 재현 spec 3종 선행 작성 (RED 확정).

## ⚠️ BUG-UI-012 (한글 깨짐) 오탐 확정
사용자(애벌레) 확인 결과 2026-04-24_101614 스크린샷에서 기권 종료 모달이 **완벽 정상 렌더**: "기권 종료 / rookie (GPT-4o) 승리! / 상대 플레이어의 기권으로 게임이 종료되었습니다." Batch 3 스크린샷 에이전트가 FastStone 4배율 이미지를 잘못 OCR해서 "상업 골셀" 로 오독. **실제 버그 아님**. 그러나 `i18n-render.spec.ts` 는 **회귀 방지용으로 유지** — 향후 실제 한글 손상이 발생하면 즉시 잡히도록.

## Changes
1. `docs/05-deployment/09-pre-deploy-playbook-gate.md` 신규 — Day 2 사고 경위 + Playbook 으로 잡혔을 시나리오 3개 인용
2. `.github/pull_request_template.md` 신규 — release/hotfix 라벨 PR 체크박스
3. `scripts/run-pre-deploy-playbook.sh` 신규 + `helm/deploy.sh` 수정 — `--with-playbook` 플래그
4. `e2e/turn-sync.spec.ts` — BUG-UI-011 재현 (T11-01 RED)
5. `e2e/i18n-render.spec.ts` — BUG-UI-012 회귀 방지용 (T12-01 RED 현재, Phase 2 완료 후 자연 GREEN 기대)
6. `e2e/hand-count-sync.spec.ts` — BUG-UI-013 재현 (T13-01 RED)

## Commits
- `8c98c55` docs(deployment): pre-deploy-playbook 배포 게이트 편입 정책
- `ee35817` feat(ci): release 라벨 PR merge 시 playbook 실행 훅
- `40e667e` test(e2e): BUG-UI-011/012/013 재현 spec 3종 (RED 확정)

## Rebuild note
최초 `feature/pre-deploy-playbook-gate` 로 시작했으나 Phase 1 병렬 4명 동시 `git checkout -b` 경합으로 타 에이전트 커밋 (\`d3080ff\`) 이 섞임. cherry-pick 으로 깨끗한 3 커밋만 재구성해서 현재 브랜치 `qa/pre-deploy-playbook-gate` 로 재배포.

## Test plan
- [x] 3 spec RED 확인 (T11-01/T12-01/T13-01)
- [ ] Phase 2 frontend-dev/go-dev 수정 후 GREEN 전환
- [ ] playbook 스크립트 수동 실행 검증 (devops)

## Links
- Day 3 스탠드업: \`work_logs/scrums/2026-04-24-01.md\` — QA §5 본문 약속 이행
- 액션 실행 계획: \`work_logs/plans/2026-04-24-standup-actions-execution-plan.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)