### PR TITLE
[UR-01..36][F-21] Phase D PR-D-D01 design-tokens-css-variables — RED→GREEN 41/41 PASS

### DIFF
--- a/src/frontend/src/__tests__/design-tokens-css-variables.test.ts
+++ b/src/frontend/src/__tests__/design-tokens-css-variables.test.ts
@@ -1,0 +1,338 @@
+/**
+ * PR-D-D01 RED spec — 디자인 토큰 30종 CSS 변수화
+ *
+ * 검증 대상: docs/02-design/57-game-rule-visual-language.md §1.1
+ * SSOT: 57 §1.1 기반 색상 토큰 30종 + 애니메이션 토큰 7종 + spacing 토큰 6종
+ *
+ * 관련 룰 ID: UR-01~UR-36 (base token layer)
+ * 관련 F-NN: F-21 (호환 드롭존 — drop-allow/drop-block 토큰 의존)
+ *
+ * RED 이유:
+ *   globals.css 에는 현재 57 §1.1 정의 토큰 중 다음이 누락/불일치:
+ *   - --tile-text-light, --tile-text-dark (타일 숫자 색)
+ *   - --tile-joker-ring (조커 무지개 링)
+ *   - --pending-border, --pending-bg, --pending-invalid (pending 그룹)
+ *   - --toast-error, --toast-info, --toast-warn (토스트 3종)
+ *   - --highlight-mine, --highlight-opp (타일 글로우)
+ *   - --timer-normal, --timer-warn, --timer-critical (타이머 3단계)
+ *   - --state-connected, --state-disconn, --state-forfeited, --state-meld-done, --state-meld-none (플레이어 상태 5종)
+ *   - --dur-instant, --dur-fast, --dur-normal, --dur-slow (애니메이션 시간)
+ *   - --ease-out, --ease-bounce (easing)
+ *   - --space-header-h, --space-player-card-compact-h, --space-rack-h, --space-action-bar-h (spacing)
+ *
+ * GREEN 조건: globals.css :root 에 위 모든 변수가 정확한 값으로 정의됨
+ */
+
+// Node.js fs로 globals.css 텍스트를 직접 읽어 검증
+// (브라우저 CSSStyleDeclaration 없는 환경에서 동작)
+import * as fs from "fs";
+import * as path from "path";
+
+const GLOBALS_CSS_PATH = path.resolve(
+  __dirname,
+  "../app/globals.css"
+);
+
+/** globals.css 파일 내용을 한 번만 읽음 */
+let cssText: string;
+beforeAll(() => {
+  cssText = fs.readFileSync(GLOBALS_CSS_PATH, "utf-8");
+});
+
+/**
+ * :root 블록에서 CSS 변수값을 추출하는 헬퍼
+ * 단순 정규식 파싱 — :root 블록 전체를 대상으로 검색
+ */
+function getRootVar(varName: string): string | null {
+  // e.g. --tile-red: #E74C3C
+  const pattern = new RegExp(
+    `${varName.replace(/[-]/g, "\\-")}\\s*:\\s*([^;\\n]+)`,
+    "i"
+  );
+  const match = cssText.match(pattern);
+  return match ? match[1].trim() : null;
+}
+
+// ─── §1 기반 색상 토큰 (57 §1.1) ────────────────────────────────────────────
+
+describe("[UR-01~UR-36][F-21] 디자인 토큰 — 타일 색상 4종", () => {
+  test("--tile-red 는 #E74C3C 또는 소문자 동등값이어야 한다", () => {
+    const v = getRootVar("--tile-red");
+    expect(v).not.toBeNull();
+    expect(v!.toLowerCase()).toBe("#e74c3c");
+  });
+
+  test("--tile-blue 는 #3498DB 또는 소문자 동등값이어야 한다", () => {
+    const v = getRootVar("--tile-blue");
+    expect(v).not.toBeNull();
+    expect(v!.toLowerCase()).toBe("#3498db");
+  });
+
+  test("--tile-yellow 는 #F1C40F 또는 소문자 동등값이어야 한다", () => {
+    const v = getRootVar("--tile-yellow");
+    expect(v).not.toBeNull();
+    expect(v!.toLowerCase()).toBe("#f1c40f");
+  });
+
+  test("--tile-black 은 #2C3E50 또는 소문자 동등값이어야 한다", () => {
+    const v = getRootVar("--tile-black");
+    expect(v).not.toBeNull();
+    expect(v!.toLowerCase()).toBe("#2c3e50");
+  });
+});
+
+describe("[UR-01~UR-36][F-21] 디자인 토큰 — 타일 텍스트 색 (현재 누락 → RED)", () => {
+  test("--tile-text-light 는 #FFFFFF 이어야 한다 (밝은 배경 위 숫자)", () => {
+    const v = getRootVar("--tile-text-light");
+    expect(v).not.toBeNull();
+    expect(v!.toLowerCase()).toBe("#ffffff");
+  });
+
+  test("--tile-text-dark 는 #1A1A1A 이어야 한다 (노랑 배경 위 숫자)", () => {
+    const v = getRootVar("--tile-text-dark");
+    expect(v).not.toBeNull();
+    expect(v!.toLowerCase()).toBe("#1a1a1a");
+  });
+});
+
+describe("[UR-09][F-21] 디자인 토큰 — 조커 링 (현재 누락 → RED)", () => {
+  test("--tile-joker-ring 은 #C084FC 이어야 한다", () => {
+    const v = getRootVar("--tile-joker-ring");
+    expect(v).not.toBeNull();
+    expect(v!.toLowerCase()).toBe("#c084fc");
+  });
+});
+
+describe("[UR-01~UR-36][F-21] 디자인 토큰 — 보드 배경", () => {
+  test("--board-bg 는 #1A3328 또는 소문자 동등값이어야 한다", () => {
+    const v = getRootVar("--board-bg");
+    expect(v).not.toBeNull();
+    expect(v!.toLowerCase()).toBe("#1a3328");
+  });
+
+  test("--board-border 는 #2A5A3A 또는 소문자 동등값이어야 한다", () => {
+    const v = getRootVar("--board-border");
+    expect(v).not.toBeNull();
+    expect(v!.toLowerCase()).toBe("#2a5a3a");
+  });
+});
+
+describe("[UR-10][UR-14][UR-18][F-21] 디자인 토큰 — 드롭존 허용 (이미 존재, GREEN 확인)", () => {
+  test("--drop-allow 는 #27AE60 소문자이어야 한다", () => {
+    const v = getRootVar("--drop-allow");
+    expect(v).not.toBeNull();
+    expect(v!.toLowerCase()).toBe("#27ae60");
+  });
+
+  test("--drop-allow-bg 는 rgba(39,174,96,0.12) 계열이어야 한다", () => {
+    const v = getRootVar("--drop-allow-bg");
+    expect(v).not.toBeNull();
+    // 공백 정규화 후 포함 여부 확인
+    expect(v!.replace(/\s/g, "").toLowerCase()).toContain("rgba(39,174,96");
+  });
+
+  test("--drop-allow-border 는 rgba(39,174,96,0.7) 계열이어야 한다", () => {
+    const v = getRootVar("--drop-allow-border");
+    expect(v).not.toBeNull();
+    expect(v!.replace(/\s/g, "").toLowerCase()).toContain("rgba(39,174,96");
+  });
+});
+
+describe("[UR-14][UR-19][F-21] 디자인 토큰 — 드롭존 차단 (이미 존재, GREEN 확인)", () => {
+  test("--drop-block 은 #C0392B 소문자이어야 한다", () => {
+    const v = getRootVar("--drop-block");
+    expect(v).not.toBeNull();
+    expect(v!.toLowerCase()).toBe("#c0392b");
+  });
+
+  test("--drop-block-bg 는 rgba(192,57,43,0.12) 계열이어야 한다", () => {
+    const v = getRootVar("--drop-block-bg");
+    expect(v).not.toBeNull();
+    expect(v!.replace(/\s/g, "").toLowerCase()).toContain("rgba(192,57,43");
+  });
+
+  test("--drop-block-border 는 rgba(192,57,43,0.7) 계열이어야 한다", () => {
+    const v = getRootVar("--drop-block-border");
+    expect(v).not.toBeNull();
+    expect(v!.replace(/\s/g, "").toLowerCase()).toContain("rgba(192,57,43");
+  });
+});
+
+describe("[UR-20][F-21] 디자인 토큰 — pending 그룹 (현재 누락 → RED)", () => {
+  test("--pending-border 는 #F1C40F 이어야 한다 (노랑 점선)", () => {
+    const v = getRootVar("--pending-border");
+    expect(v).not.toBeNull();
+    expect(v!.toLowerCase()).toBe("#f1c40f");
+  });
+
+  test("--pending-bg 는 rgba(241,196,15,0.10) 계열이어야 한다", () => {
+    const v = getRootVar("--pending-bg");
+    expect(v).not.toBeNull();
+    expect(v!.replace(/\s/g, "").toLowerCase()).toContain("rgba(241,196,15");
+  });
+
+  test("--pending-invalid 는 #E74C3C 이어야 한다 (pending 무효 빨간 ring)", () => {
+    const v = getRootVar("--pending-invalid");
+    expect(v).not.toBeNull();
+    expect(v!.toLowerCase()).toBe("#e74c3c");
+  });
+});
+
+describe("[UR-21][UR-29][UR-30] 디자인 토큰 — 토스트 3종 (현재 누락 → RED)", () => {
+  test("--toast-error 는 #C0392B 이어야 한다", () => {
+    const v = getRootVar("--toast-error");
+    expect(v).not.toBeNull();
+    expect(v!.toLowerCase()).toBe("#c0392b");
+  });
+
+  test("--toast-info 는 #3498DB 이어야 한다", () => {
+    const v = getRootVar("--toast-info");
+    expect(v).not.toBeNull();
+    expect(v!.toLowerCase()).toBe("#3498db");
+  });
+
+  test("--toast-warn 은 #E67E22 이어야 한다", () => {
+    const v = getRootVar("--toast-warn");
+    expect(v).not.toBeNull();
+    expect(v!.toLowerCase()).toBe("#e67e22");
+  });
+});
+
+describe("[UR-02][UR-05] 디자인 토큰 — 타일 글로우 (현재 누락 → RED)", () => {
+  test("--highlight-mine 은 rgba(74,222,128,0.90) 계열이어야 한다", () => {
+    const v = getRootVar("--highlight-mine");
+    expect(v).not.toBeNull();
+    expect(v!.replace(/\s/g, "").toLowerCase()).toContain("rgba(74,222,128");
+  });
+
+  test("--highlight-opp 는 rgba(251,146,60,0.90) 계열이어야 한다", () => {
+    const v = getRootVar("--highlight-opp");
+    expect(v).not.toBeNull();
+    expect(v!.replace(/\s/g, "").toLowerCase()).toContain("rgba(251,146,60");
+  });
+});
+
+describe("[UR-26] 디자인 토큰 — 타이머 3단계 (현재 누락 → RED)", () => {
+  test("--timer-normal 은 #3498DB 이어야 한다", () => {
+    const v = getRootVar("--timer-normal");
+    expect(v).not.toBeNull();
+    expect(v!.toLowerCase()).toBe("#3498db");
+  });
+
+  test("--timer-warn 은 #F1C40F 이어야 한다", () => {
+    const v = getRootVar("--timer-warn");
+    expect(v).not.toBeNull();
+    expect(v!.toLowerCase()).toBe("#f1c40f");
+  });
+
+  test("--timer-critical 은 #E74C3C 이어야 한다", () => {
+    const v = getRootVar("--timer-critical");
+    expect(v).not.toBeNull();
+    expect(v!.toLowerCase()).toBe("#e74c3c");
+  });
+});
+
+describe("[UR-32][UR-13] 디자인 토큰 — 플레이어 상태 5종 (현재 누락 → RED)", () => {
+  test("--state-connected 는 #3FB950 이어야 한다", () => {
+    const v = getRootVar("--state-connected");
+    expect(v).not.toBeNull();
+    expect(v!.toLowerCase()).toBe("#3fb950");
+  });
+
+  test("--state-disconn 은 #F0883E 이어야 한다", () => {
+    const v = getRootVar("--state-disconn");
+    expect(v).not.toBeNull();
+    expect(v!.toLowerCase()).toBe("#f0883e");
+  });
+
+  test("--state-forfeited 는 #484F58 이어야 한다", () => {
+    const v = getRootVar("--state-forfeited");
+    expect(v).not.toBeNull();
+    expect(v!.toLowerCase()).toBe("#484f58");
+  });
+
+  test("--state-meld-done 은 #3FB950 이어야 한다", () => {
+    const v = getRootVar("--state-meld-done");
+    expect(v).not.toBeNull();
+    expect(v!.toLowerCase()).toBe("#3fb950");
+  });
+
+  test("--state-meld-none 은 rgba(231,76,60,0.50) 계열이어야 한다", () => {
+    const v = getRootVar("--state-meld-none");
+    expect(v).not.toBeNull();
+    expect(v!.replace(/\s/g, "").toLowerCase()).toContain("rgba(231,76,60");
+  });
+});
+
+// ─── §1.2 애니메이션 토큰 (현재 누락 → RED) ──────────────────────────────────
+
+describe("[UR-06][UR-17] 디자인 토큰 — 애니메이션 duration (현재 누락 → RED)", () => {
+  test("--dur-instant 는 50ms 이어야 한다", () => {
+    const v = getRootVar("--dur-instant");
+    expect(v).not.toBeNull();
+    expect(v!.trim()).toBe("50ms");
+  });
+
+  test("--dur-fast 는 150ms 이어야 한다", () => {
+    const v = getRootVar("--dur-fast");
+    expect(v).not.toBeNull();
+    expect(v!.trim()).toBe("150ms");
+  });
+
+  test("--dur-normal 은 300ms 이어야 한다", () => {
+    const v = getRootVar("--dur-normal");
+    expect(v).not.toBeNull();
+    expect(v!.trim()).toBe("300ms");
+  });
+
+  test("--dur-slow 는 500ms 이어야 한다", () => {
+    const v = getRootVar("--dur-slow");
+    expect(v).not.toBeNull();
+    expect(v!.trim()).toBe("500ms");
+  });
+});
+
+describe("[UR-06][UR-17] 디자인 토큰 — easing (현재 누락 → RED)", () => {
+  test("--ease-out 은 cubic-bezier(0,0,0.2,1) 이어야 한다", () => {
+    const v = getRootVar("--ease-out");
+    expect(v).not.toBeNull();
+    // 공백 정규화 후 비교
+    expect(v!.replace(/\s/g, "").toLowerCase()).toBe("cubic-bezier(0,0,0.2,1)");
+  });
+
+  test("--ease-bounce 는 cubic-bezier(0.68,-0.55,0.265,1.55) 이어야 한다", () => {
+    const v = getRootVar("--ease-bounce");
+    expect(v).not.toBeNull();
+    expect(v!.replace(/\s/g, "").toLowerCase()).toBe(
+      "cubic-bezier(0.68,-0.55,0.265,1.55)"
+    );
+  });
+});
+
+// ─── §11.4 spacing 토큰 (현재 누락 → RED) ────────────────────────────────────
+
+describe("[UR-01][F-21] 디자인 토큰 — spacing 레이아웃 (현재 누락 → RED)", () => {
+  test("--space-header-h 는 32px 이어야 한다", () => {
+    const v = getRootVar("--space-header-h");
+    expect(v).not.toBeNull();
+    expect(v!.trim()).toBe("32px");
+  });
+
+  test("--space-player-card-compact-h 는 56px 이어야 한다", () => {
+    const v = getRootVar("--space-player-card-compact-h");
+    expect(v).not.toBeNull();
+    expect(v!.trim()).toBe("56px");
+  });
+
+  test("--space-rack-h 는 100px 이어야 한다", () => {
+    const v = getRootVar("--space-rack-h");
+    expect(v).not.toBeNull();
+    expect(v!.trim()).toBe("100px");
+  });
+
+  test("--space-action-bar-h 는 56px 이어야 한다", () => {
+    const v = getRootVar("--space-action-bar-h");
+    expect(v).not.toBeNull();
+    expect(v!.trim()).toBe("56px");
+  });
+});

--- a/src/frontend/src/app/globals.css
+++ b/src/frontend/src/app/globals.css
@@ -2,14 +2,62 @@
 @tailwind components;
 @tailwind utilities;
 
-/* CSS 디자인 토큰 (07-ui-wireframe.md §1.1 기준) */
+/* CSS 디자인 토큰 SSOT: docs/02-design/57-game-rule-visual-language.md §1.1 §1.2 §11.4 */
 :root {
-  --tile-red: #e74c3c;
-  --tile-blue: #3498db;
-  --tile-yellow: #f1c40f;
-  --tile-black: #2c3e50;
-  --board-bg: #1a3328;
-  --board-border: #2a5a3a;
+  /* ─── 타일 색상 4종 (57 §1.1) ──────────────────────────────────── */
+  --tile-red: #e74c3c;       /* 빨강 타일 배경 */
+  --tile-blue: #3498db;      /* 파랑 타일 배경 */
+  --tile-yellow: #f1c40f;    /* 노랑 타일 배경 */
+  --tile-black: #2c3e50;     /* 검정 타일 배경 */
+
+  /* 타일 숫자 색 (57 §1.1) */
+  --tile-text-light: #ffffff; /* 밝은 배경 위 숫자 (빨강/파랑/검정) */
+  --tile-text-dark: #1a1a1a;  /* 노랑 배경 위 숫자 */
+
+  /* 조커 (57 §1.1) */
+  --tile-joker-ring: #c084fc; /* 조커 무지개 링 (보라 기준) */
+
+  /* ─── 보드 배경 (57 §1.1) ──────────────────────────────────────── */
+  --board-bg: #1a3328;       /* 보드 배경 — 따뜻한 나무 계열 짙은 초록 */
+  --board-border: #2a5a3a;   /* 보드 경계선 */
+
+  /* ─── 드롭존 상태 토큰 3종 (57 §1.1, UX-004, docs/02-design/54) ── */
+  /* 허용: WCAG AA 대비율 검증 — #27AE60 on #1A3328 = 4.6:1 */
+  --drop-allow: #27ae60;
+  --drop-allow-bg: rgba(39, 174, 96, 0.12);
+  --drop-allow-border: rgba(39, 174, 96, 0.7);
+  /* 차단: WCAG AA 대비율 검증 — #C0392B on #1A3328 = 4.7:1 */
+  --drop-block: #c0392b;
+  --drop-block-bg: rgba(192, 57, 43, 0.12);
+  --drop-block-border: rgba(192, 57, 43, 0.7);
+
+  /* ─── pending 그룹 (57 §1.1, UR-20) ────────────────────────────── */
+  --pending-border: #f1c40f;              /* pending 그룹 — 노랑 점선 */
+  --pending-bg: rgba(241, 196, 15, 0.10); /* pending 그룹 배경 tint */
+  --pending-invalid: #e74c3c;             /* pending 무효 — 빨간 ring + shake */
+
+  /* ─── 토스트 3종 (57 §1.1, UR-21/29/30) ───────────────────────── */
+  --toast-error: #c0392b; /* INVALID_MOVE 토스트 배경 */
+  --toast-info: #3498db;  /* 안내 토스트 배경 */
+  --toast-warn: #e67e22;  /* 경고 토스트 배경 */
+
+  /* ─── 타일 글로우 (57 §1.1, UR-02/05) ─────────────────────────── */
+  --highlight-mine: rgba(74, 222, 128, 0.90); /* 내가 놓은 타일 글로우 */
+  --highlight-opp: rgba(251, 146, 60, 0.90);  /* 상대가 놓은 타일 글로우 */
+
+  /* ─── 타이머 3단계 (57 §1.1, UR-26) ───────────────────────────── */
+  --timer-normal: #3498db;   /* 타이머 기본 (> 10초) */
+  --timer-warn: #f1c40f;     /* 타이머 경고 (≤ 10초) */
+  --timer-critical: #e74c3c; /* 타이머 위험 (≤ 5초) + 펄스 */
+
+  /* ─── 플레이어 상태 5종 (57 §1.1, UR-32/13) ───────────────────── */
+  --state-connected: #3fb950;              /* 연결됨 */
+  --state-disconn: #f0883e;               /* 연결 끊김 */
+  --state-forfeited: #484f58;             /* 기권 */
+  --state-meld-done: #3fb950;             /* 최초 등록 완료 */
+  --state-meld-none: rgba(231, 76, 60, 0.50); /* 최초 등록 미완료 */
+
+  /* ─── 앱/패널 기반 색 (기존 유지) ──────────────────────────────── */
   --app-bg: #0d1117;
   --panel-bg: #161b22;
   --card-bg: #1c2128;
@@ -22,16 +70,22 @@
   --color-danger: #f85149;
   --color-ai: #9b59b6;
 
-  /* === 드롭존 상태 토큰 (UX-004, docs/02-design/54-drop-zone-color-system.md) === */
-  /* 유휴: 드래그 비활성 상태 — 기존 보드 색상 유지 (별도 토큰 없음) */
-  /* 허용: 드롭 가능 영역 하이라이트 (WCAG AA 대비율 검증: #27AE60 on #1A3328 = 4.6:1) */
-  --drop-allow: #27ae60;
-  --drop-allow-bg: rgba(39, 174, 96, 0.12);
-  --drop-allow-border: rgba(39, 174, 96, 0.7);
-  /* 차단: 드롭 불가 영역 하이라이트 (WCAG AA 대비율 검증: #C0392B on #1A3328 = 4.7:1) */
-  --drop-block: #c0392b;
-  --drop-block-bg: rgba(192, 57, 43, 0.12);
-  --drop-block-border: rgba(192, 57, 43, 0.7);
+  /* ─── 애니메이션 duration 토큰 (57 §1.2, UR-06/17) ────────────── */
+  --dur-instant: 50ms;   /* 즉각 피드백 (드롭존 hover) */
+  --dur-fast: 150ms;     /* 상태 전환 */
+  --dur-normal: 300ms;   /* 타일 등장/퇴장 */
+  --dur-slow: 500ms;     /* 오버레이, 게임 종료 */
+
+  /* ─── easing 토큰 (57 §1.2, UR-06/17) ─────────────────────────── */
+  --ease-out: cubic-bezier(0, 0, 0.2, 1);
+  --ease-bounce: cubic-bezier(0.68, -0.55, 0.265, 1.55);
+
+  /* ─── spacing / 레이아웃 토큰 (57 §11.4, UR-01) ───────────────── */
+  --space-header-h: 32px;              /* 헤더 고정 높이 */
+  --space-player-card-compact-h: 56px; /* 가로 배열 콤팩트 카드 높이 */
+  --space-rack-h: 100px;               /* 랙 영역 고정 높이 (타일 1행) */
+  --space-action-bar-h: 56px;          /* 드로우/초기화/확정 버튼 행 */
+  --space-board-min-h: 0px;            /* 보드 min-height — 가용 공간 모두 흡수 */
 }
 
 /* 한글 최적화 기본값 */
@@ -68,7 +122,7 @@ body {
   outline-offset: 2px;
 }
 
-/* 색약 접근성: 타일 패턴 */
+/* 색약 접근성: 타일 패턴 (♦♠♣♥★ 심볼은 Tile 컴포넌트에서 렌더) */
 .tile-pattern-red {
   background-image: repeating-linear-gradient(
     -45deg,
@@ -96,23 +150,24 @@ body {
   background-size: 6px 6px;
 }
 
-/* === 드롭존 상태 클래스 (dnd-kit over 상태에 따라 적용) === */
+/* ─── 드롭존 상태 클래스 (dnd-kit over 상태에 따라 적용) ─────────────────── */
 /* 유휴: 별도 클래스 없음, 기본 보드 스타일 유지 */
 
-/* 허용: 드롭 가능 — 초록 실선 border + 배경 tint */
+/* 허용: 드롭 가능 — 초록 실선 border + 배경 tint (UR-18) */
 .dropzone-allow {
   border: 2px solid var(--drop-allow-border) !important;
   background-color: var(--drop-allow-bg) !important;
   box-shadow: 0 0 0 1px var(--drop-allow-border) inset;
-  transition: border-color 0.12s ease, background-color 0.12s ease;
+  transition:
+    border-color var(--dur-instant) ease,
+    background-color var(--dur-instant) ease;
 }
 
-/* 차단: 드롭 불가 — 빨간 점선 border + 배경 tint + 색맹 보조 패턴 */
+/* 차단: 드롭 불가 — 빨간 점선 border + 배경 tint + 색맹 보조 패턴 (UR-19) */
 .dropzone-block {
   border: 2px dashed var(--drop-block-border) !important;
   background-color: var(--drop-block-bg) !important;
-  /* 색약 보조: 점선 자체가 시각적 패턴 역할 (border-style: dashed) */
-  /* 추가 패턴: 대각선 해칭 (적록색맹/전색맹 대비) */
+  /* 색약 보조: 대각선 해칭 (적록색맹/전색맹 대비) */
   background-image: repeating-linear-gradient(
     -45deg,
     transparent,
@@ -120,9 +175,45 @@ body {
     rgba(192, 57, 43, 0.08) 4px,
     rgba(192, 57, 43, 0.08) 5px
   );
-  transition: border-color 0.12s ease, background-color 0.12s ease;
+  transition:
+    border-color var(--dur-instant) ease,
+    background-color var(--dur-instant) ease;
 }
 
-/* 색약 접근성 보조: 아이콘 패턴 (색상만으로 구분 불가 시 대비) */
-/* 허용 드롭존에는 체크 아이콘, 차단 드롭존에는 X 아이콘을 ::after로 추가 */
-/* 실제 구현은 MeldRenderer.tsx의 isOver 상태에서 SVG 아이콘 조건부 렌더 권장 */
+/* 색약 접근성 보조: 허용 드롭존 체크 아이콘, 차단 드롭존 X 아이콘 */
+/* 실제 아이콘 렌더는 GroupDropZone.tsx / NewGroupDropZone.tsx 에서 isOver 조건부 렌더 */
+
+/* ─── 타일 글로우 애니메이션 (UR-02) ───────────────────────────────────────── */
+@keyframes tile-pulse-mine {
+  0%, 100% { box-shadow: 0 0 0 2px var(--highlight-mine); }
+  50% { box-shadow: 0 0 8px 4px var(--highlight-mine); }
+}
+
+@keyframes tile-pulse-opp {
+  0%, 100% { box-shadow: 0 0 0 2px var(--highlight-opp); }
+  50% { box-shadow: 0 0 8px 4px var(--highlight-opp); }
+}
+
+/* ─── pending 그룹 invalid shake (UR-21) ──────────────────────────────────── */
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  20% { transform: translateX(-4px); }
+  40% { transform: translateX(4px); }
+  60% { transform: translateX(-4px); }
+  80% { transform: translateX(4px); }
+}
+
+.shake {
+  animation: shake var(--dur-fast) var(--ease-out);
+}
+
+/* ─── 타이머 펄스 (UR-26) ──────────────────────────────────────────────────── */
+@keyframes timer-pulse-warn {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}
+
+@keyframes timer-pulse-critical {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}


### PR DESCRIPTION
## Phase D Day 1 — PR-D-D01 (RED + GREEN 동시)

**SSOT 매핑**: 57 §1.1 토큰 30종, 26 §4.5 token props 좌표, 60 F-21 acceptance, 55 UR-01~UR-36

## RED→GREEN
- RED `f32706a`: 41 테스트 중 29 FAIL (정확히 누락 토큰만)
- GREEN `3be2f90`: 41/41 PASS

## 신규 토큰 (globals.css :root)
- 타일 텍스트: --tile-text-light, --tile-text-dark
- 조커 링: --tile-joker-ring
- pending: --pending-border, --pending-bg, --pending-invalid
- 토스트 3종: --toast-error, --toast-info, --toast-warn
- 강조: --highlight-mine, --highlight-opp
- 타이머 3단계: --timer-normal/warn/critical
- 플레이어 상태 5종: --state-connected/disconn/forfeited/meld-done/meld-none
- duration: --dur-instant/fast/normal/slow
- easing: --ease-out, --ease-bounce
- spacing: --space-header-h, --space-player-card-compact-h, --space-rack-h, --space-action-bar-h, --space-board-min-h
- keyframe: shake, tile-pulse-mine, tile-pulse-opp, timer-pulse-warn, timer-pulse-critical

dropzone transition 하드코딩 → `var(--dur-instant) ease` 통일.

## 게이트 self-check
- G1 룰 ID: 통과
- G2 band-aid 0: 통과 (CSS 변수 추가만)
- G3 RED→GREEN 분리 commit
- G5 모듈화: CSS 변수 = 표현 계층 단일 책임

🤖 Generated with [Claude Code](https://claude.com/claude-code)