### PR TITLE
[A-01..21][V-08/14/15/16][UR-06][88-Section-2] Phase D PR-D-Q02 A1~A21 unit RED — 21 파일 90 it.todo 초안

### DIFF
--- a/src/frontend/src/lib/dragEnd/__tests__/by-action/A01-rack-to-new-group.test.ts
+++ b/src/frontend/src/lib/dragEnd/__tests__/by-action/A01-rack-to-new-group.test.ts
@@ -1,0 +1,46 @@
+/**
+ * A1 — 랙 → 보드 새 그룹 드롭 (rack-to-new-group)
+ *
+ * SSOT 매핑:
+ * - 56 §3.2 셀: A1 (RACK → NEW_GROUP)
+ * - 룰 ID: UR-06, UR-11, UR-15, V-08, D-01, D-12
+ * - 상태 전이: S1 → S2 → S5
+ * - 사용자 시나리오: F-02 (60 §1.2)
+ *
+ * RED→GREEN (G3 게이트):
+ * - Day 1 (RED 초안): describe/it 골격 + TODO 주석
+ * - Day 2~3 (RED commit): 실제 assertion 추가, CI RED 확인
+ * - Day 4 (GREEN commit): frontend-dev PR-D03 머지 후 GREEN 확인
+ *
+ * band-aid 금지 (G2 게이트):
+ * - source guard 동작 검증 X
+ * - 단순 코드 분기 (`forceNewGroup` 플래그 등) 검증 X
+ */
+
+import { describe, it } from '@jest/globals';
+
+describe('[A1] [V-08] [UR-06] rack → new group', () => {
+  describe('[A1.1] [V-08] [UR-01] OTHER_TURN reject', () => {
+    it.todo('rack tile 드래그 → new-group 드롭 시도 → 거절 (UR-01)');
+  });
+
+  describe('[A1.2] [UR-06] [UR-11] [D-12] MY_TURN PRE_MELD allow', () => {
+    it.todo('내 턴 + hasInitialMeld=false → 새 pending 그룹 생성 (V-04 무관, 자기 랙만 사용)');
+    // GREEN 기대값:
+    // - state.pendingTableGroups.length === before.length + 1
+    // - newGroup.id.startsWith("pending-") (D-12)
+    // - newGroup.id 가 D-01 유니크
+    // - state.players[mySeat].rack 에서 dragged tile 1개 제거
+  });
+
+  describe('[A1.3] [UR-06] [UR-11] [D-12] MY_TURN POST_MELD allow', () => {
+    it.todo('내 턴 + hasInitialMeld=true → 새 pending 그룹 생성 (PRE_MELD 와 동일)');
+  });
+
+  describe('[A1.4] [D-01] [D-12] pending- prefix ID 발급', () => {
+    it.todo('새 그룹 ID = "pending-{uuid v4}" 형식, 기존 그룹 ID 와 충돌 없음 (INV-G1)');
+    // GREEN 기대값:
+    // - newGroup.id.match(/^pending-[0-9a-f-]{36}$/) === non-null
+    // - state.pendingTableGroups.map(g => g.id) 가 multiset 유니크
+  });
+});

--- a/src/frontend/src/lib/dragEnd/__tests__/by-action/A02-rack-to-pending.test.ts
+++ b/src/frontend/src/lib/dragEnd/__tests__/by-action/A02-rack-to-pending.test.ts
@@ -1,0 +1,42 @@
+/**
+ * A2 — 랙 → 보드 기존 pending 그룹 드롭 (rack-to-pending)
+ *
+ * SSOT 매핑:
+ * - 56 §3.3 셀: A2 (RACK → PENDING_BOARD)
+ * - 룰 ID: UR-14, UR-19, V-14, V-15, V-08
+ * - 상태 전이: S5 → S2 → S5 (자기-루프)
+ * - 사용자 시나리오: F-03 (60 §1.2)
+ */
+
+import { describe, it } from '@jest/globals';
+
+describe('[A2] [UR-14] rack → pending group', () => {
+  describe('[A2.1] [UR-14] [V-14] COMPAT 그룹 (같은 숫자, 다른 색)', () => {
+    it.todo('R7 pending 그룹 + B7 rack 드롭 → 그룹 멤버 추가 (4색 한도 미달)');
+    // GREEN 기대값:
+    // - targetGroup.tiles.length === before + 1
+    // - INV-G2: tile code 중복 0
+    // - D-01: targetGroup.id 불변
+  });
+
+  describe('[A2.2] [UR-14] [V-15] COMPAT 런 앞 연장', () => {
+    it.todo('R5/R6/R7 pending 런 + R4 rack 드롭 → 런 앞 연장');
+  });
+
+  describe('[A2.3] [UR-14] [V-15] COMPAT 런 뒤 연장', () => {
+    it.todo('R5/R6/R7 pending 런 + R8 rack 드롭 → 런 뒤 연장');
+  });
+
+  describe('[A2.4] [UR-19] INCOMPAT 거절 (V-14 위반)', () => {
+    it.todo('R7/B7/Y7 그룹 + R8 rack (다른 숫자) 드롭 → 거절, 토스트 X (UR-19 회색 표시)');
+    // band-aid 금지: UR-19 시각 표시만, 토스트 노출 금지 (UR-21 은 INVALID_MOVE 만)
+  });
+
+  describe('[A2.5] [INV-G3] 빈 pending 그룹은 도달 불가 (자동 정리)', () => {
+    it.todo('pending 그룹 .tiles=[] 는 setter 단계에서 즉시 제거 (D-03/INV-G3) — 본 셀 도달 자체 불가');
+  });
+
+  describe('[A2.6] [V-08] [UR-01] OTHER_TURN reject', () => {
+    it.todo('다른 플레이어 턴 → rack 드래그 차단 (UR-01)');
+  });
+});

--- a/src/frontend/src/lib/dragEnd/__tests__/by-action/A03-rack-to-server.test.ts
+++ b/src/frontend/src/lib/dragEnd/__tests__/by-action/A03-rack-to-server.test.ts
@@ -1,0 +1,51 @@
+/**
+ * A3 — 랙 → 보드 서버 확정 그룹 드롭 (rack-to-server-extend)
+ *
+ * SSOT 매핑:
+ * - 56 §3.4 셀: A3 (RACK → SERVER_BOARD)
+ * - 룰 ID: UR-13, UR-14, UR-19, V-13a, V-13b, V-17, D-12
+ * - 상태 전이: S5 → S2 → S5
+ * - 사용자 시나리오: F-04 (60 §1.2)
+ *
+ * 사고 매핑:
+ * - BUG-UI-EXT-SC1 (확정 후 extend 회귀): 본 셀의 POST_MELD/COMPAT/허용이 회귀로 차단된 사고
+ * - INC-T11-FP-B10 (스탠드업 §0): 본 셀에서 source guard 가 false positive 차단한 사고
+ */
+
+import { describe, it } from '@jest/globals';
+
+describe('[A3] [V-13a] [V-17] rack → server group (extend)', () => {
+  describe('[A3.1] [V-13a] [UR-13] PRE_MELD reject', () => {
+    it.todo('hasInitialMeld=false + rack drop on server group → 거절 (V-13a)');
+    // GREEN 기대값:
+    // - state 변경 0 (서버 그룹은 건드릴 수 없음 — 자기 랙만)
+    // - UR-13 시각 표시 (회색 보더)
+  });
+
+  describe('[A3.2] [V-13a] [V-13b] [UR-14] [V-17] [D-12] POST_MELD COMPAT allow + pending 마킹', () => {
+    it.todo('hasInitialMeld=true + COMPAT rack drop → 서버 그룹이 pending 으로 마킹, 그룹 ID 보존 (V-17)');
+    // GREEN 기대값:
+    // - state.pendingGroupIds.add(serverGroupId) — D-12 매핑
+    // - serverGroup.id 불변 (V-17 서버 발급 UUID 유지)
+    // - serverGroup.tiles.length === before + 1
+    // - state.players[mySeat].rack 에서 dragged tile 1개 제거
+  });
+
+  describe('[A3.3] [UR-19] POST_MELD INCOMPAT reject', () => {
+    it.todo('POST_MELD + INCOMPAT (다른 숫자 그룹에 드롭) → 거절 (UR-19 회색 표시, 토스트 X)');
+  });
+
+  describe('[A3.4] [V-17] [D-01] 그룹 ID 보존 (UUID 형식 유지)', () => {
+    it.todo('drop 후 serverGroup.id.match(/^[0-9a-f-]{36}$/) === non-null (UUID v4)');
+    // band-aid 금지: 클라가 새 ID 할당 X. 서버 발급 ID 그대로 유지
+  });
+
+  describe('[A3.5] [V-17] 서버 ID 검증 (빈 ID 거부)', () => {
+    it.todo('serverGroup.id === "" 인 그룹 (V-17 위반 상태) → drop 자체 차단 + 콘솔 에러');
+    // INC-T11-IDDUP 직접 회귀 방지 (86 §3.1 — processAIPlace ID 누락)
+  });
+
+  describe('[A3.6] [V-08] [UR-01] OTHER_TURN reject', () => {
+    it.todo('다른 플레이어 턴 → rack 드래그 차단');
+  });
+});

--- a/src/frontend/src/lib/dragEnd/__tests__/by-action/A04-pending-to-new.test.ts
+++ b/src/frontend/src/lib/dragEnd/__tests__/by-action/A04-pending-to-new.test.ts
@@ -1,0 +1,39 @@
+/**
+ * A4 — pending → 새 그룹 (split via new)
+ *
+ * SSOT 매핑:
+ * - 56 §3.5 셀: A4 (PENDING_BOARD → NEW_GROUP)
+ * - 룰 ID: UR-11, V-13b, D-01, D-12
+ * - 상태 전이: S5 → S3 → S5
+ * - 사용자 시나리오: F-05 (60 §1.2)
+ */
+
+import { describe, it } from '@jest/globals';
+
+describe('[A4] [V-13b] pending → new group (split)', () => {
+  describe('[A4.1] [V-13b] pending split — 출발 그룹에서 tile 제거 (atomic)', () => {
+    it.todo('R7/B7/Y7 pending + R7 드래그 → new group → 출발 그룹 [B7,Y7], 새 그룹 [R7]');
+    // GREEN 기대값:
+    // - srcGroup.tiles.length === before - 1
+    // - newGroup.tiles.length === 1
+    // - INV-G2: tile code 중복 0
+    // - 변경 atomic (race 없음)
+  });
+
+  describe('[A4.2] [V-02] 잔여 ≥3 정상', () => {
+    it.todo('R7/B7/Y7/K7 4장 그룹 + R7 split → 출발 [B7,Y7,K7] (V-02 통과)');
+  });
+
+  describe('[A4.3] [UR-20] [V-02] 잔여 <3 invalid 표시 (ConfirmTurn 시 V-02 거부)', () => {
+    it.todo('R7/B7/Y7 3장 그룹 + R7 split → 출발 [B7,Y7] (UR-20 점선 + invalid 마킹)');
+    // band-aid 금지: 즉시 차단 X. ConfirmTurn 시점에서 V-02 가 거부 (UR-15 비활성)
+  });
+
+  describe('[A4.4] [D-01] [D-12] 새 그룹 pending- prefix ID', () => {
+    it.todo('newGroup.id.match(/^pending-[0-9a-f-]{36}$/), 기존 ID 와 충돌 0 (INV-G1)');
+  });
+
+  describe('[A4.5] [INV-G3] 출발 그룹 빈 → 자동 정리', () => {
+    it.todo('1장 짜리 pending 그룹에서 마지막 tile split → 출발 그룹 자동 제거');
+  });
+});

--- a/src/frontend/src/lib/dragEnd/__tests__/by-action/A05-pending-to-pending.test.ts
+++ b/src/frontend/src/lib/dragEnd/__tests__/by-action/A05-pending-to-pending.test.ts
@@ -1,0 +1,35 @@
+/**
+ * A5 — pending → 다른 pending (merge pending)
+ *
+ * SSOT 매핑:
+ * - 56 §3.6 셀: A5 (PENDING_BOARD → PENDING_BOARD)
+ * - 룰 ID: UR-14, V-13c, INV-G3, D-01
+ * - 상태 전이: S5 → S3 → S5
+ * - 사용자 시나리오: F-05 (60 §1.2)
+ */
+
+import { describe, it } from '@jest/globals';
+
+describe('[A5] [V-13c] pending → pending (merge)', () => {
+  describe('[A5.1] [UR-14] [V-13c] COMPAT merge', () => {
+    it.todo('pending [R7,B7] + 다른 pending [Y7] → R7 드래그 후 [Y7] 그룹에 추가 → [Y7,R7,B7] 4장');
+    // GREEN 기대값:
+    // - dst.tiles.length === before(dst) + 1
+    // - src.tiles.length === before(src) - 1
+    // - INV-G2: tile code 중복 0
+    // - INV-G1: 양쪽 ID 유니크 유지 (병합 후 src 가 빈 그룹이면 INV-G3 로 자동 제거)
+  });
+
+  describe('[A5.2] [UR-19] [V-13c] INCOMPAT reject', () => {
+    it.todo('pending [R7,B7] + 다른 pending [R5,R6,R7] (run) → R8 드래그 후 [R7,B7] 에 시도 → 거절');
+    // band-aid 금지: 토스트 X, UR-19 시각 표시만
+  });
+
+  describe('[A5.3] [INV-G3] 출발 그룹 빈 → 자동 정리', () => {
+    it.todo('pending [R7] (1장) + 다른 pending → R7 merge → src 자동 제거');
+  });
+
+  describe('[A5.4] [D-01] [D-12] 양쪽 pending- ID 정합성', () => {
+    it.todo('merge 후 dst.id 보존, src.id 제거 (INV-G1 유지)');
+  });
+});

--- a/src/frontend/src/lib/dragEnd/__tests__/by-action/A06-pending-to-server.test.ts
+++ b/src/frontend/src/lib/dragEnd/__tests__/by-action/A06-pending-to-server.test.ts
@@ -1,0 +1,57 @@
+/**
+ * A6 — pending → 서버 확정 그룹 (INC-T11-DUP 회귀 핵심 셀)
+ *
+ * SSOT 매핑:
+ * - 56 §3.7 셀: A6 (PENDING_BOARD → SERVER_BOARD)
+ * - 룰 ID: V-13a, V-13c, INV-G2, INV-G3, D-12
+ * - 상태 전이: S5 → S3 → S5
+ * - 사용자 시나리오: F-05 (60 §1.2)
+ *
+ * 사고 매핑 (직접 회귀 방지):
+ * - INC-T11-DUP (docs/04-testing/84): 본 셀에서 출발 그룹 tile 미제거 → D-02 위반 (11B 가 두 그룹 동시 존재)
+ * - 본 테스트는 §4.1 INC-T11-DUP 회귀 시나리오의 단위 layer
+ */
+
+import { describe, it } from '@jest/globals';
+
+describe('[A6] [V-13a] [V-13c] [INV-G2] pending → server (D-02 atomic 핵심)', () => {
+  describe('[A6.1] [V-13a] [UR-13] PRE_MELD reject', () => {
+    it.todo('hasInitialMeld=false + pending tile → server group drop → 거절 (V-13a)');
+  });
+
+  describe('[A6.2] [V-13c] [UR-14] POST_MELD COMPAT allow + pending 마킹', () => {
+    it.todo('hasInitialMeld=true + COMPAT → 서버 그룹이 pending 으로 마킹, 그룹 ID 보존');
+    // GREEN 기대값:
+    // - state.pendingGroupIds.add(serverGroupId) (D-12)
+    // - serverGroup.tiles.length === before + 1
+    // - srcPendingGroup.tiles.length === before - 1
+  });
+
+  describe('[A6.3] [UR-19] POST_MELD INCOMPAT reject', () => {
+    it.todo('POST_MELD + INCOMPAT → 거절 (UR-19 회색 표시)');
+  });
+
+  describe('[A6.4] [INV-G3] 출발 pending 빈 → 자동 정리', () => {
+    it.todo('1장 짜리 pending 그룹의 마지막 tile 을 server 로 → 출발 자동 제거');
+  });
+
+  describe('[A6.5] [D-12] 서버 그룹 pending 마킹 (D-12 정합성)', () => {
+    it.todo('drop 후 state.pendingGroupIds 에 serverGroupId 포함, ConfirmTurn 시 다시 서버 commit');
+  });
+
+  describe('[A6.6] [INV-G2] [D-02] **INC-T11-DUP 직접 회귀** — atomic tile 이동 검증', () => {
+    it.todo('11B pending [11B,12s,11s] + 서버 그룹 [12s,12r,12k] (4색 그룹) → 11B → server drop → 출발 그룹에서 11B 제거 + 서버 그룹에 11B 추가, 보드 위 11B 등장 횟수 정확히 1회');
+    // GREEN 기대값 (D-02 invariant):
+    // - 모든 board.tiles 의 multiset.get("11B") === 1 (a 접미)
+    // - srcGroup.tiles 에서 11B 제거됨
+    // - dstGroup.tiles 에 11B 추가됨
+    // - 변경 atomic (race condition 없음)
+    //
+    // 사고 시나리오 84 직접 reproduction:
+    // - 사용자: B11a → 12s 4-tile 그룹 합병 시도
+    // - 회귀 코드: 출발 [11s,11r,11k] 에 B11a 가 남음 + 서버 [12s,12r,12k,12y] 에도 B11a 추가
+    // - 결과: 보드 위 B11a 가 두 그룹 동시 존재 (D-02 위반)
+    //
+    // 본 테스트가 GREEN = INC-T11-DUP 회귀 100% 차단
+  });
+});

--- a/src/frontend/src/lib/dragEnd/__tests__/by-action/A07-pending-to-rack.test.ts
+++ b/src/frontend/src/lib/dragEnd/__tests__/by-action/A07-pending-to-rack.test.ts
@@ -1,0 +1,34 @@
+/**
+ * A7 — pending → 랙 (회수)
+ *
+ * SSOT 매핑:
+ * - 56 §3.8 셀: A7 (PENDING_BOARD → RACK)
+ * - 룰 ID: UR-12, V-06, INV-G3
+ * - 상태 전이: S5 → S3 → S5 (pending 0 이면 → S1)
+ * - 사용자 시나리오: F-05 (60 §1.2)
+ */
+
+import { describe, it } from '@jest/globals';
+
+describe('[A7] [UR-12] pending → rack (recovery)', () => {
+  describe('[A7.1] [UR-12] 회수 항상 허용 (자기 pending 만)', () => {
+    it.todo('pending [R7,B7] + R7 → rack drop → 출발 [B7], rack 에 R7 추가');
+    // GREEN 기대값:
+    // - srcGroup.tiles.length === before - 1
+    // - state.players[mySeat].rack 에 R7 추가
+    // - INV-G2: tile code 중복 0 (a/b 접미는 별개)
+  });
+
+  describe('[A7.2] [INV-G3] [D-03] 출발 그룹 빈 → 자동 정리', () => {
+    it.todo('1장 짜리 pending [R7] 마지막 tile 회수 → 출발 그룹 자동 제거');
+    // GREEN: state.pendingTableGroups 에서 srcGroup 제거됨
+  });
+
+  describe('[A7.3] [D-12] 회수 후 pendingGroupIds 갱신', () => {
+    it.todo('서버 그룹이 pending 마킹된 상태에서 마지막 추가 tile 회수 시 pendingGroupIds 에서 제거');
+  });
+
+  describe('[A7.4] [V-06] conservation 유지', () => {
+    it.todo('회수 전후 player rack tile + board tile 합 = 일정 (D-05 invariant 부분)');
+  });
+});

--- a/src/frontend/src/lib/dragEnd/__tests__/by-action/A08-server-to-new.test.ts
+++ b/src/frontend/src/lib/dragEnd/__tests__/by-action/A08-server-to-new.test.ts
@@ -1,0 +1,34 @@
+/**
+ * A8 — 서버 → 새 그룹 (split server)
+ *
+ * SSOT 매핑:
+ * - 56 §3.9 셀: A8 (SERVER_BOARD → NEW_GROUP)
+ * - 룰 ID: V-13a, V-13b, D-12
+ * - 상태 전이: S5 → S4 → S5
+ * - 사용자 시나리오: F-06 (60 §1.2)
+ */
+
+import { describe, it } from '@jest/globals';
+
+describe('[A8] [V-13a] [V-13b] server → new group (split)', () => {
+  describe('[A8.1] [V-13a] [UR-13] PRE_MELD reject', () => {
+    it.todo('hasInitialMeld=false + server tile drag → 거절 (V-13a)');
+  });
+
+  describe('[A8.2] [V-13b] POST_MELD allow + 출발 server → pending 전환', () => {
+    it.todo('hasInitialMeld=true + server [R7,B7,Y7,K7] + R7 split → 새 pending 그룹 [R7], 출발 [B7,Y7,K7] pending 마킹');
+    // GREEN 기대값:
+    // - state.pendingGroupIds.add(serverGroupId) (출발 마킹)
+    // - newGroup.id.startsWith("pending-") (D-12)
+    // - newGroup.tiles === [R7]
+    // - srcServerGroup.tiles === [B7,Y7,K7]
+  });
+
+  describe('[A8.3] [D-12] 출발 server → pending 전환 (그룹 ID 보존)', () => {
+    it.todo('split 후 srcServerGroup.id 보존 (V-17 UUID 유지), 클라가 새 pending- ID 할당 X');
+  });
+
+  describe('[A8.4] [D-01] [D-12] 새 그룹 pending- ID + INV-G1', () => {
+    it.todo('newGroup.id 가 INV-G1 유니크, pending- prefix');
+  });
+});

--- a/src/frontend/src/lib/dragEnd/__tests__/by-action/A09-server-to-server-merge.test.ts
+++ b/src/frontend/src/lib/dragEnd/__tests__/by-action/A09-server-to-server-merge.test.ts
@@ -1,0 +1,48 @@
+/**
+ * A9 — 서버 → 다른 서버 (merge server) — INC-T11-IDDUP 회귀 핵심 셀
+ *
+ * SSOT 매핑:
+ * - 56 §3.10 셀: A9 (SERVER_BOARD → SERVER_BOARD)
+ * - 룰 ID: V-13a, V-13c, INV-G1, V-17, UR-14
+ * - 상태 전이: S5 → S4 → S5
+ * - 사용자 시나리오: F-06 (60 §1.2)
+ *
+ * 사고 매핑 (직접 회귀 방지):
+ * - INC-T11-IDDUP (docs/04-testing/86 §3.1): 본 셀에서 양쪽 ID 보존 후 충돌 (D-01 위반)
+ * - 본 테스트는 §4.2 INC-T11-IDDUP 회귀 시나리오의 단위 layer
+ */
+
+import { describe, it } from '@jest/globals';
+
+describe('[A9] [V-13a] [V-13c] [V-17] [INV-G1] server → server (merge)', () => {
+  describe('[A9.1] [V-13a] [UR-13] PRE_MELD reject', () => {
+    it.todo('hasInitialMeld=false + server tile → server group drop → 거절');
+  });
+
+  describe('[A9.2] [V-13c] [UR-14] POST_MELD COMPAT allow', () => {
+    it.todo('POST_MELD + server [R7,B7,Y7] + 다른 server [K7] → R7 → [K7] drop → 결과 [K7,R7] (이후 4색 그룹 가능)');
+  });
+
+  describe('[A9.3] [UR-19] POST_MELD INCOMPAT reject', () => {
+    it.todo('POST_MELD + 다른 그룹/숫자 → 거절 (UR-19)');
+  });
+
+  describe('[A9.4] [INV-G1] [V-17] **INC-T11-IDDUP 직접 회귀** — 양쪽 ID 보존 시 충돌 검증', () => {
+    it.todo('서버 [그룹A id=uuid-A], [그룹B id=uuid-B] → 부분 합병 시도 → 결과 그룹 ID INV-G1 유니크 보장');
+    // GREEN 기대값 (INV-G1 + V-17):
+    // - 합병 후 결과 그룹들 .map(g => g.id) 가 multiset 유니크
+    // - 한쪽은 pending- prefix, 한쪽은 server UUID 보존 (혼합 X)
+    // - V-17 위반 (id="" 또는 id 충돌) 발생 시 throw 또는 reject
+    //
+    // 사고 86 §3.1 직접 reproduction:
+    // - GPT가 9장 배치 (서버 그룹 신규 생성, processAIPlace ID 누락 → id="")
+    // - 사용자가 그 그룹과 다른 서버 그룹 합병 시도
+    // - 회귀 코드: 양쪽 id 보존 → React key 충돌 → ghost group 부패
+    //
+    // 본 테스트가 GREEN = INC-T11-IDDUP 회귀 100% 차단
+  });
+
+  describe('[A9.5] [D-12] pending 전환 정합성 (양쪽 server → pending)', () => {
+    it.todo('merge 후 양쪽 server 그룹 모두 pending 마킹, ConfirmTurn 시 새 commit');
+  });
+});

--- a/src/frontend/src/lib/dragEnd/__tests__/by-action/A10-server-to-pending.test.ts
+++ b/src/frontend/src/lib/dragEnd/__tests__/by-action/A10-server-to-pending.test.ts
@@ -1,0 +1,33 @@
+/**
+ * A10 — 서버 → pending (server-to-pending move)
+ *
+ * SSOT 매핑:
+ * - 56 §3.11 셀: A10 (SERVER_BOARD → PENDING_BOARD)
+ * - 룰 ID: V-13a, V-13c, D-12
+ * - 상태 전이: S5 → S4 → S5
+ * - 사용자 시나리오: F-06 (60 §1.2)
+ */
+
+import { describe, it } from '@jest/globals';
+
+describe('[A10] [V-13a] [V-13c] server → pending', () => {
+  describe('[A10.1] [V-13a] [UR-13] PRE_MELD reject', () => {
+    it.todo('hasInitialMeld=false → 거절 (V-13a)');
+  });
+
+  describe('[A10.2] [V-13c] [UR-14] POST_MELD COMPAT allow + server → pending 전환', () => {
+    it.todo('hasInitialMeld=true + server [R7,B7,Y7] + R7 → pending [R8] drop → 거절 (INCOMPAT) — 단 [B5,B6] pending + B7 server → drop → run [B5,B6,B7] (COMPAT)');
+    // GREEN 기대값:
+    // - dst pending.tiles.length === before + 1
+    // - srcServerGroup.tiles.length === before - 1
+    // - state.pendingGroupIds.add(serverGroupId)
+  });
+
+  describe('[A10.3] [UR-19] POST_MELD INCOMPAT reject', () => {
+    it.todo('POST_MELD + INCOMPAT → 거절 (UR-19)');
+  });
+
+  describe('[A10.4] [D-12] 출발 server → pending 전환 (그룹 ID 보존)', () => {
+    it.todo('drop 후 srcServerGroup.id 보존 (V-17)');
+  });
+});

--- a/src/frontend/src/lib/dragEnd/__tests__/by-action/A11-server-to-rack.test.ts
+++ b/src/frontend/src/lib/dragEnd/__tests__/by-action/A11-server-to-rack.test.ts
@@ -1,0 +1,31 @@
+/**
+ * A11 — 서버 → 랙 (회수) — V-06 conservation 위반 거절
+ *
+ * SSOT 매핑:
+ * - 56 §3.12 셀: A11 (SERVER_BOARD → RACK)
+ * - 룰 ID: V-06, UR-12
+ * - 상태 전이: S4 → 거절 (state 변경 없음)
+ * - 사용자 시나리오: (F-NN 없음 — 항상 거절)
+ *
+ * 본 셀은 "전부 거절" — 어떤 상태에서도 서버 commit tile 을 랙으로 회수 불가.
+ * 단 V-13e 조커 swap 결과 회수 조커는 별도 (A12).
+ */
+
+import { describe, it } from '@jest/globals';
+
+describe('[A11] [V-06] [UR-12] server → rack (전체 거절)', () => {
+  describe('[A11.1] [V-13a] PRE_MELD reject', () => {
+    it.todo('hasInitialMeld=false + server tile → rack drop → 거절 (V-13a)');
+  });
+
+  describe('[A11.2] [V-06] [UR-12] POST_MELD reject (conservation)', () => {
+    it.todo('hasInitialMeld=true + server tile → rack drop → 거절 (V-06)');
+    // GREEN 기대값: state 변경 0, UR-12 시각 표시
+    // band-aid 금지: 토스트 X
+  });
+
+  describe('[A11.3] [V-06] conservation 위반 unified message', () => {
+    it.todo('어떤 상태에서도 server → rack drop 차단, UR-12 unified 시각 표시');
+    // 본 셀 도달 자체가 invariant 위반 — 코드 버그 신호
+  });
+});

--- a/src/frontend/src/lib/dragEnd/__tests__/by-action/A12-joker-swap.test.ts
+++ b/src/frontend/src/lib/dragEnd/__tests__/by-action/A12-joker-swap.test.ts
@@ -1,0 +1,48 @@
+/**
+ * A12 — 조커 swap (V-13e)
+ *
+ * SSOT 매핑:
+ * - 56 §3.13 셀: A12 (RACK → JOKER_TILE)
+ * - 룰 ID: V-13a, V-13e, V-07, UR-25
+ * - 상태 전이: S5 → S4 → S10 (joker recovered pending)
+ * - 사용자 시나리오: F-07 (60 §1.2)
+ *
+ * 별도 단위 테스트:
+ * - tryJokerSwap 순수 함수 (`tryJokerSwap-{group,run}.test.ts`) — PR-D-Q03
+ */
+
+import { describe, it } from '@jest/globals';
+
+describe('[A12] [V-13a] [V-13e] [V-07] joker swap', () => {
+  describe('[A12.1] [V-13a] [UR-13] PRE_MELD reject', () => {
+    it.todo('hasInitialMeld=false + rack tile → joker drop → 거절 (V-13a)');
+  });
+
+  describe('[A12.2] [V-13e] POST_MELD 그룹 swap', () => {
+    it.todo('서버 [R7,B7,JK1] + 랙 Y7 → JK1 위에 drop → JK1 회수, 그룹 [R7,B7,Y7]');
+    // GREEN 기대값:
+    // - 서버 그룹의 JK1 → Y7 교체
+    // - state.players[mySeat].rack 에 JK1 추가
+    // - state.pendingRecoveredJokers.add("JK1")
+    // - state 전이 S10
+  });
+
+  describe('[A12.3] [V-13e] POST_MELD 런 swap', () => {
+    it.todo('서버 [R5,JK1,R7] (R6 대체) + 랙 R6 → JK1 위에 drop → JK1 회수, 런 [R5,R6,R7]');
+  });
+
+  describe('[A12.4] [V-13e] 동등 가치 위반 reject', () => {
+    it.todo('서버 [R5,JK1,R7] (R6 대체) + 랙 R8 (값 불일치) → drop → 거절 (V-13e)');
+  });
+
+  describe('[A12.5] [V-07] [UR-25] 회수 조커 → pendingRecoveredJokers 기록', () => {
+    it.todo('swap 후 state.pendingRecoveredJokers === ["JK1"], UR-25 시각 강조 (펄스 + "이번 턴 사용 필수")');
+  });
+
+  describe('[A12.6] [V-07] 같은 턴 미사용 → ConfirmTurn 차단', () => {
+    it.todo('swap 후 회수 JK1 미배치 → ConfirmTurn 비활성 (UR-15 + V-07 클라 미러)');
+    // GREEN 기대값:
+    // - state.pendingRecoveredJokers.size > 0 → ConfirmTurn disabled
+    // - JK1 을 다시 보드에 배치 후 → ConfirmTurn 활성
+  });
+});

--- a/src/frontend/src/lib/dragEnd/__tests__/by-action/A13-rack-rearrange.test.ts
+++ b/src/frontend/src/lib/dragEnd/__tests__/by-action/A13-rack-rearrange.test.ts
@@ -1,0 +1,28 @@
+/**
+ * A13 — 랙 내 재정렬 (rack-to-rack reorder)
+ *
+ * SSOT 매핑:
+ * - 56 §3.14 셀: A13 (RACK → RACK)
+ * - 룰 ID: (rack 사적 공간 — 보드 영향 없음)
+ * - 상태 전이: 상태 머신 미영향 (S0~S10 어떤 상태에서도 허용)
+ * - 사용자 시나리오: F-08 (60 §1.2, P2)
+ */
+
+import { describe, it } from '@jest/globals';
+
+describe('[A13] rack rearrange (사적 공간)', () => {
+  describe('[A13.1] 항상 허용 (내 턴 무관)', () => {
+    it.todo('내 랙 [R7,B7,Y7] + Y7 을 인덱스 0 으로 드래그 → [Y7,R7,B7]');
+    // GREEN 기대값:
+    // - state.players[mySeat].rack 순서 변경
+    // - 보드/pending/server 영향 0
+  });
+
+  describe('[A13.2] OTHER_TURN 도 허용 (사적 공간)', () => {
+    it.todo('다른 플레이어 턴에도 내 랙 재정렬 허용 (UR-01 disable 의 예외)');
+  });
+
+  describe('[A13.3] 보드 영향 없음 (INV-G2 무관)', () => {
+    it.todo('rack 재정렬 후 board.tiles multiset 불변, INV-G2 영향 0');
+  });
+});

--- a/src/frontend/src/lib/dragEnd/__tests__/by-action/A14-confirm-turn.test.ts
+++ b/src/frontend/src/lib/dragEnd/__tests__/by-action/A14-confirm-turn.test.ts
@@ -1,0 +1,48 @@
+/**
+ * A14 — ConfirmTurn (턴 확정)
+ *
+ * SSOT 매핑:
+ * - 56 §3.15 셀: A14 (사용자 ConfirmTurn 클릭)
+ * - 룰 ID: UR-15, V-01, V-02, V-03, V-04, V-14, V-15
+ * - 상태 전이: S5/S6 → S7 → End / S8
+ * - 사용자 시나리오: F-09 (60 §1.2)
+ *
+ * 본 테스트는 클라 사전검증 (ConfirmTurn 활성/비활성 + WS 송신) 단위.
+ * 서버 검증 (V-* 응답) 단위는 §2.3 Go testify.
+ */
+
+import { describe, it } from '@jest/globals';
+
+describe('[A14] [UR-15] ConfirmTurn (S5/S6 → S7)', () => {
+  describe('[A14.1] [UR-15] [V-03] pending=0 → 비활성 (V-03 클라 미러)', () => {
+    it.todo('pending=0 → ConfirmTurn 버튼 disabled (UR-15)');
+  });
+
+  describe('[A14.2] [UR-15] [V-03] pending≥1 + tilesAdded=0 → 비활성', () => {
+    it.todo('pending 그룹은 있으나 rack→board 추가 0 → ConfirmTurn 비활성 (V-03 단순 재배치 금지)');
+  });
+
+  describe('[A14.3] [UR-15] [V-01] [V-02] [V-14] [V-15] 클라 사전검증 fail → 비활성', () => {
+    it.todo('pending [R7,B7] (2장, V-02 위반) → ConfirmTurn 비활성');
+  });
+
+  describe('[A14.4] [UR-15] [V-04] [UR-30] PRE_MELD <30 → 비활성', () => {
+    it.todo('hasInitialMeld=false + 합계 25점 < 30 → ConfirmTurn 비활성 (UR-30 안내)');
+  });
+
+  describe('[A14.5] [UR-15] OK 활성 → WS CONFIRM_TURN 송신 (S5/S6 → S7)', () => {
+    it.todo('모든 사전조건 통과 → 클릭 → WS CONFIRM_TURN 송신, state 전이 S7 (UI lock)');
+    // GREEN 기대값:
+    // - WS message 송신 (CONFIRM_TURN type)
+    // - state === S7 (COMMITTING)
+    // - UI 입력 disabled (race condition 방지)
+  });
+
+  describe('[A14.6] [UR-21] OK INVALID_MOVE 응답 → S8', () => {
+    it.todo('서버가 INVALID_MOVE 반환 → state 전이 S8, 토스트 + 스냅샷 롤백');
+  });
+
+  describe('[A14.7] [V-19] 송신 중 race UI 잠금 (S7 invariant)', () => {
+    it.todo('S7 진입 후 30s 내 응답 없음 → timeout 강제 S8 (응답 후 두 번 클릭 방지)');
+  });
+});

--- a/src/frontend/src/lib/dragEnd/__tests__/by-action/A15-reset-turn.test.ts
+++ b/src/frontend/src/lib/dragEnd/__tests__/by-action/A15-reset-turn.test.ts
@@ -1,0 +1,29 @@
+/**
+ * A15 — RESET_TURN (되돌리기)
+ *
+ * SSOT 매핑:
+ * - 56 §3.16 셀: A15 (RESET_TURN 클릭)
+ * - 룰 ID: UR-16
+ * - 상태 전이: S5/S6 → S1
+ * - 사용자 시나리오: F-10 (60 §1.2)
+ */
+
+import { describe, it } from '@jest/globals';
+
+describe('[A15] [UR-16] RESET_TURN (S5/S6 → S1)', () => {
+  describe('[A15.1] [UR-16] S5/S6 → S1 전이', () => {
+    it.todo('pending [R7,B7,Y7] + RESET 클릭 → state 전이 S1, pendingTableGroups=[]');
+    // GREEN 기대값:
+    // - state.pendingTableGroups === []
+    // - state.players[mySeat].rack 복원 (TURN_START 시점 rack)
+    // - state === S1
+  });
+
+  describe('[A15.2] [UR-16] pendingTableGroups=[] (cleanup)', () => {
+    it.todo('RESET 후 pendingTableGroups 완전 비움, pendingGroupIds 도 비움');
+  });
+
+  describe('[A15.3] [D-12] pending → server 매핑 정합성 유지', () => {
+    it.todo('RESET 후 server tableGroups 는 그대로 (TURN_START 시점), pending 마킹만 제거');
+  });
+});

--- a/src/frontend/src/lib/dragEnd/__tests__/by-action/A16-draw.test.ts
+++ b/src/frontend/src/lib/dragEnd/__tests__/by-action/A16-draw.test.ts
@@ -1,0 +1,32 @@
+/**
+ * A16 — DRAW (드로우 / 자동 패스)
+ *
+ * SSOT 매핑:
+ * - 56 §3.17 셀: A16 (DRAW 클릭)
+ * - 룰 ID: V-10, UR-22, UR-23
+ * - 상태 전이: S1 → S9 → End
+ * - 사용자 시나리오: F-11 (60 §1.2)
+ */
+
+import { describe, it } from '@jest/globals';
+
+describe('[A16] [V-10] DRAW (S1 → S9)', () => {
+  describe('[A16.1] [UR-15] pending≥1 → reject', () => {
+    it.todo('pending 그룹 1개 이상 → DRAW 비활성 (UR-15 안내: ConfirmTurn 또는 RESET 후 시도)');
+  });
+
+  describe('[A16.2] [V-10] pending=0 + drawpile>0 → 1장 추가', () => {
+    it.todo('pending=0 + drawpile.length > 0 → DRAW 활성 → state.players[mySeat].rack 에 1장 추가, turn end');
+    // GREEN 기대값:
+    // - state.players[mySeat].rack.length === before + 1
+    // - state === S9 → End
+  });
+
+  describe('[A16.3] [V-10] [UR-22] pending=0 + drawpile=0 → 패스', () => {
+    it.todo('pending=0 + drawpile.length === 0 → "패스" 라벨 (UR-22) → DRAW 클릭 → 1장 추가 X, turn end');
+  });
+
+  describe('[A16.4] DRAW 후 turn end (S9 → End)', () => {
+    it.todo('DRAW 응답 수신 → state === End → TURN_END broadcast 대기');
+  });
+});

--- a/src/frontend/src/lib/dragEnd/__tests__/by-action/A17-cancel.test.ts
+++ b/src/frontend/src/lib/dragEnd/__tests__/by-action/A17-cancel.test.ts
@@ -1,0 +1,30 @@
+/**
+ * A17 — 드래그 취소 (esc / onDragCancel)
+ *
+ * SSOT 매핑:
+ * - 56 §3.18 셀: A17 (드래그 중 ESC 키 또는 dnd-kit onDragCancel)
+ * - 룰 ID: UR-17, INV-G1, INV-G2
+ * - 상태 전이: S2/S3/S4 → S1/S5
+ * - 사용자 시나리오: F-12 (60 §1.2)
+ */
+
+import { describe, it } from '@jest/globals';
+
+describe('[A17] [UR-17] cancel (S2/S3/S4 → S1/S5)', () => {
+  describe('[A17.1] [UR-17] S2/S3/S4 → 원위치 (state 변경 0)', () => {
+    it.todo('드래그 중 ESC 또는 onDragCancel → state === 직전 상태 (S5 또는 S1)');
+    // GREEN 기대값:
+    // - 어떠한 setState 호출 없음 (D-01/D-02 invariant 보호)
+    // - state.pendingTableGroups === before
+    // - state.players[mySeat].rack === before
+  });
+
+  describe('[A17.2] [UR-17] state 변경 0 (D-01/D-02 invariant 유지)', () => {
+    it.todo('cancel 경로에서 어떠한 store mutation 도 발생 X');
+    // band-aid 금지: cancel 처리에 source guard / invariant validator 사용 X
+  });
+
+  describe('[A17.3] [INV-G1] [INV-G2] cancel 후 invariant 유지', () => {
+    it.todo('cancel 후 모든 board.tiles multiset 유니크 (INV-G2), 모든 group.id 유니크 (INV-G1)');
+  });
+});

--- a/src/frontend/src/lib/dragEnd/__tests__/by-action/A18-ws-place-tiles-from-other.test.ts
+++ b/src/frontend/src/lib/dragEnd/__tests__/by-action/A18-ws-place-tiles-from-other.test.ts
@@ -1,0 +1,26 @@
+/**
+ * A18 — WS PLACE_TILES (다른 플레이어 turn)
+ *
+ * SSOT 매핑:
+ * - 56 §3.19 셀: A18 (WS 수신)
+ * - 룰 ID: UR-04 (자기 턴 invariant)
+ * - 상태 전이: S0 (관전 표시), 내 pending 영향 0
+ * - 사용자 시나리오: F-14 (60 §1.2)
+ */
+
+import { describe, it } from '@jest/globals';
+
+describe('[A18] [UR-04] WS PLACE_TILES from other player', () => {
+  describe('[A18.1] 관전 표시 (state.tableGroups 갱신)', () => {
+    it.todo('다른 플레이어 PLACE_TILES 수신 → state.tableGroups 만 갱신, state === S0 유지');
+    // GREEN 기대값:
+    // - state.tableGroups 갱신
+    // - state.players[mySeat].rack 영향 0
+    // - state.pendingTableGroups 영향 0 (UR-04 invariant)
+  });
+
+  describe('[A18.2] [UR-04] 내 pending 영향 없음 (invariant)', () => {
+    it.todo('내가 S5 (pending building) 상태일 때 PLACE_TILES 수신 → pending 동결, S5 유지');
+    // 단 TURN_START 수신 시는 pending 강제 reset (A19)
+  });
+});

--- a/src/frontend/src/lib/dragEnd/__tests__/by-action/A19-ws-turn-start.test.ts
+++ b/src/frontend/src/lib/dragEnd/__tests__/by-action/A19-ws-turn-start.test.ts
@@ -1,0 +1,35 @@
+/**
+ * A19 — WS TURN_START
+ *
+ * SSOT 매핑:
+ * - 56 §3.19 셀: A19 (WS 수신)
+ * - 룰 ID: UR-02, UR-04, V-08
+ * - 상태 전이: → S1 (mySeat) 또는 → S0 (otherSeat)
+ * - 사용자 시나리오: F-01 (60 §1.2)
+ */
+
+import { describe, it } from '@jest/globals';
+
+describe('[A19] [V-08] [UR-02] [UR-04] WS TURN_START', () => {
+  describe('[A19.1] [V-08] [UR-02] mySeat 일치 → S1', () => {
+    it.todo('TURN_START { currentSeat: mySeat } 수신 → state === S1 (MY_TURN_IDLE)');
+    // GREEN 기대값:
+    // - state === S1
+    // - UI 활성화 (UR-02)
+    // - 타이머 시작
+  });
+
+  describe('[A19.2] [V-08] mySeat 불일치 → S0', () => {
+    it.todo('TURN_START { currentSeat: otherSeat } 수신 → state === S0 (OUT_OF_TURN)');
+  });
+
+  describe('[A19.3] [UR-04] pendingTableGroups=[] 강제', () => {
+    it.todo('TURN_START 수신 → pendingTableGroups = [], pendingGroupIds = new Set() (UR-04 invariant)');
+    // GREEN: 이전 턴의 잔재 pending 이 있어도 강제 cleanup
+    // band-aid 금지: 잔재가 있어도 토스트 X (코드 버그라면 console.error 만)
+  });
+
+  describe('[A19.4] [UR-04] S5/S6/S7 진행 중에도 TURN_START 우선', () => {
+    it.todo('S7 (COMMITTING) 중에도 TURN_START 수신 → S0/S1 으로 강제 전이 (서버 진실 우선)');
+  });
+});

--- a/src/frontend/src/lib/dragEnd/__tests__/by-action/A20-ws-turn-end.test.ts
+++ b/src/frontend/src/lib/dragEnd/__tests__/by-action/A20-ws-turn-end.test.ts
@@ -1,0 +1,29 @@
+/**
+ * A20 — WS TURN_END
+ *
+ * SSOT 매핑:
+ * - 56 §3.19 셀: A20 (WS 수신)
+ * - 룰 ID: UR-05, UR-27
+ * - 상태 전이: → S0 (또는 End → 다음 TURN_START 대기)
+ * - 사용자 시나리오: (F-01 의 cleanup 부분)
+ */
+
+import { describe, it } from '@jest/globals';
+
+describe('[A20] [UR-05] WS TURN_END', () => {
+  describe('[A20.1] [UR-05] TURN_END OK → S0/S1', () => {
+    it.todo('TURN_END { reason: "OK" } 수신 → state === S0, pendingTableGroups=[]');
+    // GREEN 기대값:
+    // - state === S0
+    // - state.tableGroups 갱신 (서버 commit 결과)
+    // - state.pendingTableGroups === []
+  });
+
+  describe('[A20.2] cleanup (S0 invariant 진입)', () => {
+    it.todo('TURN_END 후 모든 drag state 초기화 (activeId=null, isHandlingDragEndRef=false)');
+  });
+
+  describe('[A20.3] [UR-27] WIN/ALL_PASS reason 분기', () => {
+    it.todo('TURN_END { reason: "WIN" } → GAME_OVER 오버레이 (UR-28). reason: "ALL_PASS" → UR-27 안내');
+  });
+});

--- a/src/frontend/src/lib/dragEnd/__tests__/by-action/A21-ws-invalid-move.test.ts
+++ b/src/frontend/src/lib/dragEnd/__tests__/by-action/A21-ws-invalid-move.test.ts
@@ -1,0 +1,55 @@
+/**
+ * A21 — WS INVALID_MOVE — INC-T11-FP-B10 사고 회귀 핵심
+ *
+ * SSOT 매핑:
+ * - 56 §3.19 셀: A21 (WS 수신)
+ * - 룰 ID: UR-21, UR-34
+ * - 상태 전이: S7 → S8
+ * - 사용자 시나리오: F-13 (60 §1.2)
+ *
+ * 사고 매핑:
+ * - INC-T11-FP-B10 (스탠드업 §0): 본 셀에서 band-aid 토스트 (UR-34 위반) 가 사용자 incident 직전 노출
+ */
+
+import { describe, it } from '@jest/globals';
+
+describe('[A21] [UR-21] [UR-34] WS INVALID_MOVE (S7 → S8)', () => {
+  describe('[A21.1] [UR-21] S7 → S8 전이', () => {
+    it.todo('S7 (COMMITTING) 중 INVALID_MOVE 수신 → state === S8 (INVALID_RECOVER)');
+    // GREEN 기대값:
+    // - state === S8
+    // - 토스트 표시 (UR-21)
+  });
+
+  describe('[A21.2] [UR-21] 토스트 표시 (룰 ID prefix 강제)', () => {
+    it.todo('토스트 카피 = "[V-04] 최초 등록은 30점 이상이어야 합니다" (룰 ID prefix 의무)');
+    // band-aid 금지: "상태 이상" / "invariant 오류" / "소스 불일치" 류 위협 카피 X (UR-34)
+  });
+
+  describe('[A21.3] [UR-21] 스냅샷 롤백 (서버 마지막 healthy state 복원)', () => {
+    it.todo('INVALID_MOVE 수신 → state.tableGroups, state.players[*].rack 모두 서버 마지막 healthy 스냅샷으로 롤백');
+    // GREEN 기대값:
+    // - state.pendingTableGroups === []
+    // - state.tableGroups === serverSnapshot.tableGroups
+    // - state.players === serverSnapshot.players
+  });
+
+  describe('[A21.4] [UR-34] **INC-T11-FP-B10 직접 회귀** — band-aid 토스트 금지 검증', () => {
+    it.todo('INVALID_MOVE 수신 → 토스트 노출, 단 UR-34 위반 패턴 0건');
+    // GREEN 기대값 (UR-34):
+    // - grep 패턴 0 hit (negative assertion — 검증 대상 패턴, 도입 X):
+    //   - BUG-UI-T11-INVARIANT // G2-EXEMPT: A21.4 negative assertion
+    //   - BUG-UI-T11-SOURCE-GUARD // G2-EXEMPT: A21.4 negative assertion
+    //   - "상태 이상"
+    //   - "invariant 오류"
+    //   - "소스 불일치"
+    // - 토스트 카피는 V-* 룰 ID prefix 만 허용
+    //
+    // 사고 매핑 (스탠드업 §0):
+    // - 사용자가 B10/B11/B12 런 + B10 추가 시도
+    // - 회귀 코드: source guard 가 INV-G1/G2 false positive 로 setPendingTableGroups 거부
+    // - 사용자 입장: "왜 못 놓이지?" + 위협 토스트 노출
+    //
+    // 본 테스트가 GREEN = INC-T11-FP-B10 회귀 100% 차단
+  });
+});

--- a/src/frontend/src/lib/dragEnd/__tests__/by-action/README.md
+++ b/src/frontend/src/lib/dragEnd/__tests__/by-action/README.md
@@ -1,0 +1,72 @@
+# A1~A21 행동 매트릭스 1:1 단위 테스트 (PR-D-Q02 RED)
+
+- **작성**: 2026-04-25, qa Day 1 (RED 초안)
+- **상위 SSOT**: `docs/02-design/56-action-state-matrix.md` §3.2~§3.19
+- **상위 dispatch**: `work_logs/plans/2026-04-25-phase-c-implementation-dispatch.md` §3.4 PR-D-Q02
+- **상위 산출물**: `docs/04-testing/88-test-strategy-rebuild.md` §2.1
+- **목적**: 사용자 행동 21개 (A1~A21) × SSOT 56 매트릭스 셀 1:1 매핑 단위 테스트
+
+## 파일 구조
+
+```
+by-action/
+├── A01-rack-to-new-group.test.ts        (4 cases, A1)
+├── A02-rack-to-pending.test.ts          (6 cases, A2)
+├── A03-rack-to-server.test.ts           (6 cases, A3)
+├── A04-pending-to-new.test.ts           (5 cases, A4)
+├── A05-pending-to-pending.test.ts       (4 cases, A5)
+├── A06-pending-to-server.test.ts        (6 cases, A6, INC-T11-DUP 회귀 핵심)
+├── A07-pending-to-rack.test.ts          (4 cases, A7)
+├── A08-server-to-new.test.ts            (4 cases, A8)
+├── A09-server-to-server-merge.test.ts   (5 cases, A9, INC-T11-IDDUP 회귀 핵심)
+├── A10-server-to-pending.test.ts        (4 cases, A10)
+├── A11-server-to-rack.test.ts           (3 cases, A11)
+├── A12-joker-swap.test.ts               (6 cases, A12)
+├── A13-rack-rearrange.test.ts           (3 cases, A13)
+├── A14-confirm-turn.test.ts             (7 cases, A14)
+├── A15-reset-turn.test.ts               (3 cases, A15)
+├── A16-draw.test.ts                     (4 cases, A16)
+├── A17-cancel.test.ts                   (3 cases, A17)
+├── A18-ws-place-tiles-from-other.test.ts (2 cases, A18)
+├── A19-ws-turn-start.test.ts            (4 cases, A19)
+├── A20-ws-turn-end.test.ts              (3 cases, A20)
+└── A21-ws-invalid-move.test.ts          (4 cases, A21, INC-T11-FP-B10 회귀)
+
+총 21 파일 / 90 cases (88 §2.1 합계 일치)
+```
+
+## RED → GREEN 전환 (G3 게이트)
+
+**Day 1 (현재)**: 본 파일들은 모두 **RED** — describe/it 골격 + TODO 주석 + 룰 ID 매핑만.
+실제 assertion 은 frontend-dev PR-D03~D08 (F-02~F-06) 의 reducer 재작성 후 작성.
+
+**Day 2~3 (PR-D-Q02 RED commit)**: 본 RED 파일들에 실제 assertion 추가. CI RED 확인.
+
+**Day 4 (PR-D-Q02 GREEN commit)**: frontend-dev PR-D03~D08 머지 후 본 테스트 GREEN 확인.
+
+## SSOT 룰 ID 매핑 (G1 게이트)
+
+각 파일의 모든 `describe` / `it` 명에 다음 패턴 1개 이상 포함:
+- `V-[0-9]+[a-e]?` (서버 검증)
+- `UR-[0-9]+` (UI 인터랙션)
+- `D-[0-9]+` (데이터 무결성)
+- `INV-G?[0-9]+` (invariant)
+- `A[0-9]+` (행동 매트릭스 셀, 본 파일 자체)
+
+## band-aid 금지 (G2 게이트)
+
+본 디렉토리 어떤 테스트도 다음 검증 금지:
+- `source.guard` / `sourceGuard` 동작
+- `invariant.validator` 동작
+- `BUG-UI-T11-INVARIANT` / `BUG-UI-T11-SOURCE-GUARD` 토스트 노출
+- `detectDuplicateTileCodes` helper 사용 검증 (INV-G2 property test 제외)
+
+## 모듈화 7원칙 (G5 게이트)
+
+- **SRP**: 1 파일 = 1 셀 = 1 행동 (A-NN)
+- **순수 함수 우선**: dragEndReducer 가 순수 함수가 되도록 검증
+- **의존성 주입**: gameStore mock 주입
+- **계층 분리**: UI / 상태 / 도메인 / 통신 4계층 명확
+- **테스트 가능성**: describe/it 명에 SSOT 룰 ID 명시
+- **수정 용이성**: 룰 1개 수정 시 1~3 파일만
+- **band-aid 금지**: G2 통과


### PR DESCRIPTION
## Phase D Day 1 — PR-D-Q02 (Day 1 RED 초안, Day 2~3 assertion 추가, Day 4 GREEN)

**SSOT 매핑**: 88 §2.1 A1~A21 행동별 1:1 단위 90건

## commit
- `3fc9472` `[A-01] [V-08] [UR-06] [A-21] rack-to-board-empty unit test — RED spec (Day 1 초안 21 파일 90 it.todo)`

## 산출
- `src/frontend/src/lib/dragEnd/__tests__/by-action/` (22 파일 = 21 RED + README.md)
- A1=4, A2=6, A3=6, A4=5, A5=4, A6=6, A7=4, A8=4, A9=5, A10=4, A11=3, A12=6, A13=3, A14=7, A15=3, A16=4, A17=3, A18=2, A19=4, A20=3, A21=4 = **90 it.todo**

## 사고 직접 회귀 셀 (3건)
- A06.6 INC-T11-DUP (D-02 atomic, 사고 84)
- A09.4 INC-T11-IDDUP (V-17 + INV-G1, 사고 86 §3.1)
- A21.4 INC-T11-FP-B10 (UR-34 band-aid 토스트 금지, 스탠드업 §0)

## Day 2~7 일정
- Day 2 (4-26): RED commit (assertion 추가) — 90 it.todo → 90 it()
- Day 3 (4-27): mergeCompatibility 32 + jokerSwap 16 RED (PR-D-Q03)
- Day 4 (4-28): **PR-D-Q01+Q02+Q03 동시 머지** GREEN
- Day 5: PR-D-Q04 (전이 24+invariant 16 fast-check) + Q05
- Day 6: PR-D-Q06 (self-play harness 28) + Q07 (G1~G5 자동화)
- Day 7: PR-D-Q08 CI

## 게이트 self-check
- G1 룰 ID: describe/it 명에 V-/UR-/D-/INV-/A-/F- 1+ (grep 100%)
- G2 band-aid 0 (A21.4 negative assertion 만, G2-EXEMPT 주석)
- G3 RED→GREEN 분리 (it.todo SKIP, Day 2~3 assertion, Day 4 GREEN)
- G5 1 파일 1 셀 1 행동

🤖 Generated with [Claude Code](https://claude.com/claude-code)