### PR TITLE
fix(frontend): BUG-UI-016 PlayerRack aria-label selector 호환성 복원

### DIFF
--- a/src/frontend/src/components/game/PlayerRack.tsx
+++ b/src/frontend/src/components/game/PlayerRack.tsx
@@ -100,7 +100,7 @@ const PlayerRack = memo(function PlayerRack({
 
   return (
     <section
-      aria-label={`내 타일 랙 (${tileCount}장)`}
+      aria-label="내 타일 랙"
       ref={setNodeRef}
       className={[
         "rounded-xl",


### PR DESCRIPTION
## 증상

qa Stage 1 v2 이미지 재실행에서 **33 TC FAIL** — 전량 동일 원인:

```
section[aria-label="내 타일 랙"] not found → waitForGameReady 30s timeout
```

## 근본 원인

PR #78 커밋 `e689cee` 에서 `PlayerRack.tsx` outer section 의 aria-label 변경:

```diff
- aria-label="내 타일 랙"
+ aria-label={`내 타일 랙 (${tileCount}장)`}
```

`game-helpers.ts` 의 `waitForGameReady`, `getRackTileCodes` 등이
`section[aria-label="내 타일 랙"]` **완전 일치** selector 를 사용하므로
동적 포맷으로 바뀌면 모든 테스트가 rack section 을 찾지 못하고 30s timeout.

오전 qa Stage 1 은 v1 이미지(구 aria-label)라 통과, v2 재빌드 후 회귀 감지.

## 수정 1줄 diff

```diff
- aria-label={`내 타일 랙 (${tileCount}장)`}
+ aria-label="내 타일 랙"
```

## a11y 유지 근거

- `data-testid="hand-count"` span (`aria-label="손패 N장"`) 은 PR #78 에서 이미 추가됨 — 타일 카운트 정보 유지
- 스크린 리더: section 진입 시 "내 타일 랙" 인식, 내부 span 의 "손패 N장" 보조 안내로 읽음
- BUG-UI-013 `readDisplayedTileCount` 는 `data-testid="hand-count"` testid 폴백(2번)으로 카운트 추출 가능

## BUG-UI-013 기능 영향 없음

`data-testid="hand-count"` span 은 이번 PR 에서 **변경하지 않음** (PR #78 에서 추가된 상태 유지).
`readDisplayedTileCount` 의 testid 폴백 경로가 정상 동작하므로 T13-01~03 영향 없음.

## 예상 GREEN 복구

- `waitForGameReady` 30s timeout 원인 해소 → 33 TC 전량 회복 예상
- `hand-count-sync.spec.ts` `section[aria-label*="내 타일 랙"]` contains 패턴 사용 → 변경 없이 호환

## 롤백

```bash
git revert f4f1f6a
```

## 후속 (별도 PR)

spec helper `waitForGameReady` 를 `section[aria-label*="내 타일 랙"]` contains 패턴으로 보강하여
동적 aria-label 변경에 의한 유사 회귀 재발 방지.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)