### PR TITLE
fix(ai-adapter): path-to-regexp 의존성 drift 해소 — Express 5 호환 (Task #21)

### DIFF
--- a/src/ai-adapter/package-lock.json
+++ b/src/ai-adapter/package-lock.json
@@ -7480,10 +7480,14 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-      "license": "MIT"
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",

--- a/src/ai-adapter/package.json
+++ b/src/ai-adapter/package.json
@@ -21,7 +21,6 @@
   },
   "overrides": {
     "multer": "2.1.1",
-    "path-to-regexp": "0.1.13",
     "lodash": "4.18.0"
   },
   "dependencies": {


### PR DESCRIPTION
## 증상

ai-adapter 신규 이미지 기동 시 즉시 크래시:

```
TypeError: pathRegexp.match is not a function
    at matcher (/app/node_modules/router/lib/layer.js:86:23)
    at new Layer (/app/node_modules/router/lib/layer.js:93:62)
```

이전 이미지 `integration-p0-2026-04-22`로 롤백하여 K8s 안정 유지 중.

## 근본 원인

`@nestjs/platform-express@^11.0.0` → `express@5.2.1` → `router@2.2.0` 의존 체인에서:

- `router@2.2.0`은 `path-to-regexp@^8.0.0` (v8 API: `.match()` 메서드) 요구
- `package.json` `overrides`의 `"path-to-regexp": "0.1.13"`이 **전체 트리**를 v0.1.13으로 강제
- v0.1.13에는 `.match()` 메서드가 없으므로 `router@2.2.0` 초기화 시 `TypeError` 발생
- 이 override는 Express 4 시절 CVE-2024-45296 대응으로 추가되었으나, NestJS v11의 Express 5 채택으로 역효과

코드 변경 없이 이미지 재빌드만으로 발생한 이유: `npm ci`는 lock 파일을 존중하지만, **lock 파일 자체**가 `overrides` 설정을 기반으로 생성되어 있으므로 override 값이 lock에 반영됨.

## 수정

`package.json` `overrides`에서 `path-to-regexp: 0.1.13` 제거.

Express 5 / `router@2.2.0`이 요구하는 `path-to-regexp@8.4.2`로 자연스럽게 해소. `package-lock.json` 재생성하여 `node_modules/path-to-regexp: 8.4.2`로 lock 갱신.

`multer: 2.1.1` / `lodash: 4.18.0` override는 유지 (별도 보안 이슈 대응).

## 검증

```
# Docker 빌드 성공
docker build -t rummiarena/ai-adapter:day3-fix-dep-drift . → DONE

# 컨테이너 정상 기동 (TypeError 없음)
[Nest] LOG [NestFactory] Starting Nest application...
[Nest] LOG [RoutesResolver] AppController {/}:
[Nest] LOG [RouterExplorer] Mapped {/, GET} route
[Nest] LOG [RoutesResolver] MoveController {/move}:
[Nest] LOG [RouterExplorer] Mapped {/move, POST} route
...

# Jest: 599 tests all PASS
Test Suites: 28 passed, 28 total
Tests:       599 passed, 599 total
```

## 배포 (메인 세션 인수)

```bash
# 이미지 태그 교체 후 K8s 적용
kubectl set image deployment/ai-adapter \
  ai-adapter=rummiarena/ai-adapter:day3-fix-dep-drift \
  -n rummikub

# 또는 Helm rollout
helm upgrade ai-adapter helm/charts/ai-adapter \
  --set image.tag=day3-fix-dep-drift -n rummikub
```

## Sprint 7 Week 2 후속

- game-server, frontend, admin Dockerfile도 `npm install` 여부 점검 → 모두 `npm ci` 적용 확인
- `overrides` 섹션 변경 시 Express 버전 호환성 재확인 체크리스트 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)