### PR TITLE
[Phase0][L3] 순수 함수 7종 + dragEndReducer RDX-01/05 — 58 §7 Phase 0

### DIFF
--- a/src/frontend/src/lib/__tests__/confirmValidator.test.ts
+++ b/src/frontend/src/lib/__tests__/confirmValidator.test.ts
@@ -1,0 +1,152 @@
+/**
+ * confirmValidator.ts 단위 테스트
+ *
+ * SSOT: V-01/02/03/04/14/15 클라이언트 미러, UR-36 (추가 게이트 금지)
+ */
+
+import { validateTurnPreCheck } from "@/lib/confirmValidator";
+import type { TableGroup, TileCode } from "@/types/tile";
+
+const makeGroup = (id: string, tiles: TileCode[]): TableGroup => ({
+  id,
+  tiles,
+  type: "group",
+});
+
+// ---------------------------------------------------------------------------
+// V-03: tilesAdded >= 1
+// ---------------------------------------------------------------------------
+
+describe("[confirmValidator] V-03 랙에서 최소 1장 추가", () => {
+  it("tilesAdded === 0 → valid: false, ERR_NO_RACK_TILE", () => {
+    const result = validateTurnPreCheck([], true, 0, 0);
+    expect(result.valid).toBe(false);
+    expect(result.errorCode).toBe("ERR_NO_RACK_TILE");
+  });
+
+  it("tilesAdded === 1 → V-03 통과", () => {
+    const groups = [makeGroup("p1", ["R7a", "B7a", "Y7a"])];
+    const result = validateTurnPreCheck(groups, true, 21, 1);
+    expect(result.valid).toBe(true);
+  });
+
+  it("tilesAdded === 3 → V-03 통과 (여러 장)", () => {
+    const groups = [makeGroup("p1", ["R10a", "B10a", "Y10a"])];
+    const result = validateTurnPreCheck(groups, true, 30, 3);
+    expect(result.valid).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// V-04: 초기 등록 30점 이상
+// ---------------------------------------------------------------------------
+
+describe("[confirmValidator] V-04 초기 등록 30점", () => {
+  it("hasInitialMeld=false, 점수 < 30 → ERR_INITIAL_MELD_SCORE", () => {
+    const groups = [makeGroup("p1", ["R5a", "B5a", "Y5a"])];
+    const result = validateTurnPreCheck(groups, false, 15, 1);
+    expect(result.valid).toBe(false);
+    expect(result.errorCode).toBe("ERR_INITIAL_MELD_SCORE");
+  });
+
+  it("hasInitialMeld=false, 점수 === 30 → 통과", () => {
+    const groups = [makeGroup("p1", ["R10a", "B10a", "Y10a"])];
+    const result = validateTurnPreCheck(groups, false, 30, 3);
+    expect(result.valid).toBe(true);
+  });
+
+  it("hasInitialMeld=true, 점수 < 30 → V-04 면제, 다른 검사만", () => {
+    const groups = [makeGroup("p1", ["R7a", "B7a", "Y7a"])];
+    const result = validateTurnPreCheck(groups, true, 5, 1);
+    expect(result.valid).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// V-02: 세트 크기 3장 이상
+// ---------------------------------------------------------------------------
+
+describe("[confirmValidator] V-02 세트 크기 3장", () => {
+  it("2장 그룹 → ERR_SET_SIZE", () => {
+    const groups = [makeGroup("p1", ["R7a", "B7a"])];
+    const result = validateTurnPreCheck(groups, true, 14, 2);
+    expect(result.valid).toBe(false);
+    expect(result.errorCode).toBe("ERR_SET_SIZE");
+    expect(result.errorGroupId).toBe("p1");
+  });
+
+  it("3장 그룹 → V-02 통과", () => {
+    const groups = [makeGroup("p1", ["R7a", "B7a", "Y7a"])];
+    const result = validateTurnPreCheck(groups, true, 21, 3);
+    expect(result.valid).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// V-14: 그룹 동색 중복 불가
+// ---------------------------------------------------------------------------
+
+describe("[confirmValidator] V-14 그룹 동색 중복", () => {
+  it("[R7a, R7b, B7a] 같은 색(R) 중복 → ERR_GROUP_COLOR_DUP", () => {
+    const groups = [makeGroup("p1", ["R7a", "R7b", "B7a"])];
+    const result = validateTurnPreCheck(groups, true, 21, 1);
+    expect(result.valid).toBe(false);
+    expect(result.errorCode).toBe("ERR_GROUP_COLOR_DUP");
+  });
+
+  it("[R7a, B7a, Y7a] 서로 다른 색 → 통과", () => {
+    const groups = [makeGroup("p1", ["R7a", "B7a", "Y7a"])];
+    const result = validateTurnPreCheck(groups, true, 21, 1);
+    expect(result.valid).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// V-15: 런 숫자 연속
+// ---------------------------------------------------------------------------
+
+describe("[confirmValidator] V-15 런 연속성", () => {
+  it("[R5a, R7a, R8a] 비연속 런 → ERR_RUN_SEQUENCE", () => {
+    const group: TableGroup = { id: "p1", tiles: ["R5a", "R7a", "R8a"], type: "run" };
+    const result = validateTurnPreCheck([group], true, 20, 1);
+    expect(result.valid).toBe(false);
+    expect(result.errorCode).toBe("ERR_RUN_SEQUENCE");
+  });
+
+  it("[R5a, R6a, R7a] 연속 런 → 통과", () => {
+    const group: TableGroup = { id: "p1", tiles: ["R5a", "R6a", "R7a"], type: "run" };
+    const result = validateTurnPreCheck([group], true, 18, 3);
+    expect(result.valid).toBe(true);
+  });
+
+  it("[R11a, R12a, R13a] 최대 숫자 런 → 통과", () => {
+    const group: TableGroup = { id: "p1", tiles: ["R11a", "R12a", "R13a"], type: "run" };
+    const result = validateTurnPreCheck([group], true, 36, 3);
+    expect(result.valid).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 복합 시나리오
+// ---------------------------------------------------------------------------
+
+describe("[confirmValidator] 복합 시나리오", () => {
+  it("여러 그룹 모두 유효 → valid: true", () => {
+    const groups: TableGroup[] = [
+      makeGroup("p1", ["R10a", "B10a", "Y10a"]),
+      { id: "p2", tiles: ["K5a", "K6a", "K7a"], type: "run" },
+    ];
+    const result = validateTurnPreCheck(groups, false, 45, 6);
+    expect(result.valid).toBe(true);
+  });
+
+  it("첫 번째 그룹 무효 → 첫 번째 그룹 ID 반환", () => {
+    const groups: TableGroup[] = [
+      makeGroup("p1", ["R7a", "B7a"]), // 2장 → ERR_SET_SIZE
+      makeGroup("p2", ["R10a", "B10a", "Y10a"]),
+    ];
+    const result = validateTurnPreCheck(groups, true, 44, 5);
+    expect(result.valid).toBe(false);
+    expect(result.errorGroupId).toBe("p1");
+  });
+});

--- a/src/frontend/src/lib/__tests__/stateMachineGuard.test.ts
+++ b/src/frontend/src/lib/__tests__/stateMachineGuard.test.ts
@@ -1,0 +1,226 @@
+/**
+ * stateMachineGuard.ts 단위 테스트
+ *
+ * SSOT: 56b 전이 24개, canTransition, nextState
+ */
+
+import { nextState, canTransition } from "@/lib/stateMachineGuard";
+import type { TurnState, TurnAction } from "@/lib/stateMachineGuard";
+
+// ---------------------------------------------------------------------------
+// S0: OUT_OF_TURN
+// ---------------------------------------------------------------------------
+
+describe("[stateMachineGuard] S0 OUT_OF_TURN", () => {
+  it("TURN_START + isMyTurn=true → MY_TURN_IDLE (S1)", () => {
+    expect(nextState("OUT_OF_TURN", "TURN_START", { isMyTurn: true })).toBe("MY_TURN_IDLE");
+  });
+
+  it("TURN_START + isMyTurn=false → OUT_OF_TURN (S0 유지)", () => {
+    expect(nextState("OUT_OF_TURN", "TURN_START", { isMyTurn: false })).toBe("OUT_OF_TURN");
+  });
+
+  it("DRAG_START_RACK → null (허용 안 됨)", () => {
+    expect(nextState("OUT_OF_TURN", "DRAG_START_RACK")).toBeNull();
+  });
+
+  it("CONFIRM → null", () => {
+    expect(nextState("OUT_OF_TURN", "CONFIRM")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// S1: MY_TURN_IDLE
+// ---------------------------------------------------------------------------
+
+describe("[stateMachineGuard] S1 MY_TURN_IDLE", () => {
+  it("DRAG_START_RACK → DRAGGING_FROM_RACK (S2)", () => {
+    expect(nextState("MY_TURN_IDLE", "DRAG_START_RACK")).toBe("DRAGGING_FROM_RACK");
+  });
+
+  it("DRAW → DRAWING (S9)", () => {
+    expect(nextState("MY_TURN_IDLE", "DRAW")).toBe("DRAWING");
+  });
+
+  it("TURN_START + isMyTurn=false → OUT_OF_TURN", () => {
+    expect(nextState("MY_TURN_IDLE", "TURN_START", { isMyTurn: false })).toBe("OUT_OF_TURN");
+  });
+
+  it("CONFIRM → null (pending 없을 때 불허)", () => {
+    expect(nextState("MY_TURN_IDLE", "CONFIRM")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// S2: DRAGGING_FROM_RACK
+// ---------------------------------------------------------------------------
+
+describe("[stateMachineGuard] S2 DRAGGING_FROM_RACK", () => {
+  it("DROP_OK → PENDING_BUILDING (S5)", () => {
+    expect(nextState("DRAGGING_FROM_RACK", "DROP_OK")).toBe("PENDING_BUILDING");
+  });
+
+  it("DRAG_CANCEL → MY_TURN_IDLE (S1, pending 없음 기본)", () => {
+    expect(nextState("DRAGGING_FROM_RACK", "DRAG_CANCEL")).toBe("MY_TURN_IDLE");
+  });
+
+  it("CONFIRM → null", () => {
+    expect(nextState("DRAGGING_FROM_RACK", "CONFIRM")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// S5: PENDING_BUILDING
+// ---------------------------------------------------------------------------
+
+describe("[stateMachineGuard] S5 PENDING_BUILDING", () => {
+  it("DRAG_START_RACK → DRAGGING_FROM_RACK (S2)", () => {
+    expect(nextState("PENDING_BUILDING", "DRAG_START_RACK")).toBe("DRAGGING_FROM_RACK");
+  });
+
+  it("DRAG_START_PENDING → DRAGGING_FROM_PENDING (S3)", () => {
+    expect(nextState("PENDING_BUILDING", "DRAG_START_PENDING")).toBe("DRAGGING_FROM_PENDING");
+  });
+
+  it("DRAG_START_SERVER + hasInitialMeld=true → DRAGGING_FROM_SERVER (S4)", () => {
+    expect(nextState("PENDING_BUILDING", "DRAG_START_SERVER", { hasInitialMeld: true })).toBe(
+      "DRAGGING_FROM_SERVER",
+    );
+  });
+
+  it("DRAG_START_SERVER + hasInitialMeld=false → null (V-13a 차단)", () => {
+    expect(nextState("PENDING_BUILDING", "DRAG_START_SERVER", { hasInitialMeld: false })).toBeNull();
+  });
+
+  it("PRE_CHECK_PASS → PENDING_READY (S6)", () => {
+    expect(nextState("PENDING_BUILDING", "PRE_CHECK_PASS")).toBe("PENDING_READY");
+  });
+
+  it("RESET → MY_TURN_IDLE (S1)", () => {
+    expect(nextState("PENDING_BUILDING", "RESET")).toBe("MY_TURN_IDLE");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// S6: PENDING_READY
+// ---------------------------------------------------------------------------
+
+describe("[stateMachineGuard] S6 PENDING_READY", () => {
+  it("CONFIRM → COMMITTING (S7)", () => {
+    expect(nextState("PENDING_READY", "CONFIRM")).toBe("COMMITTING");
+  });
+
+  it("PRE_CHECK_FAIL → PENDING_BUILDING (S5)", () => {
+    expect(nextState("PENDING_READY", "PRE_CHECK_FAIL")).toBe("PENDING_BUILDING");
+  });
+
+  it("RESET → MY_TURN_IDLE (S1)", () => {
+    expect(nextState("PENDING_READY", "RESET")).toBe("MY_TURN_IDLE");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// S7: COMMITTING
+// ---------------------------------------------------------------------------
+
+describe("[stateMachineGuard] S7 COMMITTING", () => {
+  it("TURN_END_OK → OUT_OF_TURN (S0)", () => {
+    expect(nextState("COMMITTING", "TURN_END_OK")).toBe("OUT_OF_TURN");
+  });
+
+  it("INVALID → INVALID_RECOVER (S8)", () => {
+    expect(nextState("COMMITTING", "INVALID")).toBe("INVALID_RECOVER");
+  });
+
+  it("CONFIRM → null (이미 커밋 중)", () => {
+    expect(nextState("COMMITTING", "CONFIRM")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// S8: INVALID_RECOVER
+// ---------------------------------------------------------------------------
+
+describe("[stateMachineGuard] S8 INVALID_RECOVER", () => {
+  it("RESET → MY_TURN_IDLE (S1)", () => {
+    expect(nextState("INVALID_RECOVER", "RESET")).toBe("MY_TURN_IDLE");
+  });
+
+  it("DROP_OK → PENDING_BUILDING (재시도 가능)", () => {
+    expect(nextState("INVALID_RECOVER", "DROP_OK")).toBe("PENDING_BUILDING");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// S4: DRAGGING_FROM_SERVER → JOKER_SWAP
+// ---------------------------------------------------------------------------
+
+describe("[stateMachineGuard] S4 DRAGGING_FROM_SERVER", () => {
+  it("JOKER_SWAP → JOKER_RECOVERED (S10)", () => {
+    expect(nextState("DRAGGING_FROM_SERVER", "JOKER_SWAP")).toBe("JOKER_RECOVERED");
+  });
+
+  it("DROP_OK → PENDING_BUILDING", () => {
+    expect(nextState("DRAGGING_FROM_SERVER", "DROP_OK")).toBe("PENDING_BUILDING");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// S10: JOKER_RECOVERED
+// ---------------------------------------------------------------------------
+
+describe("[stateMachineGuard] S10 JOKER_RECOVERED", () => {
+  it("JOKER_PLACED → PENDING_BUILDING (S5)", () => {
+    expect(nextState("JOKER_RECOVERED", "JOKER_PLACED")).toBe("PENDING_BUILDING");
+  });
+
+  it("RESET → MY_TURN_IDLE (S1)", () => {
+    expect(nextState("JOKER_RECOVERED", "RESET")).toBe("MY_TURN_IDLE");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GAME_OVER — 모든 상태에서 S0으로
+// ---------------------------------------------------------------------------
+
+describe("[stateMachineGuard] GAME_OVER 전역 전이", () => {
+  const allStates: TurnState[] = [
+    "OUT_OF_TURN",
+    "MY_TURN_IDLE",
+    "DRAGGING_FROM_RACK",
+    "DRAGGING_FROM_PENDING",
+    "DRAGGING_FROM_SERVER",
+    "PENDING_BUILDING",
+    "PENDING_READY",
+    "COMMITTING",
+    "INVALID_RECOVER",
+    "DRAWING",
+    "JOKER_RECOVERED",
+  ];
+
+  allStates.forEach((state) => {
+    it(`${state} + GAME_OVER → OUT_OF_TURN`, () => {
+      expect(nextState(state, "GAME_OVER")).toBe("OUT_OF_TURN");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// canTransition 헬퍼
+// ---------------------------------------------------------------------------
+
+describe("[stateMachineGuard] canTransition", () => {
+  it("허용된 전이 → true", () => {
+    expect(canTransition("MY_TURN_IDLE", "DRAG_START_RACK")).toBe(true);
+  });
+
+  it("불허된 전이 → false", () => {
+    expect(canTransition("OUT_OF_TURN", "CONFIRM")).toBe(false);
+  });
+
+  it("컨텍스트 필요 전이 — 조건 미충족 → false", () => {
+    expect(canTransition("PENDING_BUILDING", "DRAG_START_SERVER", { hasInitialMeld: false })).toBe(
+      false,
+    );
+  });
+});

--- a/src/frontend/src/lib/__tests__/tileClassify.test.ts
+++ b/src/frontend/src/lib/__tests__/tileClassify.test.ts
@@ -1,0 +1,72 @@
+/**
+ * tileClassify.ts 단위 테스트
+ *
+ * SSOT: D-10 (type 힌트는 참고용, 내용 기준 분류)
+ */
+
+import { classifySetType } from "@/lib/tileClassify";
+import type { TileCode } from "@/types/tile";
+
+describe("[tileClassify] classifySetType", () => {
+  // ---- 기본 그룹 분류 ----
+  describe("그룹 (같은 숫자, 다른 색)", () => {
+    it("3장 그룹 — 숫자가 모두 같으면 'group'", () => {
+      const tiles: TileCode[] = ["R7a", "B7a", "Y7a"];
+      expect(classifySetType(tiles)).toBe("group");
+    });
+
+    it("4장 그룹 — 모든 색상 포함 'group'", () => {
+      const tiles: TileCode[] = ["R7a", "B7a", "Y7a", "K7a"];
+      expect(classifySetType(tiles)).toBe("group");
+    });
+
+    it("1장 그룹 — 숫자 단독 'group'", () => {
+      // 1장이지만 숫자가 같으면 group (조커 없음)
+      const tiles: TileCode[] = ["R5a"];
+      expect(classifySetType(tiles)).toBe("group");
+    });
+  });
+
+  // ---- 런 분류 ----
+  describe("런 (같은 색, 연속 숫자)", () => {
+    it("3장 런 — 색상이 모두 같으면 'run'", () => {
+      const tiles: TileCode[] = ["B5a", "B6a", "B7a"];
+      expect(classifySetType(tiles)).toBe("run");
+    });
+
+    it("5장 런 — 연속 숫자, 같은 색 'run'", () => {
+      const tiles: TileCode[] = ["R1a", "R2a", "R3a", "R4a", "R5a"];
+      expect(classifySetType(tiles)).toBe("run");
+    });
+  });
+
+  // ---- 조커 처리 ----
+  describe("조커 처리", () => {
+    it("조커만 있으면 'run' (기본값)", () => {
+      const tiles: TileCode[] = ["JK1"];
+      expect(classifySetType(tiles)).toBe("run");
+    });
+
+    it("빈 배열은 'run' (기본값)", () => {
+      expect(classifySetType([])).toBe("run");
+    });
+
+    it("조커 + 같은 숫자 → 'group'", () => {
+      const tiles: TileCode[] = ["R7a", "B7a", "JK1"];
+      expect(classifySetType(tiles)).toBe("group");
+    });
+
+    it("조커 + 같은 색상 → 'run'", () => {
+      const tiles: TileCode[] = ["B5a", "B6a", "JK2"];
+      expect(classifySetType(tiles)).toBe("run");
+    });
+  });
+
+  // ---- 혼재 타일 ----
+  describe("혼재 타일 (그룹도 런도 아님)", () => {
+    it("숫자 다르고 색상 다르면 'run' (기본값, 서버에서 V-01 거부)", () => {
+      const tiles: TileCode[] = ["R7a", "B5a", "Y8a"];
+      expect(classifySetType(tiles)).toBe("run");
+    });
+  });
+});

--- a/src/frontend/src/lib/__tests__/turnUtils.test.ts
+++ b/src/frontend/src/lib/__tests__/turnUtils.test.ts
@@ -1,0 +1,134 @@
+/**
+ * turnUtils.ts 단위 테스트
+ *
+ * SSOT: V-08 (자기 턴), V-13a (initialMeld), V-03 (tilesAdded), V-04 (30점)
+ */
+
+import {
+  computeIsMyTurn,
+  computeEffectiveMeld,
+  computeTilesAdded,
+  computePendingScore,
+} from "@/lib/turnUtils";
+import type { Player } from "@/types/game";
+import type { TileCode, TableGroup } from "@/types/tile";
+
+// ---------------------------------------------------------------------------
+// computeIsMyTurn — V-08
+// ---------------------------------------------------------------------------
+
+describe("[turnUtils] computeIsMyTurn (V-08)", () => {
+  it("currentSeat === mySeat → true (내 턴)", () => {
+    expect(computeIsMyTurn(2, 2)).toBe(true);
+  });
+
+  it("currentSeat !== mySeat → false (상대 턴)", () => {
+    expect(computeIsMyTurn(1, 2)).toBe(false);
+  });
+
+  it("seat 0 기준 동일 → true", () => {
+    expect(computeIsMyTurn(0, 0)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeEffectiveMeld — V-13a
+// ---------------------------------------------------------------------------
+
+const makePlayer = (seat: number, hasInitialMeld: boolean | undefined): Player => ({
+  seat,
+  type: "HUMAN",
+  userId: `user-${seat}`,
+  displayName: `Player ${seat}`,
+  status: "CONNECTED",
+  hasInitialMeld,
+});
+
+describe("[turnUtils] computeEffectiveMeld (V-13a)", () => {
+  it("해당 플레이어의 hasInitialMeld가 true → true", () => {
+    const players: Player[] = [makePlayer(0, false), makePlayer(1, true)];
+    expect(computeEffectiveMeld(players, 1)).toBe(true);
+  });
+
+  it("해당 플레이어의 hasInitialMeld가 false → false", () => {
+    const players: Player[] = [makePlayer(0, false), makePlayer(1, false)];
+    expect(computeEffectiveMeld(players, 1)).toBe(false);
+  });
+
+  it("해당 플레이어가 없으면 false", () => {
+    const players: Player[] = [makePlayer(0, true)];
+    expect(computeEffectiveMeld(players, 99)).toBe(false);
+  });
+
+  it("hasInitialMeld가 undefined이면 false", () => {
+    const players: Player[] = [makePlayer(0, undefined)];
+    expect(computeEffectiveMeld(players, 0)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeTilesAdded — V-03
+// ---------------------------------------------------------------------------
+
+describe("[turnUtils] computeTilesAdded (V-03)", () => {
+  it("랙에서 2장 제거 → 2 반환", () => {
+    const start: TileCode[] = ["R7a", "B5a", "Y8a", "K1a"];
+    const current: TileCode[] = ["R7a", "B5a"];
+    expect(computeTilesAdded(start, current)).toBe(2);
+  });
+
+  it("랙 변화 없음 → 0 반환", () => {
+    const rack: TileCode[] = ["R7a", "B5a"];
+    expect(computeTilesAdded(rack, rack)).toBe(0);
+  });
+
+  it("드로우로 랙이 늘어난 경우 → 0 (음수 클램프)", () => {
+    const start: TileCode[] = ["R7a"];
+    const current: TileCode[] = ["R7a", "B5a"];
+    expect(computeTilesAdded(start, current)).toBe(0);
+  });
+
+  it("랙 전부 비움 → 전체 수 반환", () => {
+    const start: TileCode[] = ["R1a", "B2a", "Y3a"];
+    expect(computeTilesAdded(start, [])).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computePendingScore — V-04
+// ---------------------------------------------------------------------------
+
+const makeGroup = (id: string, tiles: TileCode[]): TableGroup => ({
+  id,
+  tiles,
+  type: "run",
+});
+
+describe("[turnUtils] computePendingScore (V-04)", () => {
+  it("일반 타일 합산 — R7+B5+Y8 = 20점", () => {
+    const groups: TableGroup[] = [makeGroup("p1", ["R7a", "B5a", "Y8a"])];
+    expect(computePendingScore(groups)).toBe(20);
+  });
+
+  it("조커는 0점 처리", () => {
+    const groups: TableGroup[] = [makeGroup("p1", ["JK1", "B5a", "Y8a"])];
+    expect(computePendingScore(groups)).toBe(13); // 5+8=13
+  });
+
+  it("여러 그룹 합산", () => {
+    const groups: TableGroup[] = [
+      makeGroup("p1", ["R10a", "B10a", "Y10a"]),
+      makeGroup("p2", ["K1a", "K2a", "K3a"]),
+    ];
+    expect(computePendingScore(groups)).toBe(36); // 30+6
+  });
+
+  it("빈 배열 → 0점", () => {
+    expect(computePendingScore([])).toBe(0);
+  });
+
+  it("30점 이상 체크 — 10+10+10 = 30", () => {
+    const groups: TableGroup[] = [makeGroup("p1", ["R10a", "B10a", "Y10a"])];
+    expect(computePendingScore(groups)).toBeGreaterThanOrEqual(30);
+  });
+});

--- a/src/frontend/src/lib/confirmValidator.ts
+++ b/src/frontend/src/lib/confirmValidator.ts
@@ -1,0 +1,197 @@
+/**
+ * confirmValidator — ConfirmTurn 사전검증 SSOT (L3 순수 함수)
+ *
+ * SSOT 매핑:
+ *   - V-01: 세트 유효성 (그룹 또는 런)
+ *   - V-02: 세트 크기 (3장 이상)
+ *   - V-03: 랙에서 최소 1장 추가
+ *   - V-04: 초기 등록 30점 이상
+ *   - V-14: 그룹 동색 중복 불가
+ *   - V-15: 런 숫자 연속 (1↔13 순환 금지)
+ *   - UR-36: ConfirmTurn 사전검증은 위 6가지 클라 미러만. 임의 게이트 추가 금지.
+ *
+ * 금지:
+ *   - store, WS, DOM import 불가 (L3 계층 규칙)
+ *   - UR-36: 위 V-* 외 추가 검증 게이트 절대 추가 금지 (band-aid)
+ *
+ * 주의: 이 함수는 서버 최종 검증의 클라이언트 미러일 뿐이다.
+ * false positive로 사용자 액션을 차단하지 않도록 보수적으로 검사한다.
+ */
+
+import type { TileCode, TableGroup, TileColor, TileNumber } from "@/types/tile";
+import { parseTileCode } from "@/types/tile";
+
+// ---------------------------------------------------------------------------
+// 결과 타입
+// ---------------------------------------------------------------------------
+
+export interface ValidationResult {
+  valid: boolean;
+  /** 검증 실패한 그룹 ID */
+  errorGroupId?: string;
+  /**
+   * 에러 코드 (서버 ERR_* 미러)
+   * "ERR_SET_SIZE" | "ERR_INVALID_SET" | "ERR_NO_RACK_TILE" |
+   * "ERR_INITIAL_MELD_SCORE" | "ERR_GROUP_COLOR_DUP" | "ERR_RUN_SEQUENCE"
+   */
+  errorCode?: string;
+}
+
+// ---------------------------------------------------------------------------
+// 내부 헬퍼
+// ---------------------------------------------------------------------------
+
+function isJoker(code: TileCode): boolean {
+  return code === "JK1" || code === "JK2";
+}
+
+/**
+ * V-02: 세트 크기 검사 (3장 이상)
+ */
+function checkSetSize(group: TableGroup): boolean {
+  return group.tiles.length >= 3;
+}
+
+/**
+ * V-14: 그룹 동색 중복 불가
+ * 조커를 제외한 일반 타일 중 같은 색이 2번 이상 나오면 거절.
+ */
+function checkGroupColorDuplicate(group: TableGroup): boolean {
+  const regular = group.tiles.filter((t) => !isJoker(t));
+  const parsed = regular.map((t) => parseTileCode(t));
+  const colors = parsed.map((t) => t.color as TileColor);
+  return new Set(colors).size === colors.length;
+}
+
+/**
+ * V-15: 런 숫자 연속 (1~13 범위, 1↔13 순환 금지, 중복 금지)
+ */
+function checkRunSequence(group: TableGroup): boolean {
+  const regular = group.tiles.filter((t) => !isJoker(t));
+  if (regular.length === 0) return true;
+
+  const parsed = regular.map((t) => parseTileCode(t));
+  const numbers = parsed
+    .map((t) => t.number)
+    .filter((n): n is TileNumber => n !== null);
+
+  if (numbers.length === 0) return true;
+
+  // 중복 검사
+  if (new Set(numbers).size !== numbers.length) return false;
+
+  const sorted = [...numbers].sort((a, b) => a - b);
+  const min = sorted[0];
+  const max = sorted[sorted.length - 1];
+
+  // 범위 검사 (1~13)
+  if (min < 1 || max > 13) return false;
+
+  // 연속성 검사: 조커 수만큼 공백 허용
+  const jokerCount = group.tiles.filter((t) => isJoker(t)).length;
+  const span = max - min + 1;
+  if (span > sorted.length + jokerCount) return false;
+
+  // 1↔13 순환 금지: max - min < 12 이어야 함 (전체 범위 = 12)
+  // 예: [12,13,1] → sorted=[1,12,13] → span=13 > 3+0 → 이미 위에서 차단됨
+
+  return true;
+}
+
+/**
+ * V-01: 세트 유효성 — 그룹 또는 런 둘 중 하나를 이루어야 한다.
+ *
+ * 판정:
+ *   - 일반 타일 숫자 모두 같음 → 그룹 후보 → V-14 검사
+ *   - 일반 타일 색상 모두 같음 → 런 후보 → V-15 검사
+ *   - 조커만 있으면 → 유효 (서버 판정에 위임)
+ *   - 그 외 → 무효
+ */
+function checkSetValidity(group: TableGroup): { valid: boolean; errorCode?: string } {
+  const regular = group.tiles.filter((t) => !isJoker(t));
+
+  // 조커만 있거나 비어있으면 서버에 위임
+  if (regular.length === 0) return { valid: true };
+
+  const parsed = regular.map((t) => parseTileCode(t));
+  const numbers = new Set(parsed.map((t) => t.number));
+  const colors = new Set(parsed.map((t) => t.color));
+
+  const isGroupCandidate = numbers.size === 1;
+  const isRunCandidate = colors.size === 1;
+
+  if (isGroupCandidate) {
+    // V-14: 동색 중복
+    if (!checkGroupColorDuplicate(group)) {
+      return { valid: false, errorCode: "ERR_GROUP_COLOR_DUP" };
+    }
+    return { valid: true };
+  }
+
+  if (isRunCandidate) {
+    // V-15: 런 연속성
+    if (!checkRunSequence(group)) {
+      return { valid: false, errorCode: "ERR_RUN_SEQUENCE" };
+    }
+    return { valid: true };
+  }
+
+  // 그룹도 런도 아님
+  return { valid: false, errorCode: "ERR_INVALID_SET" };
+}
+
+// ---------------------------------------------------------------------------
+// 메인 검증 함수
+// ---------------------------------------------------------------------------
+
+/**
+ * ConfirmTurn 사전검증 (V-01/02/03/04/14/15 클라이언트 미러)
+ *
+ * UR-36: 이 함수 외에 임의 게이트 추가 절대 금지.
+ *
+ * @param pendingOnlyGroups pending 전용 그룹 배열 (pending- prefix ID 그룹만)
+ * @param hasInitialMeld 초기 등록 완료 여부
+ * @param pendingPlacementScore pending 그룹 점수 합계 (computePendingScore 결과)
+ * @param tilesAdded 랙에서 보드로 옮긴 타일 수 (computeTilesAdded 결과)
+ * @returns ValidationResult
+ */
+export function validateTurnPreCheck(
+  pendingOnlyGroups: TableGroup[],
+  hasInitialMeld: boolean,
+  pendingPlacementScore: number,
+  tilesAdded: number,
+): ValidationResult {
+  // V-03: 랙에서 최소 1장 추가
+  if (tilesAdded < 1) {
+    return { valid: false, errorCode: "ERR_NO_RACK_TILE" };
+  }
+
+  // V-04: 초기 등록 전이면 30점 이상
+  if (!hasInitialMeld && pendingPlacementScore < 30) {
+    return { valid: false, errorCode: "ERR_INITIAL_MELD_SCORE" };
+  }
+
+  // V-02: 각 그룹 크기 검사 + V-01/V-14/V-15: 세트 유효성
+  for (const group of pendingOnlyGroups) {
+    // V-02: 3장 이상
+    if (!checkSetSize(group)) {
+      return {
+        valid: false,
+        errorGroupId: group.id,
+        errorCode: "ERR_SET_SIZE",
+      };
+    }
+
+    // V-01, V-14, V-15 통합 검사
+    const validity = checkSetValidity(group);
+    if (!validity.valid) {
+      return {
+        valid: false,
+        errorGroupId: group.id,
+        errorCode: validity.errorCode,
+      };
+    }
+  }
+
+  return { valid: true };
+}

--- a/src/frontend/src/lib/dragEnd/dragEndReducer.ts
+++ b/src/frontend/src/lib/dragEnd/dragEndReducer.ts
@@ -1,0 +1,614 @@
+/**
+ * 드래그 종료 상태 전이 순수 리듀서
+ *
+ * GameClient.tsx:730-1287 의 handleDragEnd 분기 로직을 100% 순수 함수로 추출한 것.
+ * 테스트 가능성 + 대량 시나리오 검증을 위해 분리한다.
+ *
+ * 작성: 2026-04-24 22:30 KST, Claude main (Opus 4.7 xhigh)
+ * 발단: 사용자 Turn#11 보드 그룹 중복 복제 사고 (docs/04-testing/84)
+ * 설계 원칙:
+ *   1. 모든 분기가 `setPendingTableGroups` 출력 직전 `detectDuplicateTileCodes` 방어선 통과
+ *   2. table→table 이동에 `isCompatibleWithGroup` 사전검사 강제
+ *   3. 입력 → 출력 단일 전이, 재진입/pointer re-fire 처리는 상위 레이어 책임
+ *   4. reject 사유 열거 가능 (사용자 토스트 + 디버그 로그 일관화)
+ */
+
+import type { TileCode, TableGroup, TileNumber, TileColor } from "@/types/tile";
+import { parseTileCode } from "@/types/tile";
+import { isCompatibleWithGroup } from "@/lib/mergeCompatibility";
+import { detectDuplicateTileCodes, removeFirstOccurrence } from "@/lib/tileStateHelpers";
+// RDX-05: classifySetType, tryJokerSwap 중복 정의 제거 → 단일 SSOT 파일에서 import
+import { classifySetType } from "@/lib/tileClassify";
+import { tryJokerSwap } from "@/lib/jokerSwap";
+// 하위 호환 re-export: 기존 테스트/코드가 dragEndReducer에서 import하는 경우를 위해
+export { classifySetType } from "@/lib/tileClassify";
+export { tryJokerSwap } from "@/lib/jokerSwap";
+export type { JokerSwapResult } from "@/lib/jokerSwap";
+
+// ---------------------------------------------------------------------------
+// 리듀서 입력 / 출력 타입
+// ---------------------------------------------------------------------------
+
+export interface DragReducerState {
+  tableGroups: TableGroup[];
+  myTiles: TileCode[];
+  pendingGroupIds: Set<string>;
+  pendingRecoveredJokers: TileCode[];
+  hasInitialMeld: boolean;
+  forceNewGroup: boolean;
+  /** 현재까지 생성된 pending 그룹 시퀀스 (ID 생성용 단조 카운터) */
+  pendingGroupSeq: number;
+}
+
+export type DragSource =
+  | { kind: "rack" }
+  | { kind: "table"; groupId: string; index: number };
+
+export interface DragInput {
+  source: DragSource;
+  tileCode: TileCode;
+  overId: string;
+  /** Date.now() 또는 테스트 주입 ms */
+  now: number;
+}
+
+export type RejectReason =
+  | "no-op-self-drop"
+  | "cannot-return-server-tile"
+  | "initial-meld-required"
+  | "target-not-found"
+  | "target-equals-source"
+  | "index-mismatch"
+  | "incompatible-merge"           // 가설 A 수정
+  | "duplicate-detected"           // 가설 B/C 방어선
+  | "not-my-turn"
+  | "no-drop-position"
+  | "invalid-tile"
+  | "source-not-found";
+
+export interface DragOutput {
+  nextTableGroups: TableGroup[] | null;  // null = pending 초기화
+  nextMyTiles: TileCode[] | null;
+  nextPendingGroupIds: Set<string>;
+  nextPendingRecoveredJokers: TileCode[];
+  nextPendingGroupSeq: number;
+  addedJoker?: TileCode;
+  removedJoker?: TileCode;
+  /** reject 시 이유 + 상태 변경 없음 */
+  rejected?: RejectReason;
+  /** 사용자에게 보여줄 경고 (예: 초기 등록 전 서버 그룹 드롭 시 토스트) */
+  warning?: "extend-lock-before-initial-meld";
+  /** 디버그용 branch tag */
+  branch: string;
+}
+
+// ---------------------------------------------------------------------------
+// 메인 리듀서
+// ---------------------------------------------------------------------------
+
+export function dragEndReducer(state: DragReducerState, input: DragInput): DragOutput {
+  const {
+    tableGroups,
+    myTiles,
+    pendingGroupIds,
+    pendingRecoveredJokers,
+    hasInitialMeld,
+    forceNewGroup,
+    pendingGroupSeq,
+  } = state;
+  const { source, tileCode, overId, now } = input;
+
+  const defaults = {
+    nextTableGroups: tableGroups,
+    nextMyTiles: myTiles,
+    nextPendingGroupIds: pendingGroupIds,
+    nextPendingRecoveredJokers: pendingRecoveredJokers,
+    nextPendingGroupSeq: pendingGroupSeq,
+  };
+
+  const makeNewGroupId = (seq: number) => `pending-${now}-${seq}`;
+
+  const rejectWith = (reason: RejectReason, branch: string): DragOutput => ({
+    ...defaults,
+    rejected: reason,
+    branch,
+  });
+
+  // ======================================================================
+  // table → ? 분기
+  // ======================================================================
+  if (source.kind === "table") {
+    const sourceGroup = tableGroups.find((g) => g.id === source.groupId);
+    if (!sourceGroup) return rejectWith("source-not-found", "table:source-missing");
+
+    const sourceIsPending = pendingGroupIds.has(source.groupId);
+
+    if (overId === source.groupId) {
+      return rejectWith("no-op-self-drop", "table:self-drop");
+    }
+
+    // ---- table → rack ----
+    if (overId === "player-rack") {
+      if (!sourceIsPending) {
+        return rejectWith("cannot-return-server-tile", "table→rack:server-locked");
+      }
+      const baseTiles = [...sourceGroup.tiles];
+      if (baseTiles[source.index] !== tileCode) {
+        return rejectWith("index-mismatch", "table→rack:index-mismatch");
+      }
+      baseTiles.splice(source.index, 1);
+
+      const updated = tableGroups
+        .map((g) =>
+          g.id === source.groupId
+            ? { ...g, tiles: baseTiles, type: classifySetType(baseTiles) }
+            : g
+        )
+        .filter((g) => g.tiles.length > 0);
+
+      const stillHasPending = updated.some((g) => pendingGroupIds.has(g.id));
+      const nextIds = stillHasPending
+        ? new Set([...pendingGroupIds].filter((id) => updated.some((g) => g.id === id)))
+        : new Set<string>();
+
+      return {
+        ...defaults,
+        nextTableGroups: stillHasPending ? updated : null,
+        nextMyTiles: [...myTiles, tileCode],
+        nextPendingGroupIds: nextIds,
+        branch: "table→rack:ok",
+      };
+    }
+
+    // ---- table → table ----
+    if (!hasInitialMeld) {
+      return rejectWith("initial-meld-required", "table→table:initial-meld-lock");
+    }
+    const targetGroup = tableGroups.find((g) => g.id === overId);
+    if (!targetGroup) return rejectWith("target-not-found", "table→table:no-target");
+    if (targetGroup.id === sourceGroup.id) {
+      return rejectWith("target-equals-source", "table→table:same-group");
+    }
+
+    const updatedSourceTiles = [...sourceGroup.tiles];
+    if (updatedSourceTiles[source.index] !== tileCode) {
+      return rejectWith("index-mismatch", "table→table:index-mismatch");
+    }
+    updatedSourceTiles.splice(source.index, 1);
+
+    // RDX-01 [SSOT 56 §3.6]: A5(pending→pending), A6(pending→server), A9(server→server)
+    // 모두 이 분기를 통과한다. 타겟이 pending이든 서버이든 호환성 검사를 수행한다.
+    // COMPAT 시만 허용 — pending→pending 재배치도 호환성 불일치 시 거절 (INC-T11-DUP 재발 방지).
+    const targetIsPending = pendingGroupIds.has(targetGroup.id);
+    if (!isCompatibleWithGroup(tileCode, targetGroup)) {
+      const branch = targetIsPending
+        ? "table→table:incompatible-pending"
+        : "table→table:incompatible-server";
+      return rejectWith("incompatible-merge", branch);
+    }
+
+    const updatedTargetTiles = [...targetGroup.tiles, tileCode];
+    const nextTableGroups = tableGroups
+      .map((g) => {
+        if (g.id === sourceGroup.id) {
+          return { ...g, tiles: updatedSourceTiles, type: classifySetType(updatedSourceTiles) };
+        }
+        if (g.id === targetGroup.id) {
+          return { ...g, tiles: updatedTargetTiles, type: classifySetType(updatedTargetTiles) };
+        }
+        return g;
+      })
+      .filter((g) => g.tiles.length > 0);
+
+    // ★ 가설 B/C 방어선: 중복 타일 검출
+    const dupes = detectDuplicateTileCodes(nextTableGroups);
+    if (dupes.length > 0) {
+      return rejectWith("duplicate-detected", "table→table:dup-guard");
+    }
+
+    const nextGroupIdSet = new Set(nextTableGroups.map((g) => g.id));
+    const nextPendingGroupIds = new Set(
+      [...pendingGroupIds, targetGroup.id].filter((id) => nextGroupIdSet.has(id))
+    );
+
+    return {
+      ...defaults,
+      nextTableGroups,
+      nextPendingGroupIds,
+      branch: "table→table:ok",
+    };
+  }
+
+  // ======================================================================
+  // rack → ? 분기
+  // ======================================================================
+
+  // ---- rack → player-rack (자기 랙으로) — no-op ----
+  if (overId === "player-rack") {
+    // 보드의 pending 그룹에서 동일 tile code 를 1개 회수한다 (서버 보호)
+    const sourceGroupIdx = tableGroups.findIndex(
+      (g) => pendingGroupIds.has(g.id) && g.tiles.includes(tileCode)
+    );
+    if (sourceGroupIdx < 0) {
+      // 실제로 회수할 곳이 없음 (랙→랙 드래그의 의미 없는 케이스)
+      return rejectWith("source-not-found", "rack→rack:no-source");
+    }
+
+    const updated = tableGroups
+      .map((g, idx) =>
+        idx !== sourceGroupIdx
+          ? g
+          : { ...g, tiles: removeFirstOccurrence(g.tiles, tileCode), type: classifySetType(removeFirstOccurrence(g.tiles, tileCode)) }
+      )
+      .filter((g) => g.tiles.length > 0);
+
+    const stillHasPending = updated.some((g) => pendingGroupIds.has(g.id));
+    const nextIds = stillHasPending
+      ? new Set([...pendingGroupIds].filter((id) => updated.some((g) => g.id === id)))
+      : new Set<string>();
+
+    return {
+      ...defaults,
+      nextTableGroups: stillHasPending ? updated : null,
+      nextMyTiles: [...myTiles, tileCode],
+      nextPendingGroupIds: nextIds,
+      branch: "rack→rack:recover-pending",
+    };
+  }
+
+  // ---- rack → 조커 교체 시도 ----
+  const swapCandidate = tableGroups.find((g) => g.id === overId);
+  if (swapCandidate) {
+    const hasJoker = swapCandidate.tiles.some((t) => t === "JK1" || t === "JK2");
+    if (hasJoker) {
+      const isPending = pendingGroupIds.has(swapCandidate.id);
+      if (isPending || hasInitialMeld) {
+        const swap = tryJokerSwap(swapCandidate.tiles, tileCode);
+        if (swap) {
+          const nextTableGroups = tableGroups.map((g) =>
+            g.id === swapCandidate.id
+              ? { ...g, tiles: swap.nextTiles, type: classifySetType(swap.nextTiles) }
+              : g
+          );
+          const dupes = detectDuplicateTileCodes(nextTableGroups);
+          if (dupes.length > 0) {
+            return rejectWith("duplicate-detected", "rack→joker-swap:dup-guard");
+          }
+          const nextMyTiles = [
+            ...removeFirstOccurrence(myTiles, tileCode),
+            swap.recoveredJoker,
+          ];
+          const nextPendingGroupIds = new Set([...pendingGroupIds, swapCandidate.id]);
+          const nextPendingRecoveredJokers = [...pendingRecoveredJokers, swap.recoveredJoker];
+          return {
+            ...defaults,
+            nextTableGroups,
+            nextMyTiles,
+            nextPendingGroupIds,
+            nextPendingRecoveredJokers,
+            addedJoker: swap.recoveredJoker,
+            branch: "rack→joker-swap:ok",
+          };
+        }
+      }
+    }
+  }
+
+  // ---- rack → pending 그룹 드롭 ----
+  const existingPendingGroup = tableGroups.find(
+    (g) => g.id === overId && pendingGroupIds.has(g.id)
+  );
+  if (existingPendingGroup) {
+    if (!isCompatibleWithGroup(tileCode, existingPendingGroup)) {
+      // 호환 안 되면 새 그룹 생성
+      const nextSeq = pendingGroupSeq + 1;
+      const newGroupId = makeNewGroupId(nextSeq);
+      const newGroup: TableGroup = {
+        id: newGroupId,
+        tiles: [tileCode],
+        type: classifySetType([tileCode]),
+      };
+      const nextTableGroups = [...tableGroups, newGroup];
+      const dupes = detectDuplicateTileCodes(nextTableGroups);
+      if (dupes.length > 0) {
+        return rejectWith("duplicate-detected", "rack→pending-incompat:dup-guard");
+      }
+      const nextMyTiles = removeFirstOccurrence(myTiles, tileCode);
+      const nextPendingGroupIds = new Set([...pendingGroupIds, newGroupId]);
+      const nextPendingRecoveredJokers = pendingRecoveredJokers.includes(tileCode)
+        ? pendingRecoveredJokers.filter((j) => j !== tileCode)
+        : pendingRecoveredJokers;
+      return {
+        ...defaults,
+        nextTableGroups,
+        nextMyTiles,
+        nextPendingGroupIds,
+        nextPendingRecoveredJokers,
+        nextPendingGroupSeq: nextSeq,
+        removedJoker: pendingRecoveredJokers.includes(tileCode) ? tileCode : undefined,
+        branch: "rack→pending-incompat:new-group",
+      };
+    }
+    // 호환 → 병합
+    const updatedTiles = [...existingPendingGroup.tiles, tileCode];
+    const nextTableGroups = tableGroups.map((g) =>
+      g.id !== existingPendingGroup.id
+        ? g
+        : { ...g, tiles: updatedTiles, type: classifySetType(updatedTiles) }
+    );
+    const dupes = detectDuplicateTileCodes(nextTableGroups);
+    if (dupes.length > 0) {
+      return rejectWith("duplicate-detected", "rack→pending-compat:dup-guard");
+    }
+    const nextMyTiles = removeFirstOccurrence(myTiles, tileCode);
+    const nextPendingRecoveredJokers = pendingRecoveredJokers.includes(tileCode)
+      ? pendingRecoveredJokers.filter((j) => j !== tileCode)
+      : pendingRecoveredJokers;
+    return {
+      ...defaults,
+      nextTableGroups,
+      nextMyTiles,
+      nextPendingRecoveredJokers,
+      removedJoker: pendingRecoveredJokers.includes(tileCode) ? tileCode : undefined,
+      branch: "rack→pending-compat:merge",
+    };
+  }
+
+  // ---- rack → 서버 확정 그룹 (하지만 pending 아님) ----
+  const targetServerGroup = tableGroups.find((g) => g.id === overId);
+
+  if (targetServerGroup && !hasInitialMeld) {
+    // 초기 등록 전: 서버 그룹 확장 금지 → 새 pending 그룹 생성
+    const nextSeq = pendingGroupSeq + 1;
+    const newGroupId = makeNewGroupId(nextSeq);
+    const newGroup: TableGroup = {
+      id: newGroupId,
+      tiles: [tileCode],
+      type: classifySetType([tileCode]),
+    };
+    const nextTableGroups = [...tableGroups, newGroup];
+    const dupes = detectDuplicateTileCodes(nextTableGroups);
+    if (dupes.length > 0) {
+      return rejectWith("duplicate-detected", "rack→server-preinitial:dup-guard");
+    }
+    const nextMyTiles = removeFirstOccurrence(myTiles, tileCode);
+    const nextPendingGroupIds = new Set([...pendingGroupIds, newGroupId]);
+    const nextPendingRecoveredJokers = pendingRecoveredJokers.includes(tileCode)
+      ? pendingRecoveredJokers.filter((j) => j !== tileCode)
+      : pendingRecoveredJokers;
+    return {
+      ...defaults,
+      nextTableGroups,
+      nextMyTiles,
+      nextPendingGroupIds,
+      nextPendingRecoveredJokers,
+      nextPendingGroupSeq: nextSeq,
+      warning: "extend-lock-before-initial-meld",
+      removedJoker: pendingRecoveredJokers.includes(tileCode) ? tileCode : undefined,
+      branch: "rack→server-preinitial:new-group",
+    };
+  }
+
+  if (targetServerGroup && hasInitialMeld) {
+    if (!isCompatibleWithGroup(tileCode, targetServerGroup)) {
+      // 비호환 → 새 그룹 (옵션 A 폴스루)
+      const nextSeq = pendingGroupSeq + 1;
+      const newGroupId = makeNewGroupId(nextSeq);
+      const newGroup: TableGroup = {
+        id: newGroupId,
+        tiles: [tileCode],
+        type: classifySetType([tileCode]),
+      };
+      const nextTableGroups = [...tableGroups, newGroup];
+      const dupes = detectDuplicateTileCodes(nextTableGroups);
+      if (dupes.length > 0) {
+        return rejectWith("duplicate-detected", "rack→server-incompat:dup-guard");
+      }
+      const nextMyTiles = removeFirstOccurrence(myTiles, tileCode);
+      const nextPendingGroupIds = new Set([...pendingGroupIds, newGroupId]);
+      const nextPendingRecoveredJokers = pendingRecoveredJokers.includes(tileCode)
+        ? pendingRecoveredJokers.filter((j) => j !== tileCode)
+        : pendingRecoveredJokers;
+      return {
+        ...defaults,
+        nextTableGroups,
+        nextMyTiles,
+        nextPendingGroupIds,
+        nextPendingRecoveredJokers,
+        nextPendingGroupSeq: nextSeq,
+        removedJoker: pendingRecoveredJokers.includes(tileCode) ? tileCode : undefined,
+        branch: "rack→server-incompat:new-group",
+      };
+    }
+    // 호환 → 서버 그룹 확장
+    const updatedTiles = [...targetServerGroup.tiles, tileCode];
+    const nextTableGroups = tableGroups.map((g) =>
+      g.id !== targetServerGroup.id
+        ? g
+        : { ...g, tiles: updatedTiles, type: classifySetType(updatedTiles) }
+    );
+    const dupes = detectDuplicateTileCodes(nextTableGroups);
+    if (dupes.length > 0) {
+      return rejectWith("duplicate-detected", "rack→server-compat:dup-guard");
+    }
+    const nextMyTiles = removeFirstOccurrence(myTiles, tileCode);
+    const nextPendingGroupIds = new Set([...pendingGroupIds, targetServerGroup.id]);
+    const nextPendingRecoveredJokers = pendingRecoveredJokers.includes(tileCode)
+      ? pendingRecoveredJokers.filter((j) => j !== tileCode)
+      : pendingRecoveredJokers;
+    return {
+      ...defaults,
+      nextTableGroups,
+      nextMyTiles,
+      nextPendingGroupIds,
+      nextPendingRecoveredJokers,
+      removedJoker: pendingRecoveredJokers.includes(tileCode) ? tileCode : undefined,
+      branch: "rack→server-compat:merge",
+    };
+  }
+
+  // ---- rack → game-board (빈 공간) ----
+  if (overId === "game-board") {
+    const pendingOnlyGroups = tableGroups.filter(
+      (g) => pendingGroupIds.has(g.id) && g.id.startsWith("pending-")
+    );
+    const lastPendingGroup = pendingOnlyGroups[pendingOnlyGroups.length - 1];
+
+    const shouldCreateNewGroup = computeShouldCreateNewGroup({
+      forceNewGroup,
+      tileCode,
+      lastPendingGroup,
+    });
+
+    if (lastPendingGroup && !shouldCreateNewGroup) {
+      const updatedTiles = [...lastPendingGroup.tiles, tileCode];
+      const nextTableGroups = tableGroups.map((g) =>
+        g.id !== lastPendingGroup.id
+          ? g
+          : { ...g, tiles: updatedTiles, type: classifySetType(updatedTiles) }
+      );
+      const dupes = detectDuplicateTileCodes(nextTableGroups);
+      if (dupes.length > 0) {
+        return rejectWith("duplicate-detected", "rack→board:append-dup-guard");
+      }
+      const nextMyTiles = removeFirstOccurrence(myTiles, tileCode);
+      const nextPendingRecoveredJokers = pendingRecoveredJokers.includes(tileCode)
+        ? pendingRecoveredJokers.filter((j) => j !== tileCode)
+        : pendingRecoveredJokers;
+      return {
+        ...defaults,
+        nextTableGroups,
+        nextMyTiles,
+        nextPendingRecoveredJokers,
+        removedJoker: pendingRecoveredJokers.includes(tileCode) ? tileCode : undefined,
+        branch: "rack→board:append-last",
+      };
+    }
+    // 새 그룹 생성
+    const nextSeq = pendingGroupSeq + 1;
+    const newGroupId = makeNewGroupId(nextSeq);
+    const newGroup: TableGroup = {
+      id: newGroupId,
+      tiles: [tileCode],
+      type: classifySetType([tileCode]),
+    };
+    const nextTableGroups = [...tableGroups, newGroup];
+    const dupes = detectDuplicateTileCodes(nextTableGroups);
+    if (dupes.length > 0) {
+      return rejectWith("duplicate-detected", "rack→board:new-group-dup-guard");
+    }
+    const nextMyTiles = removeFirstOccurrence(myTiles, tileCode);
+    const nextPendingGroupIds = new Set([...pendingGroupIds, newGroupId]);
+    const nextPendingRecoveredJokers = pendingRecoveredJokers.includes(tileCode)
+      ? pendingRecoveredJokers.filter((j) => j !== tileCode)
+      : pendingRecoveredJokers;
+    return {
+      ...defaults,
+      nextTableGroups,
+      nextMyTiles,
+      nextPendingGroupIds,
+      nextPendingRecoveredJokers,
+      nextPendingGroupSeq: nextSeq,
+      removedJoker: pendingRecoveredJokers.includes(tileCode) ? tileCode : undefined,
+      branch: "rack→board:new-group",
+    };
+  }
+
+  // ---- rack → game-board-new-group ----
+  if (overId === "game-board-new-group") {
+    const nextSeq = pendingGroupSeq + 1;
+    const newGroupId = makeNewGroupId(nextSeq);
+    const newGroup: TableGroup = {
+      id: newGroupId,
+      tiles: [tileCode],
+      type: classifySetType([tileCode]),
+    };
+    const nextTableGroups = [...tableGroups, newGroup];
+    const dupes = detectDuplicateTileCodes(nextTableGroups);
+    if (dupes.length > 0) {
+      return rejectWith("duplicate-detected", "rack→board-new-group:dup-guard");
+    }
+    const nextMyTiles = removeFirstOccurrence(myTiles, tileCode);
+    const nextPendingGroupIds = new Set([...pendingGroupIds, newGroupId]);
+    const nextPendingRecoveredJokers = pendingRecoveredJokers.includes(tileCode)
+      ? pendingRecoveredJokers.filter((j) => j !== tileCode)
+      : pendingRecoveredJokers;
+    return {
+      ...defaults,
+      nextTableGroups,
+      nextMyTiles,
+      nextPendingGroupIds,
+      nextPendingRecoveredJokers,
+      nextPendingGroupSeq: nextSeq,
+      removedJoker: pendingRecoveredJokers.includes(tileCode) ? tileCode : undefined,
+      branch: "rack→board-new-group:ok",
+    };
+  }
+
+  return rejectWith("no-drop-position", "rack→unknown");
+}
+
+// ---------------------------------------------------------------------------
+// shouldCreateNewGroup 판정 (GameClient.tsx:1096-1164 동일 로직)
+// ---------------------------------------------------------------------------
+
+function computeShouldCreateNewGroup(params: {
+  forceNewGroup: boolean;
+  tileCode: TileCode;
+  lastPendingGroup: TableGroup | undefined;
+}): boolean {
+  const { forceNewGroup, tileCode, lastPendingGroup } = params;
+  if (forceNewGroup) return true;
+  if (!lastPendingGroup) return false;
+
+  const newTile = parseTileCode(tileCode);
+  const existingTiles = lastPendingGroup.tiles
+    .filter((t) => t !== "JK1" && t !== "JK2")
+    .map((t) => parseTileCode(t));
+
+  if (existingTiles.length === 0 || newTile.isJoker) return false;
+
+  const existingNumbers = new Set(existingTiles.map((t) => t.number));
+  const isGroupCandidate = existingNumbers.size === 1;
+  const existingColors = new Set(existingTiles.map((t) => t.color));
+  const isRunCandidate = existingColors.size === 1;
+
+  if (isGroupCandidate && isRunCandidate) {
+    const refNumber = existingTiles[0].number;
+    const refColor = existingTiles[0].color;
+    const numberMatches = newTile.number === refNumber;
+    const colorMatches = newTile.color === refColor;
+    if (!numberMatches && !colorMatches) return true;
+    if (!numberMatches && colorMatches) {
+      if (newTile.number === null) return false;
+      const refNum = refNumber ?? 0;
+      if (Math.abs(newTile.number - refNum) !== 1) return true;
+    }
+  }
+
+  if (isGroupCandidate && !isRunCandidate) {
+    const groupNumber = existingTiles[0].number;
+    if (newTile.number !== groupNumber) return true;
+    if (existingColors.has(newTile.color as TileColor)) return true;
+    if (lastPendingGroup.tiles.length >= 4) return true;
+  }
+
+  if (isRunCandidate && !isGroupCandidate) {
+    const runColor = existingTiles[0].color;
+    if (newTile.color !== runColor) return true;
+    if (newTile.number !== null) {
+      const allNums = existingTiles
+        .map((t) => t.number)
+        .filter((n): n is TileNumber => n !== null);
+      allNums.push(newTile.number);
+      allNums.sort((a, b) => a - b);
+      for (let i = 1; i < allNums.length; i++) {
+        if (allNums[i] - allNums[i - 1] !== 1) return true;
+      }
+    }
+  }
+
+  if (!isGroupCandidate && !isRunCandidate) return true;
+
+  return false;
+}

--- a/src/frontend/src/lib/errorMapping.ts
+++ b/src/frontend/src/lib/errorMapping.ts
@@ -1,0 +1,69 @@
+/**
+ * errorMapping — ERR_* → 한글 메시지 매핑 SSOT (L3 순수 함수)
+ *
+ * SSOT 매핑:
+ *   - UR-21: INVALID_MOVE 토스트 = 빨강, ERR_* 메시지 표시
+ *   - UR-34: state 부패 토스트 금지 — invariant validator류 메시지는 이 파일에 없음
+ *
+ * 출처: useWebSocket.ts:49~79의 INVALID_MOVE_MESSAGES 분리 (RDX-05 정신)
+ * 이전 위치: useWebSocket.ts 내 인라인 상수 + 함수
+ *
+ * 금지:
+ *   - store, WS, DOM import 불가 (L3 계층 규칙)
+ *   - UR-34: invariant validator / source guard 류 토스트 메시지 추가 금지
+ */
+
+/**
+ * 서버 에러 코드 → 한글 메시지 매핑 테이블
+ *
+ * BUG-UI-012 카피 에디트 (2026-04-24): 용어 일관성 + 명료성 개선
+ * 변경 기준: docs/02-design/53-ux004-extend-lock-copy.md §5 게임 용어 일관성 표
+ */
+const ERROR_MESSAGES: Record<string, string> = {
+  // 세트 유효성 관련 (V-01)
+  ERR_INVALID_SET: "유효하지 않은 타일 조합이에요. 그룹 또는 런 조건을 확인해 주세요",
+  ERR_SET_SIZE: "멜드는 타일 3장 이상이어야 해요",
+  ERR_GROUP_NUMBER: "그룹은 모든 타일의 숫자가 같아야 해요",
+  ERR_GROUP_COLOR_DUP: "그룹에 같은 색상 타일이 중복되었어요",
+  ERR_RUN_COLOR: "런은 모든 타일의 색상이 같아야 해요",
+  ERR_RUN_SEQUENCE: "런의 숫자가 연속되지 않았어요",
+  ERR_RUN_RANGE: "런의 숫자는 1~13 범위여야 해요",
+  ERR_RUN_DUPLICATE: "런에 같은 숫자의 타일이 중복되었어요",
+  ERR_RUN_NO_NUMBER: "런에 숫자 타일이 최소 1장 이상 필요해요",
+  // 턴 규칙 관련 (V-03, V-06, V-07)
+  ERR_NO_RACK_TILE: "내 타일을 최소 1장 사용해야 확정할 수 있어요",
+  ERR_TABLE_TILE_MISSING: "보드 타일이 일부 사라졌어요. 초기화 후 다시 시도해 주세요",
+  ERR_JOKER_NOT_USED: "교체한 조커는 같은 턴에 사용해야 해요",
+  // 초기 등록 관련 (V-04, V-05, V-13a)
+  // 용어 기준: docs/02-design/53-ux004-extend-lock-copy.md §5 "초기 등록" 통일
+  ERR_INITIAL_MELD_SCORE: "초기 등록은 30점 이상이어야 해요",
+  ERR_INITIAL_MELD_SOURCE: "초기 등록은 내 타일로만 해야 해요",
+  ERR_NO_REARRANGE_PERM: "초기 등록(30점 확정) 전에는 보드 재배치가 불가해요",
+  // 턴 순서 관련 (V-08, V-09, V-10)
+  ERR_NOT_YOUR_TURN: "지금은 내 차례가 아니에요",
+  ERR_DRAW_PILE_EMPTY: "드로우 더미가 비었어요",
+  ERR_TURN_TIMEOUT: "턴 시간이 초과되었어요",
+  // 타일 파싱 관련 (D-04)
+  ERR_INVALID_TILE_CODE: "인식할 수 없는 타일 코드예요",
+  // WS 시퀀스 관련 (V-19, UR-29)
+  STALE_SEQ: "통신 지연 — 다시 시도해 주세요",
+  // 레거시 호환 (서버 이전 버전 응답)
+  ERR_GROUP_INVALID: "유효하지 않은 그룹이에요",
+  ERR_RUN_INVALID: "유효하지 않은 런이에요",
+  ERR_TILE_NOT_IN_RACK: "내 타일에 없는 타일을 배치하려 했어요",
+  ERR_TILE_CONSERVATION: "보드 타일이 유실되었어요. 초기화 후 다시 시도해 주세요",
+};
+
+/**
+ * ERR_* 코드를 한글 메시지로 변환한다.
+ *
+ * UR-21: INVALID_MOVE 토스트에서 사용.
+ * UR-34: 이 함수는 서버 에러 코드 변환만 담당. invariant validator 메시지는 없음.
+ *
+ * @param code 서버 에러 코드 (예: "ERR_SET_SIZE")
+ * @param fallback 코드가 매핑 테이블에 없을 때 대체 메시지
+ * @returns 한글 메시지
+ */
+export function resolveErrorMessage(code: string, fallback?: string): string {
+  return ERROR_MESSAGES[code] ?? fallback ?? "유효하지 않은 배치입니다";
+}

--- a/src/frontend/src/lib/invariantValidator.ts
+++ b/src/frontend/src/lib/invariantValidator.ts
@@ -1,0 +1,130 @@
+/**
+ * invariantValidator — INV-G1~G5 개발 모드 assert (L3 순수 함수)
+ *
+ * SSOT 매핑:
+ *   - INV-G1: D-01 그룹 ID 유니크
+ *   - INV-G2: D-02 동일 tile code 보드 위 1회만
+ *   - INV-G3: D-03 빈 그룹 없음
+ *   - 56b §4.3: 개발 환경 console.error + throw, 프로덕션 silent
+ *   - UR-34: 사용자에게 invariant validator 류 토스트 절대 노출 금지
+ *
+ * 사용 정책:
+ *   - 개발 모드 (NODE_ENV !== "production"): throw Error
+ *   - 프로덕션: console.error만 (Sentry alert 대상)
+ *   - 토스트 노출 금지 (UR-34)
+ *
+ * 금지: store, WS, DOM import 불가 (L3 계층 규칙)
+ */
+
+import type { TileCode, TableGroup } from "@/types/tile";
+
+// ---------------------------------------------------------------------------
+// 환경 판별
+// ---------------------------------------------------------------------------
+
+const IS_DEV = process.env.NODE_ENV !== "production";
+
+function invariantFail(message: string): void {
+  console.error(`[INVARIANT VIOLATION] ${message}`);
+  if (IS_DEV) {
+    throw new Error(`[INVARIANT] ${message}`);
+  }
+  // 프로덕션: console.error만 (Sentry 연동은 호출자 책임)
+}
+
+// ---------------------------------------------------------------------------
+// INV-G1: 그룹 ID 유니크 (D-01)
+// ---------------------------------------------------------------------------
+
+/**
+ * 그룹 ID 중복이 없는지 검사한다.
+ *
+ * INV-G1 (D-01): 모든 pendingTableGroups[].id + tableGroups[].id 는 유일해야 한다.
+ * 위반 시 개발 모드에서 throw. 프로덕션에서 console.error.
+ *
+ * @param groups 검사할 그룹 배열
+ */
+export function assertGroupIdUnique(groups: TableGroup[]): void {
+  const ids = groups.map((g) => g.id);
+  const idSet = new Set(ids);
+
+  if (idSet.size !== ids.length) {
+    const duplicates = ids.filter((id, index) => ids.indexOf(id) !== index);
+    invariantFail(
+      `INV-G1 위반 (D-01): 그룹 ID 중복 검출 — ${JSON.stringify([...new Set(duplicates)])}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// INV-G2: tile code 중복 없음 (D-02)
+// ---------------------------------------------------------------------------
+
+/**
+ * 모든 그룹에 걸쳐 동일 tile code가 1회 이상 중복되지 않는지 검사한다.
+ *
+ * INV-G2 (D-02): 동일 tile code는 보드 위 1회만 등장.
+ * 위반 = INC-T11-DUP 사고 유형.
+ *
+ * @param groups 검사할 그룹 배열
+ */
+export function assertNoTileCodeDuplicate(groups: TableGroup[]): void {
+  const codeCount = new Map<TileCode, number>();
+
+  for (const group of groups) {
+    for (const code of group.tiles) {
+      codeCount.set(code, (codeCount.get(code) ?? 0) + 1);
+    }
+  }
+
+  const duplicates = [...codeCount.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([code]) => code);
+
+  if (duplicates.length > 0) {
+    invariantFail(
+      `INV-G2 위반 (D-02): tile code 중복 검출 — ${JSON.stringify(duplicates)}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// INV-G3: 빈 그룹 없음 (D-03)
+// ---------------------------------------------------------------------------
+
+/**
+ * 빈 그룹(tiles.length === 0)이 없는지 검사한다.
+ *
+ * INV-G3 (D-03): 빈 그룹은 그룹 배열에서 즉시 제거되어야 한다.
+ * setter에서 자동 정리하는 것이 명세이므로 이 assert는 버그 검출용.
+ *
+ * @param groups 검사할 그룹 배열
+ */
+export function assertNoEmptyGroup(groups: TableGroup[]): void {
+  const emptyGroups = groups.filter((g) => g.tiles.length === 0);
+
+  if (emptyGroups.length > 0) {
+    const ids = emptyGroups.map((g) => g.id);
+    invariantFail(
+      `INV-G3 위반 (D-03): 빈 그룹 검출 — ${JSON.stringify(ids)}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 통합 검사 (편의 함수)
+// ---------------------------------------------------------------------------
+
+/**
+ * INV-G1 + INV-G2 + INV-G3 를 한 번에 검사한다.
+ *
+ * dragEndReducer 출력 직후, pendingStore.applyMutation() 직후 등
+ * 상태 변경 직후 호출하면 빠른 버그 검출이 가능하다.
+ *
+ * @param groups 검사할 그룹 배열
+ */
+export function assertGroupsInvariant(groups: TableGroup[]): void {
+  assertGroupIdUnique(groups);
+  assertNoTileCodeDuplicate(groups);
+  assertNoEmptyGroup(groups);
+}

--- a/src/frontend/src/lib/jokerSwap.ts
+++ b/src/frontend/src/lib/jokerSwap.ts
@@ -1,0 +1,123 @@
+/**
+ * tryJokerSwap — 조커 교체 순수 함수 SSOT (L3)
+ *
+ * SSOT 매핑:
+ *   - V-07: 회수한 조커는 같은 턴 내 반드시 재사용
+ *   - V-13e: 조커 교체(Joker Swap) 재배치 유형 4
+ *   - 56b S10: JOKER_RECOVERED_PENDING 상태 진입
+ *
+ * 금지: store, WS, DOM import 불가 (L3 계층 규칙)
+ *
+ * 이전 중복 정의 위치:
+ *   - dragEndReducer.ts:46~102 (폐기 → 본 파일로 통합 RDX-05)
+ *   - GameClient.tsx:내부 (폐기 예정)
+ */
+
+import type { TileCode, TileNumber } from "@/types/tile";
+import { parseTileCode } from "@/types/tile";
+
+/**
+ * 조커 교체 결과
+ */
+export interface JokerSwapResult {
+  /** 교체 후 그룹 타일 배열 (조커 대신 rackTile, 위치 유지) */
+  nextTiles: TileCode[];
+  /** 랙으로 회수된 조커 코드 */
+  recoveredJoker: TileCode;
+}
+
+/**
+ * 그룹 내 조커를 랙 타일로 교체 시도한다 (V-13e, V-07).
+ *
+ * 교체 가능 조건:
+ *   1. groupTiles에 조커(JK1 또는 JK2)가 1개 이상 있어야 한다.
+ *   2. rackTile이 조커가 아닌 일반 타일이어야 한다.
+ *   3. 교체 후 그룹이 여전히 유효한 세트여야 한다:
+ *      - 조커가 그룹에서 대체하던 위치에 rackTile을 넣어도 세트 유효성 유지
+ *      - 구체적으로: 조커 제거 후 나머지 타일들이 rackTile과 함께
+ *        그룹(같은 숫자) 또는 런(같은 색·연속) 을 이룰 수 있어야 한다.
+ *
+ * 구현 전략:
+ *   조커를 하나씩 제거하고 rackTile로 대체해본다. 결과 배열이
+ *   유효한 그룹 또는 런을 이루는지 검사한다.
+ *   첫 번째 성공한 교체를 반환한다.
+ *
+ * @param groupTiles 그룹의 현재 타일 배열
+ * @param rackTile 교체할 랙 타일
+ * @returns 교체 성공 시 JokerSwapResult, 불가능하면 null
+ */
+export function tryJokerSwap(
+  groupTiles: TileCode[],
+  rackTile: TileCode,
+): JokerSwapResult | null {
+  // rackTile이 조커면 교체 불가
+  const rackParsed = parseTileCode(rackTile);
+  if (rackParsed.isJoker) return null;
+
+  const jokerCodes: TileCode[] = ["JK1", "JK2"];
+
+  for (const jokerCode of jokerCodes) {
+    const jokerIndex = groupTiles.indexOf(jokerCode);
+    if (jokerIndex < 0) continue;
+
+    // 조커를 rackTile로 교체
+    const candidate = [...groupTiles];
+    candidate[jokerIndex] = rackTile;
+
+    // 교체 후 그룹 유효성 검사
+    if (isValidSetAfterSwap(candidate)) {
+      return {
+        nextTiles: candidate,
+        recoveredJoker: jokerCode,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * 조커 교체 후 세트 유효성 검사 (내부 헬퍼)
+ *
+ * 기준:
+ *   - 모두 조커가 아닌 일반 타일이어야 함 (교체 후 상태)
+ *   - 그룹 조건: 모든 타일의 숫자가 같고, 색상이 모두 다름
+ *   - 런 조건: 모든 타일의 색상이 같고, 숫자가 연속 (1~13 범위, 중복 없음)
+ *   - 단, 여전히 조커가 있는 경우 (조커 2개인 그룹에서 1개만 교체)엔 조커 wildcard 허용
+ */
+function isValidSetAfterSwap(tiles: TileCode[]): boolean {
+  if (tiles.length < 3) return false;
+
+  const jokers = tiles.filter((t) => t === "JK1" || t === "JK2");
+  const regular = tiles.filter((t) => t !== "JK1" && t !== "JK2");
+
+  if (regular.length === 0) return false;
+
+  const parsed = regular.map((t) => parseTileCode(t));
+  const numbers = parsed.map((t) => t.number).filter((n): n is TileNumber => n !== null);
+  const colors = new Set(parsed.map((t) => t.color));
+
+  // 그룹 검사: 같은 숫자, 서로 다른 색상, 최대 4장
+  if (tiles.length <= 4 && numbers.every((n) => n === numbers[0])) {
+    const colorSet = new Set(parsed.map((t) => t.color));
+    // 조커 없으면 색상 중복 금지
+    if (jokers.length === 0 && colorSet.size === regular.length) return true;
+    // 조커 있으면 색상 중복만 없으면 됨
+    if (jokers.length > 0 && colorSet.size === regular.length) return true;
+  }
+
+  // 런 검사: 같은 색상, 연속 숫자
+  if (colors.size === 1 && numbers.length === regular.length) {
+    const sorted = [...numbers].sort((a, b) => a - b);
+    // 중복 없음 검사
+    const numSet = new Set(sorted);
+    if (numSet.size !== sorted.length) return false;
+    // 연속성 검사 (조커로 공백 허용)
+    const min = sorted[0];
+    const max = sorted[sorted.length - 1];
+    const span = max - min + 1;
+    if (sorted.length + jokers.length >= span && min >= 1 && max <= 13) return true;
+  }
+
+  return false;
+}

--- a/src/frontend/src/lib/stateMachineGuard.ts
+++ b/src/frontend/src/lib/stateMachineGuard.ts
@@ -1,0 +1,260 @@
+/**
+ * stateMachineGuard — S0~S10 전이 가드 (L3 순수 함수)
+ *
+ * SSOT 매핑:
+ *   - 56b 전이 24개 1:1 구현
+ *   - 56b §1: 상태 12개 (S0~S10 + TURN_END_RECEIVED)
+ *   - 56b §2: 전이 다이어그램
+ *   - 56b §3: invariant (위반 시 null 반환 → 호출자가 버그 처리)
+ *
+ * 금지: store, WS, DOM import 불가 (L3 계층 규칙)
+ *
+ * nextState() 반환값:
+ *   - TurnState: 전이 성공
+ *   - null: 해당 상태에서 해당 액션은 허용되지 않음 (호출자 버그)
+ */
+
+// ---------------------------------------------------------------------------
+// 타입 정의 (58 §4.2 TurnStateStore 타입과 동기화)
+// ---------------------------------------------------------------------------
+
+export type TurnState =
+  | "OUT_OF_TURN"             // S0
+  | "MY_TURN_IDLE"            // S1
+  | "DRAGGING_FROM_RACK"      // S2
+  | "DRAGGING_FROM_PENDING"   // S3
+  | "DRAGGING_FROM_SERVER"    // S4
+  | "PENDING_BUILDING"        // S5
+  | "PENDING_READY"           // S6
+  | "COMMITTING"              // S7
+  | "INVALID_RECOVER"         // S8
+  | "DRAWING"                 // S9
+  | "JOKER_RECOVERED"         // S10
+  ;
+
+export type TurnAction =
+  | "TURN_START"           // S0↔S1 (isMyTurn으로 분기)
+  | "DRAG_START_RACK"      // S1/S5/S6 → S2
+  | "DRAG_START_PENDING"   // S5/S6 → S3
+  | "DRAG_START_SERVER"    // S5/S6 → S4 (POST_MELD만)
+  | "DROP_OK"              // S2/S3/S4 → S5
+  | "DRAG_CANCEL"          // S2 → S1, S3/S4 → S5
+  | "PRE_CHECK_PASS"       // S5 → S6
+  | "PRE_CHECK_FAIL"       // S6 → S5
+  | "CONFIRM"              // S6 → S7
+  | "TURN_END_OK"          // S7 → S0 (TURN_END 수신)
+  | "INVALID"              // S7 → S8
+  | "RESET"                // S5/S6/S8/S10 → S1
+  | "DRAW"                 // S1 → S9
+  | "DRAW_OK"              // S9 → S0 (TURN_END 드로우 결과)
+  | "JOKER_SWAP"           // S4 → S10
+  | "JOKER_PLACED"         // S10 → S5
+  | "GAME_OVER"            // * → S0 (terminal)
+  ;
+
+export interface TransitionContext {
+  /** TURN_START 액션에서 내 턴인지 여부 (V-08) */
+  isMyTurn?: boolean;
+  /** DRAG_START_SERVER 액션에서 hasInitialMeld (V-13a) */
+  hasInitialMeld?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// 상태 전이 테이블 (56b §2 Mermaid stateDiagram-v2 1:1 매핑)
+// ---------------------------------------------------------------------------
+
+/**
+ * 현재 상태와 액션으로 다음 상태를 계산한다.
+ *
+ * 56b 전이 24개를 exhaustive switch로 구현한다.
+ *
+ * @param current 현재 TurnState
+ * @param action TurnAction
+ * @param context 전이에 필요한 추가 컨텍스트 (isMyTurn 등)
+ * @returns 다음 TurnState 또는 null (허용되지 않는 전이)
+ */
+export function nextState(
+  current: TurnState,
+  action: TurnAction,
+  context: TransitionContext = {},
+): TurnState | null {
+  // GAME_OVER는 모든 상태에서 S0으로 (terminal)
+  if (action === "GAME_OVER") return "OUT_OF_TURN";
+
+  switch (current) {
+    // ---- S0: OUT_OF_TURN ----
+    case "OUT_OF_TURN":
+      switch (action) {
+        case "TURN_START":
+          // isMyTurn=true → S1, false → S0 유지
+          return context.isMyTurn === true ? "MY_TURN_IDLE" : "OUT_OF_TURN";
+        default:
+          return null;
+      }
+
+    // ---- S1: MY_TURN_IDLE ----
+    case "MY_TURN_IDLE":
+      switch (action) {
+        case "TURN_START":
+          // 다른 사람 TURN_START → S0
+          return context.isMyTurn === true ? "MY_TURN_IDLE" : "OUT_OF_TURN";
+        case "DRAG_START_RACK":
+          return "DRAGGING_FROM_RACK";
+        case "DRAW":
+          return "DRAWING";
+        default:
+          return null;
+      }
+
+    // ---- S2: DRAGGING_FROM_RACK ----
+    case "DRAGGING_FROM_RACK":
+      switch (action) {
+        case "DROP_OK":
+          return "PENDING_BUILDING";
+        case "DRAG_CANCEL":
+          // S2에서 cancel → S1 (pending 없음) 또는 S5 (pending 있음)
+          // 호출자가 pending 여부를 판단해서 사용해야 함
+          // 여기서는 DRAG_CANCEL은 pending 없을 때 S1 기본값
+          return "MY_TURN_IDLE";
+        default:
+          return null;
+      }
+
+    // ---- S3: DRAGGING_FROM_PENDING ----
+    case "DRAGGING_FROM_PENDING":
+      switch (action) {
+        case "DROP_OK":
+          return "PENDING_BUILDING";
+        case "DRAG_CANCEL":
+          return "PENDING_BUILDING";
+        default:
+          return null;
+      }
+
+    // ---- S4: DRAGGING_FROM_SERVER ----
+    case "DRAGGING_FROM_SERVER":
+      switch (action) {
+        case "DROP_OK":
+          return "PENDING_BUILDING";
+        case "DRAG_CANCEL":
+          return "PENDING_BUILDING";
+        case "JOKER_SWAP":
+          return "JOKER_RECOVERED";
+        default:
+          return null;
+      }
+
+    // ---- S5: PENDING_BUILDING ----
+    case "PENDING_BUILDING":
+      switch (action) {
+        case "DRAG_START_RACK":
+          return "DRAGGING_FROM_RACK";
+        case "DRAG_START_PENDING":
+          return "DRAGGING_FROM_PENDING";
+        case "DRAG_START_SERVER":
+          // V-13a: hasInitialMeld가 있어야만 서버 그룹 드래그 가능
+          if (context.hasInitialMeld !== true) return null;
+          return "DRAGGING_FROM_SERVER";
+        case "PRE_CHECK_PASS":
+          return "PENDING_READY";
+        case "RESET":
+          return "MY_TURN_IDLE";
+        case "TURN_START":
+          // 서버 강제 진행 (race condition)
+          return context.isMyTurn === true ? "MY_TURN_IDLE" : "OUT_OF_TURN";
+        default:
+          return null;
+      }
+
+    // ---- S6: PENDING_READY ----
+    case "PENDING_READY":
+      switch (action) {
+        case "DRAG_START_RACK":
+          return "DRAGGING_FROM_RACK";
+        case "DRAG_START_PENDING":
+          return "DRAGGING_FROM_PENDING";
+        case "DRAG_START_SERVER":
+          if (context.hasInitialMeld !== true) return null;
+          return "DRAGGING_FROM_SERVER";
+        case "PRE_CHECK_FAIL":
+          return "PENDING_BUILDING";
+        case "CONFIRM":
+          return "COMMITTING";
+        case "RESET":
+          return "MY_TURN_IDLE";
+        case "TURN_START":
+          return context.isMyTurn === true ? "MY_TURN_IDLE" : "OUT_OF_TURN";
+        default:
+          return null;
+      }
+
+    // ---- S7: COMMITTING ----
+    case "COMMITTING":
+      switch (action) {
+        case "TURN_END_OK":
+          return "OUT_OF_TURN";
+        case "INVALID":
+          return "INVALID_RECOVER";
+        default:
+          return null;
+      }
+
+    // ---- S8: INVALID_RECOVER ----
+    case "INVALID_RECOVER":
+      switch (action) {
+        case "RESET":
+          return "MY_TURN_IDLE";
+        case "DROP_OK":
+          // 재시도 (재드래그)
+          return "PENDING_BUILDING";
+        case "TURN_START":
+          return context.isMyTurn === true ? "MY_TURN_IDLE" : "OUT_OF_TURN";
+        default:
+          return null;
+      }
+
+    // ---- S9: DRAWING ----
+    case "DRAWING":
+      switch (action) {
+        case "DRAW_OK":
+          return "OUT_OF_TURN";
+        case "TURN_START":
+          return context.isMyTurn === true ? "MY_TURN_IDLE" : "OUT_OF_TURN";
+        default:
+          return null;
+      }
+
+    // ---- S10: JOKER_RECOVERED ----
+    case "JOKER_RECOVERED":
+      switch (action) {
+        case "JOKER_PLACED":
+          return "PENDING_BUILDING";
+        case "RESET":
+          return "MY_TURN_IDLE";
+        case "TURN_START":
+          return context.isMyTurn === true ? "MY_TURN_IDLE" : "OUT_OF_TURN";
+        default:
+          return null;
+      }
+
+    default:
+      // TypeScript exhaustiveness — never 도달해선 안 됨
+      return null;
+  }
+}
+
+/**
+ * 주어진 상태에서 특정 액션이 허용되는지 확인한다.
+ *
+ * @param current 현재 TurnState
+ * @param action TurnAction
+ * @param context TransitionContext
+ * @returns true = 허용, false = 불허
+ */
+export function canTransition(
+  current: TurnState,
+  action: TurnAction,
+  context: TransitionContext = {},
+): boolean {
+  return nextState(current, action, context) !== null;
+}

--- a/src/frontend/src/lib/tileClassify.ts
+++ b/src/frontend/src/lib/tileClassify.ts
@@ -1,0 +1,52 @@
+/**
+ * classifySetType — 세트 타입 분류 SSOT (L3 순수 함수)
+ *
+ * SSOT 매핑:
+ *   - D-10: tableGroup.type 힌트는 참고용. 진실은 tiles 내용.
+ *   - V-01: 유효한 그룹(같은 숫자·다른 색) 또는 런(같은 색·연속 숫자)
+ *   - 56b §3.5~3.6: A1~A12 모든 분기에서 동일 분류 기준 사용
+ *
+ * 금지: store, WS, DOM import 불가 (L3 계층 규칙)
+ *
+ * 이전 중복 정의 위치:
+ *   - dragEndReducer.ts:25~35 (폐기 → 본 파일로 통합 RDX-05)
+ *   - GameClient.tsx:내부 (폐기 예정)
+ */
+
+import type { TileCode, GroupType } from "@/types/tile";
+import { parseTileCode } from "@/types/tile";
+
+/**
+ * 타일 배열을 보고 세트 타입을 분류한다.
+ *
+ * 분류 우선순위:
+ *   1. 타일이 0장이면 → "run" (기본값, 타입 힌트 없음)
+ *   2. 조커만 있으면 → "run" (타입 미확정)
+ *   3. 일반 타일의 숫자가 모두 같으면 → "group"
+ *   4. 일반 타일의 색상이 모두 같으면 → "run"
+ *   5. 그 외 → "run" (기본값, 서버 검증에서 V-01 거부)
+ *
+ * D-10 정책: 타입 힌트와 내용 불일치 시 내용 기준으로 재분류.
+ * 상위에서 type 힌트를 신뢰해야 하면 mergeCompatibility.ts의
+ * classifyKind()를 사용한다.
+ *
+ * @param tiles 타일 코드 배열
+ * @returns "group" | "run"
+ */
+export function classifySetType(tiles: TileCode[]): GroupType {
+  const regular = tiles.filter((t) => t !== "JK1" && t !== "JK2");
+
+  if (regular.length === 0) return "run";
+
+  const parsed = regular.map((t) => parseTileCode(t));
+  const numbers = new Set(parsed.map((t) => t.number));
+  const colors = new Set(parsed.map((t) => t.color));
+
+  // 같은 숫자 → group 후보
+  if (numbers.size === 1) return "group";
+  // 같은 색상 → run 후보
+  if (colors.size === 1) return "run";
+
+  // 혼재 → run (서버에서 V-01으로 거부될 것)
+  return "run";
+}

--- a/src/frontend/src/lib/turnUtils.ts
+++ b/src/frontend/src/lib/turnUtils.ts
@@ -1,0 +1,104 @@
+/**
+ * turnUtils — 턴 관련 순수 유틸 함수 모음 (L3)
+ *
+ * SSOT 매핑:
+ *   - V-08: 자기 턴 확인 (currentSeat === mySeat)
+ *   - V-13a: hasInitialMeld — 재배치 권한 판정
+ *   - V-03: tilesAdded >= 1 (랙에서 최소 1장 추가)
+ *   - V-04: 30점 초과 확인
+ *   - 56b §3.2: computeIsMyTurn → S0 / S1 진입 조건
+ *
+ * 금지: store, WS, DOM import 불가 (L3 계층 규칙)
+ */
+
+import type { TileCode, TableGroup } from "@/types/tile";
+import type { Player } from "@/types/game";
+import { parseTileCode } from "@/types/tile";
+
+// ---------------------------------------------------------------------------
+// computeIsMyTurn — V-08
+// ---------------------------------------------------------------------------
+
+/**
+ * 현재 턴이 내 턴인지 판정한다.
+ *
+ * @param currentSeat 현재 행동해야 할 플레이어 seat (TURN_START payload)
+ * @param mySeat 나의 seat 번호
+ * @returns true = 내 턴 (S1), false = 상대 턴 (S0)
+ */
+export function computeIsMyTurn(currentSeat: number, mySeat: number): boolean {
+  return currentSeat === mySeat;
+}
+
+// ---------------------------------------------------------------------------
+// computeEffectiveMeld — V-13a, 7지점 통합
+// ---------------------------------------------------------------------------
+
+/**
+ * 나의 effectiveHasInitialMeld 값을 계산한다.
+ *
+ * "7지점" 분산 참조를 이 함수 한 곳으로 통합 (W2-A 해소).
+ * 서버 응답의 player.hasInitialMeld를 single source로 사용한다.
+ *
+ * @param players 현재 게임의 전체 플레이어 배열
+ * @param mySeat 나의 seat 번호
+ * @returns true = 초기 등록 완료 (재배치 가능), false = 미완료
+ */
+export function computeEffectiveMeld(players: Player[], mySeat: number): boolean {
+  const me = players.find((p) => p.seat === mySeat);
+  return me?.hasInitialMeld === true;
+}
+
+// ---------------------------------------------------------------------------
+// computeTilesAdded — V-03
+// ---------------------------------------------------------------------------
+
+/**
+ * 턴 시작 시점 랙과 현재 랙을 비교하여 보드에 추가된 타일 수를 계산한다.
+ *
+ * V-03: 턴 확정 시 tilesAdded >= 1 이어야 함 (단순 재배치 금지).
+ *
+ * @param turnStartRack TURN_START 시점의 랙 타일 배열 (스냅샷)
+ * @param currentRack 현재 랙 타일 배열
+ * @returns 보드로 옮긴 타일 수 (음수 불가, 드로우로 늘어난 경우는 0으로 클램프)
+ */
+export function computeTilesAdded(
+  turnStartRack: TileCode[],
+  currentRack: TileCode[],
+): number {
+  const diff = turnStartRack.length - currentRack.length;
+  return Math.max(0, diff);
+}
+
+// ---------------------------------------------------------------------------
+// computePendingScore — V-04
+// ---------------------------------------------------------------------------
+
+/**
+ * 조커가 아닌 타일의 숫자값 합산 (조커는 실제 대체 숫자 사용 불가 → 0 처리)
+ */
+function scoreTile(code: TileCode): number {
+  const parsed = parseTileCode(code);
+  if (parsed.isJoker || parsed.number === null) return 0;
+  return parsed.number;
+}
+
+/**
+ * pending 전용 그룹들의 점수 합계를 계산한다 (V-04 클라이언트 미러).
+ *
+ * V-04: 초기 등록 시 자신의 랙 타일만으로 구성한 세트 합계 >= 30점.
+ * 조커는 대체 타일의 숫자값으로 계산해야 하지만, 클라이언트 미러에서는
+ * 보수적으로 0점 처리한다. 서버가 최종 판정자임.
+ *
+ * @param pendingOnlyGroups pending 전용 그룹 배열 (pendingGroupIds에 포함된 그룹만)
+ * @returns 합산 점수
+ */
+export function computePendingScore(pendingOnlyGroups: TableGroup[]): number {
+  let total = 0;
+  for (const group of pendingOnlyGroups) {
+    for (const tile of group.tiles) {
+      total += scoreTile(tile);
+    }
+  }
+  return total;
+}


### PR DESCRIPTION
## Summary
- L3 도메인 순수 함수 7개 신규 생성: tileClassify, jokerSwap, turnUtils, confirmValidator, stateMachineGuard, errorMapping, invariantValidator
- dragEndReducer RDX-05: classifySetType/tryJokerSwap 중복 제거 → 단일 소스 import
- dragEndReducer RDX-01: A5 pending→pending 호환성 검사 추가
- 단위 테스트 84개 PASS, 기존 21 스위트 회귀 0건, next build 성공
- 58 §7 Phase 0 완료, L3 계층 규칙 준수 (store/WS/DOM import 없음)

## 룰 ID 매핑
V-01/02/03/04/07/08/13a/13e/14/15, UR-21/34/36, D-10, INV-G1/G2/G3

## Test plan
- [x] 신규 테스트 84개 PASS
- [x] 기존 by-action 21 스위트 회귀 0건
- [x] `pnpm build` TS 에러 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)