### PR TITLE
fix(ws): winnerPlayer.displayName type guard — PR #81 후속

### DIFF
--- a/src/frontend/src/hooks/useWebSocket.ts
+++ b/src/frontend/src/hooks/useWebSocket.ts
@@ -356,7 +356,7 @@ export function useWebSocket({ roomId, enabled = true }: UseWebSocketOptions) {
               winner: winnerPlayer
                 ? {
                     userId: (winnerPlayer as { userId?: string }).userId ?? "",
-                    displayName: winnerPlayer.displayName ?? "",
+                    displayName: (winnerPlayer as { displayName?: string }).displayName ?? "",
                   }
                 : null,
             });


### PR DESCRIPTION
PR #81 GAME_OVER winner payload 의 displayName 접근에 AIPlayer 호환 type guard 추가. userId 패턴과 동일.

🤖 Generated with [Claude Code](https://claude.com/claude-code)