### PR TITLE
fix(frontend): 이월 F1~F5 통합 수정 — BUG-UI-012 Phase2 + V-04 rack sync + FINDING-01 이중화 + T11-03 정합성

### DIFF
--- a/src/frontend/e2e/turn-sync.spec.ts
+++ b/src/frontend/e2e/turn-sync.spec.ts
@@ -115,8 +115,11 @@ test.describe("BUG-UI-011: AI 턴 중 플레이어 버튼 활성화 금지", () 
       }
     }
 
-    // 최소 하나라도 렌더되어 있어야 의미 있는 테스트
-    const totalCount = (await undoBtn.count()) + (await newGroupBtn.count());
-    expect(totalCount).toBeGreaterThan(0);
+    // F5 결정 (architect 옵션 C): T11-01 ActionBar hidden 정책과 정합.
+    // AI 턴에는 ActionBar 전체 hidden (PR #78 isMyTurn SSOT) 이므로
+    // 되돌리기/새 그룹 버튼이 totalCount=0 이어도 FAIL 이 아니다.
+    // T11-01 이 이미 hidden 을 검증하므로 여기서 중복 가드는 자기 모순.
+    // 버튼이 렌더된 경우에만 disabled 검증 (방어적) — 가드 삭제.
+    // 참조: work_logs/plans/tmp-analysis/f3-f4-f5-architect-guide.md §3.3
   });
 });

--- a/src/frontend/src/app/game/[roomId]/GameClient.tsx
+++ b/src/frontend/src/app/game/[roomId]/GameClient.tsx
@@ -475,6 +475,10 @@ export default function GameClient({ roomId }: GameClientProps) {
     deadlockReason,
     turnHistory,
     lastTurnPlacement,
+    // F1/F2 (BUG-UI-012 Phase 2): 기권 종료 모달 트리거용 스키마
+    gameStatus,
+    endReason,
+    winner: gameWinner,
     reset: resetGameStore,
   } = useGameStore();
 
@@ -1376,6 +1380,15 @@ export default function GameClient({ roomId }: GameClientProps) {
     const tilesFromRack = myTiles.filter(
       (t) => !pendingMyTiles.includes(t)
     );
+    // F3 (V-04 SC1): Optimistic myTiles commit.
+    // 확정 요청 직후 pendingMyTiles 를 myTiles 루트 state 로 커밋한다.
+    // spec 은 handleConfirm 직후 rack DOM 을 읽으므로, 서버 TURN_END 응답을
+    // 기다리지 않고 즉시 반영이 필요하다.
+    // 서버 TURN_END.payload.myRack 이 SSOT 이므로 INVALID_MOVE 시 서버가
+    // 원본 rack 을 내려줘 복구된다 (architect 가이드 §F3 A1).
+    if (pendingMyTiles) {
+      setMyTiles(pendingMyTiles);
+    }
     // [Issue #48] 전송 직전 락 설정 — TURN_START 또는 INVALID_MOVE 수신 시 useEffect 에서 해제
     setConfirmBusy(true);
     // 1단계: 이번 턴 배치 내용을 서버에 전송
@@ -1440,6 +1453,45 @@ export default function GameClient({ roomId }: GameClientProps) {
         players={players}
         deadlockReason={deadlockReason}
       />
+    );
+  }
+
+  // F1/F2 (BUG-UI-012 Phase 2): gameStatus='ended' 모달 렌더 조건 배선.
+  // PLAYER_FORFEITED 또는 GAME_OVER 이벤트로 gameStatus='ended' 가 설정되면
+  // gameEnded(GAME_OVER 전용) 와 별개로 기권 종료 모달을 즉시 표시한다.
+  // endReason + winner 를 props 로 전달하여 정상 한글 문구를 렌더링 가능.
+  if (gameStatus === "ended" && !gameEnded) {
+    return (
+      <div
+        role="dialog"
+        aria-label="게임 종료"
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+      >
+        <div className="bg-surface border border-border rounded-2xl p-8 max-w-md w-full text-center space-y-4">
+          <h2 className="text-xl font-bold text-text-primary">
+            {endReason === "opponent_forfeit" ? "상대방 기권" : "게임 종료"}
+          </h2>
+          <p className="text-text-secondary">
+            {endReason === "opponent_forfeit"
+              ? "상대방이 기권하여 게임이 중단되었습니다."
+              : "게임이 종료되었습니다."}
+          </p>
+          {gameWinner && (
+            <p className="text-text-primary font-semibold">
+              {gameWinner.displayName} 승리
+            </p>
+          )}
+          <button
+            onClick={() => {
+              resetGameStore();
+              router.push("/lobby");
+            }}
+            className="mt-4 px-6 py-2 bg-primary text-white rounded-lg hover:bg-primary/80 transition"
+          >
+            로비로 돌아가기
+          </button>
+        </div>
+      </div>
     );
   }
 

--- a/src/frontend/src/app/game/[roomId]/GameClient.tsx
+++ b/src/frontend/src/app/game/[roomId]/GameClient.tsx
@@ -484,6 +484,16 @@ export default function GameClient({ roomId }: GameClientProps) {
 
   const { mySeat: roomMySeat } = useRoomStore();
 
+  // F4 (FINDING-01 재검토): effectiveHasInitialMeld — players[mySeat].hasInitialMeld 를 1차 SSOT,
+  // 루트 hasInitialMeld 를 fallback 으로 사용하는 derived 값.
+  // GAME_STATE 핸들러(useWebSocket.ts)가 players[] 만 업데이트하는 구조 때문에
+  // 루트 hasInitialMeld 가 stale 될 수 있다 (architect 가이드 §F4 B1).
+  const effectiveHasInitialMeld = useMemo(() => {
+    if (mySeat === null || mySeat < 0) return hasInitialMeld;
+    const me = players.find((p) => p.seat === mySeat);
+    return me?.hasInitialMeld ?? hasInitialMeld;
+  }, [players, mySeat, hasInitialMeld]);
+
   const [activeDragCode, setActiveDragCode] = useState<TileCode | null>(null);
   const isDragging = activeDragCode !== null;
   // BUG-UI-LAYOUT-001: 히스토리 패널 토글 (기본 펼침)
@@ -759,7 +769,16 @@ export default function GameClient({ roomId }: GameClientProps) {
       const freshPendingTableGroups = latestState.pendingTableGroups;
       const freshPendingGroupIds = latestState.pendingGroupIds;
       const freshPendingRecoveredJokers = latestState.pendingRecoveredJokers;
-      const freshHasInitialMeld = latestState.hasInitialMeld;
+      // F4 (FINDING-01): players[mySeat].hasInitialMeld 를 1차 SSOT 로 사용 (루트는 fallback).
+      // GAME_STATE 핸들러가 players[] 만 업데이트하므로 루트 hasInitialMeld 가 stale 될 수 있음.
+      const freshHasInitialMeld = (() => {
+        const seat = latestState.mySeat;
+        if (seat >= 0) {
+          const me = latestState.players.find((p) => p.seat === seat);
+          if (me?.hasInitialMeld !== undefined) return me.hasInitialMeld;
+        }
+        return latestState.hasInitialMeld;
+      })();
 
       const dragSource = activeDragSourceRef.current;
       activeDragSourceRef.current = null;
@@ -1663,7 +1682,7 @@ export default function GameClient({ roomId }: GameClientProps) {
           <main className="flex-1 flex flex-col p-4 gap-3 overflow-hidden min-h-0 min-w-0">
             {/* UX-004: 초기 등록 안내 배너 (최초 진입 1회) */}
             <InitialMeldBanner
-              hasInitialMeld={hasInitialMeld}
+              hasInitialMeld={effectiveHasInitialMeld}
               roomId={roomId}
             />
 
@@ -1680,7 +1699,7 @@ export default function GameClient({ roomId }: GameClientProps) {
               tilesDraggable={isMyTurn}
               validMergeGroupIds={validMergeGroupIds}
               showNewGroupDropZone={isMyTurn}
-              hasInitialMeld={hasInitialMeld}
+              hasInitialMeld={effectiveHasInitialMeld}
               className="flex-1"
             />
 
@@ -1729,7 +1748,7 @@ export default function GameClient({ roomId }: GameClientProps) {
                   <span className="text-text-primary font-medium">
                     ({currentMyTiles.length}장)
                   </span>
-                  {hasInitialMeld ? (
+                  {effectiveHasInitialMeld ? (
                     <span> &middot; 최초 등록 완료</span>
                   ) : pendingPlacementScore > 0 ? (
                     <span

--- a/src/frontend/src/hooks/useWebSocket.ts
+++ b/src/frontend/src/hooks/useWebSocket.ts
@@ -338,6 +338,28 @@ export function useWebSocket({ roomId, enabled = true }: UseWebSocketOptions) {
           console.info("[WS] GAME_OVER", payload);
           useGameStore.getState().setGameOverResult(payload);
           setGameEnded(true);
+          // F1/F2 (BUG-UI-012 Phase 2): gameStatus + endReason + winner 반영
+          // setStoreState({gameStatus:'ended',...}) E2E 주입 및 실제 WS 이벤트 모두 처리
+          {
+            const storeState = useGameStore.getState();
+            const winnerPlayer = payload.winnerId
+              ? storeState.players.find((p) => {
+                  // Player 타입은 userId 필드를 가짐
+                  const hp = p as { userId?: string; displayName?: string };
+                  return hp.userId === payload.winnerId;
+                })
+              : null;
+            useGameStore.setState({
+              gameStatus: "ended",
+              endReason: "game_over",
+              winner: winnerPlayer
+                ? {
+                    userId: (winnerPlayer as { userId?: string }).userId ?? "",
+                    displayName: winnerPlayer.displayName ?? "",
+                  }
+                : null,
+            });
+          }
           break;
         }
         case "PLAYER_JOIN": {
@@ -410,7 +432,18 @@ export function useWebSocket({ roomId, enabled = true }: UseWebSocketOptions) {
             "[WS] PLAYER_FORFEITED seat=%d %s reason=%s activePlayers=%d",
             payload.seat, payload.displayName, payload.reason, payload.activePlayers
           );
-          // isGameOver이면 GAME_OVER 메시지가 별도로 오므로 여기서는 처리하지 않음
+          // F1/F2 (BUG-UI-012 Phase 2): 상대 기권 시 gameStatus='ended' + endReason 반영
+          // activePlayers <= 1 이면 게임 종료로 간주 (GAME_OVER 메시지 도달 전 모달 선행 렌더)
+          if (payload.activePlayers <= 1) {
+            // 나를 제외한 기권자가 winner 가 아님 → winner 는 나(현재 플레이어) 또는 null
+            useGameStore.setState({
+              gameStatus: "ended",
+              endReason: "opponent_forfeit",
+              // winner 는 GAME_OVER 이벤트에서 확정 예정. 여기서는 null 유지.
+              winner: null,
+            });
+          }
+          // isGameOver이면 GAME_OVER 메시지가 별도로 오므로 거기서 확정
           break;
         }
         // ---- 교착 처리 메시지 ----

--- a/src/frontend/src/hooks/useWebSocket.ts
+++ b/src/frontend/src/hooks/useWebSocket.ts
@@ -177,16 +177,17 @@ export function useWebSocket({ roomId, enabled = true }: UseWebSocketOptions) {
             } as Player;
           });
           setPlayers(playersUpdated);
-          // BUG-UI-EXT 수정 3: hasInitialMeld SSOT 동기화 —
+          // BUG-UI-EXT 수정 3 + F4 B2 (FINDING-01): hasInitialMeld 완전 SSOT 동기화 —
           // TURN_END 에서만 루트 hasInitialMeld 를 갱신하던 기존 로직은 GAME_STATE (재연결/
           // 새로고침 복구) 시 루트 hasInitialMeld 가 false 로 초기화되는 드리프트를 유발한다.
           // GAME_STATE 수신 시에도 내 seat 의 hasInitialMeld 를 루트 state 에 동기화한다.
-          // (architect 재재조사 §4.3 + §5.2 C)
+          // F4 B2: true 뿐만 아니라 false 포함 전체 값을 동기화 (이중화 해소).
+          // (architect 가이드 §F4 B2 + 재재조사 §4.3 + §5.2 C)
           {
             const mySeatNow = useGameStore.getState().mySeat;
             const myPlayer = payload.players.find((p) => p.seat === mySeatNow);
-            if (myPlayer?.hasInitialMeld) {
-              setHasInitialMeld(true);
+            if (myPlayer !== undefined && myPlayer.hasInitialMeld !== undefined) {
+              setHasInitialMeld(myPlayer.hasInitialMeld);
             }
           }
           // drawPileCount가 0이면 소진 상태 설정

--- a/src/frontend/src/store/gameStore.ts
+++ b/src/frontend/src/store/gameStore.ts
@@ -122,6 +122,16 @@ interface GameStore {
   // pending 상태만 초기화 (INVALID_MOVE 롤백 시 사용)
   resetPending: () => void;
 
+  // F1/F2 (BUG-UI-012 Phase 2): 게임 종료 상태 스키마
+  // GAME_ENDED / PLAYER_FORFEITED 이벤트 수신 시 모달 트리거에 사용.
+  // gameEnded(boolean) 는 GAME_OVER 이벤트 기반이므로 별도 유지.
+  gameStatus: "waiting" | "playing" | "ended";
+  setGameStatus: (status: "waiting" | "playing" | "ended") => void;
+  endReason: string | null;
+  setEndReason: (reason: string | null) => void;
+  winner: { userId: string; displayName: string } | null;
+  setWinner: (winner: { userId: string; displayName: string } | null) => void;
+
   // 전체 초기화
   reset: () => void;
 }
@@ -148,6 +158,10 @@ const initialState = {
   deadlockReason: null as string | null,
   turnHistory: [] as TurnPlacement[],
   lastTurnPlacement: null as TurnPlacement | null,
+  // F1/F2 (BUG-UI-012 Phase 2)
+  gameStatus: "waiting" as "waiting" | "playing" | "ended",
+  endReason: null as string | null,
+  winner: null as { userId: string; displayName: string } | null,
 };
 
 // 히스토리 보관 최대 건수 (메모리 절약)
@@ -194,6 +208,10 @@ export const useGameStore = create<GameStore>()(
     setTurnNumber: (turnNumber) => set({ turnNumber }),
     setGameEnded: (gameEnded) => set({ gameEnded }),
     setGameOverResult: (gameOverResult) => set({ gameOverResult }),
+    // F1/F2 (BUG-UI-012 Phase 2) setters
+    setGameStatus: (gameStatus) => set({ gameStatus }),
+    setEndReason: (endReason) => set({ endReason }),
+    setWinner: (winner) => set({ winner }),
 
     addDisconnectedPlayer: (info) =>
       set((state) => ({


### PR DESCRIPTION
## Summary

Sprint 7 Week 2 이월 5건 통합 수정 (architect 가이드 `work_logs/plans/tmp-analysis/f3-f4-f5-architect-guide.md` 준수).

### F1+F2: BUG-UI-012 Phase 2 — gameStore 스키마 확장 + 기권 모달 배선

**증상**: `i18n-render T12-01/T12-02` FAIL — 기권 종료 모달 자체가 미렌더.

**수정**:
- `src/frontend/src/store/gameStore.ts`: `gameStatus`/`endReason`/`winner` 3개 키 + setter 추가 (`initialState` 포함).
- `src/frontend/src/hooks/useWebSocket.ts`: `GAME_OVER` 이벤트 시 `gameStatus='ended'` + `winner` 반영. `PLAYER_FORFEITED` + `activePlayers<=1` 시 `endReason='opponent_forfeit'` 선행 반영.
- `src/frontend/src/app/game/[roomId]/GameClient.tsx`: `gameStatus === 'ended' && !gameEnded` 조건 모달 렌더. `role="dialog"` + `aria-label="게임 종료"` + 정상 한글 문구 ("상대방이 기권하여 게임이 중단되었습니다.").

**기대 GREEN**: `i18n-render T12-01`, `T12-02`

### F3: V-04 확정 후 rack 동기화

**증상**: `rule-initial-meld-30pt V04-SC1` FAIL — 확정 후 rack 에서 타일이 제거되지 않음.

**수정**:
- `GameClient.tsx` `handleConfirm` 직전에 `setMyTiles(pendingMyTiles)` optimistic commit 1 라인 추가.
- 서버 `TURN_END.payload.myRack` 이 SSOT 이므로 INVALID_MOVE 시 자동 복구 (아키텍트 가이드 §F3 A1).

**기대 GREEN**: `rule-initial-meld-30pt V04-SC1`

### F4: FINDING-01 hasInitialMeld=false 새 그룹 분리 (architect + frontend-dev 페어)

**증상**: `rule-initial-meld-30pt V04-SC3` FAIL — `hasInitialMeld=false` 상태에서 서버 그룹 위 drop 시 새 pending 그룹 분리 미발동.

**수정** (architect 가이드 §F4 B1 + B2 병용):
- `GameClient.tsx` destructure 직후 `effectiveHasInitialMeld` useMemo 추가: `players[mySeat].hasInitialMeld` 1차 SSOT, 루트 `hasInitialMeld` fallback.
- render 경로 3지점 교체: `InitialMeldBanner` prop, `GameBoard.hasInitialMeld` prop, 랙 헤더 표시 분기.
- `handleDragEnd` 내 `freshHasInitialMeld` 파생 로직: `latestState.players[mySeat]` 우선.
- `useWebSocket.ts` GAME_STATE 핸들러: `hasInitialMeld` 동기화를 `true` 전용에서 전체 값으로 확장 (F4 B2).

**페어 증거**: architect 가이드 `f3-f4-f5-architect-guide.md` §2.3 B1+B2 지정 범위만 수정. Sprint 8 ADR: state 이중화 근본 리팩터 예정.

**기대 GREEN**: `rule-initial-meld-30pt V04-SC3`

### F5: T11-03 정합성 — 옵션 C (spec 수정)

**증상**: `turn-sync T11-03` FAIL — AI 턴 중 버튼 `totalCount=0` (ActionBar hidden 시).

**수정**:
- `src/frontend/e2e/turn-sync.spec.ts:119-120` `totalCount > 0` 가드 삭제 + 정책 주석 추가.
- 근거: T11-01 `ActionBar toBeHidden` 과 자기 모순. `hidden` ActionBar 안의 버튼은 count=0 이 정상.
- 구현 변경 없음 (PR #78 isMyTurn SSOT 이미 배포).

**기대 GREEN**: `turn-sync T11-03`

## Phase B 테스트 결과

```
Jest (unit): 203 passed / 0 failed / 12 suites
회귀: 0건 (hotfix-p0-*, regression-pr41-*, meld-dup-render 포함)
```

## 후속 배포 플로우 (메인 세션 인수)

1. `docker build -t rummiarena/frontend:day3-f1-f5 .` (worktree 아닌 main 머지 후 재빌드 권장)
2. `kubectl -n rummikub set image deploy/frontend frontend=rummiarena/frontend:day3-f1-f5`
3. qa Stage 1 재실행: `npx playwright test turn-sync.spec.ts i18n-render.spec.ts rule-initial-meld-30pt.spec.ts --workers=1`
4. 기대: F1~F5 해당 5 TC GREEN 전환 (잔존 회귀 0 확인 후 smoke --axis i18n 재실행)

## Sprint 7 Week 2 후속

- **F4 state 이중화 근본 리팩터**: Sprint 8 ADR 제안 (루트 `hasInitialMeld` 제거 or `players[]` 제거 중 택일).
- **EXT-SC4**: PR #76 + PR #78 결합 후 재실행 필요 (본 PR 범위 외).

🤖 Generated with [Claude Code](https://claude.com/claude-code)